### PR TITLE
fix: resolve horizontal scrollbar overflow caused by DashedH component

### DIFF
--- a/components/landing/dashed-h.tsx
+++ b/components/landing/dashed-h.tsx
@@ -6,7 +6,7 @@ export function DashedH() {
       aria-hidden
       className="relative h-px"
       style={{
-        width: "100vw",
+        width: "99.6vw",
         marginLeft: "calc(50% - 50vw)",
         ...RAIL_H_STYLE,
       }}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  esbuild: false
+  msw: false
+  sharp: false
+  unrs-resolver: false
+  workerd: false


### PR DESCRIPTION
## Summary

Horizontal scrollbar was overflowing bcz of DashedH component having 100vw.

## Type of Change

- fix

## Changes Made

in DashedH component:
`width: "100vw"` --> `width: "99.6vw"`

## Checklist

- [yes] I ran `pnpm lint`
- [yes] I ran `pnpm typecheck`
- [yes] I did not include secrets or sensitive data
- [no] I updated docs when behavior changed
- [yes] I kept this PR focused and reasonably small
