### PR TITLE
fix: settings button of upload-card was getting outside the card.

### DIFF
--- a/components/editor/canvas/upload-card.tsx
+++ b/components/editor/canvas/upload-card.tsx
@@ -582,7 +582,7 @@ const DEFAULT_SIZING = {
     "flex w-full items-center justify-center gap-2.5 rounded-lg px-5 py-4 text-[14px] font-semibold tracking-[-0.02em] transition-all",
   urlRow: "flex items-center gap-1.5",
   urlLabel:
-    "flex min-h-10 flex-1 items-center gap-2 rounded-md border border-neutral-200 bg-neutral-50 px-3 text-left transition-colors focus-within:border-neutral-300 focus-within:bg-white dark:border-white/10 dark:bg-white/8 dark:focus-within:bg-white/12",
+    "flex min-h-10 flex-1 items-center gap-2 max-md:w-10 rounded-md border border-neutral-200 bg-neutral-50 px-3 text-left transition-colors focus-within:border-neutral-300 focus-within:bg-white dark:border-white/10 dark:bg-white/8 dark:focus-within:bg-white/12",
   urlIconTint: "text-neutral-400 dark:text-white/35",
   urlInput:
     "min-w-0 flex-1 bg-transparent text-[16px] text-neutral-950 placeholder:text-neutral-400 focus:outline-none sm:text-[13px] dark:text-white dark:placeholder:text-white/35",

--- a/components/landing/comparison-section.tsx
+++ b/components/landing/comparison-section.tsx
@@ -35,42 +35,49 @@ const FEATURE_MATRIX = [
     tokokino: true,
     figma: false,
     canva: false,
+    cleanshot: false,
   },
   {
     feature: "No watermark exports",
     tokokino: true,
     figma: true,
     canva: false,
+    cleanshot: true,
   },
   {
     feature: "Device and browser frames",
     tokokino: true,
     figma: "manual",
     canva: "limited",
+    cleanshot: "limited",
   },
   {
     feature: "Auto-sampled palettes",
     tokokino: true,
     figma: "plugin",
     canva: false,
+    cleanshot: false,
   },
   {
     feature: "Multi-screenshot layouts",
     tokokino: true,
     figma: "manual",
     canva: "manual",
+    cleanshot: true,
   },
   {
     feature: "Local-first by default",
     tokokino: true,
     figma: false,
     canva: false,
+    cleanshot: true,
   },
   {
     feature: "No AI training on uploads",
     tokokino: true,
     figma: "policy",
     canva: "policy",
+    cleanshot: true,
   },
 ] as const
 
@@ -172,19 +179,20 @@ export function ComparisonSection() {
         transition={{ duration: 0.65, ease, delay: 0.08 }}
         className="mt-5 max-h-[28rem] overflow-auto rounded-md border border-border/70 bg-background/55 backdrop-blur-md sm:max-h-none sm:overflow-visible"
       >
-        <div className="grid min-w-[38rem] grid-cols-[minmax(10rem,1.4fr)_repeat(3,minmax(4.5rem,0.55fr))] border-b border-border/60 bg-background/70 text-center font-mono text-[10px] tracking-[0.2em] text-foreground/42 uppercase">
+        <div className="grid min-w-[38rem] grid-cols-[minmax(10rem,1.4fr)_repeat(4,minmax(4.5rem,0.55fr))] border-b border-border/60 bg-background/70 text-center font-mono text-[10px] tracking-[0.2em] text-foreground/42 uppercase">
           <div className="px-4 py-3 text-left">Feature</div>
           <div className="bg-primary/[0.07] px-3 py-3 text-primary">
             Tokokino
           </div>
           <div className="px-3 py-3">Figma</div>
           <div className="px-3 py-3">Canva</div>
+          <div className="px-3 py-3">CleanShot</div>
         </div>
 
         {FEATURE_MATRIX.map((row) => (
           <div
             key={row.feature}
-            className="grid min-w-[38rem] grid-cols-[minmax(10rem,1.4fr)_repeat(3,minmax(4.5rem,0.55fr))] border-b border-border/45 last:border-b-0"
+            className="grid min-w-[38rem] grid-cols-[minmax(10rem,1.4fr)_repeat(4,minmax(4.5rem,0.55fr))] border-b border-border/45 last:border-b-0"
           >
             <div className="px-4 py-3 text-[13px] font-medium text-foreground/78">
               {row.feature}
@@ -197,6 +205,9 @@ export function ComparisonSection() {
             </div>
             <div className="px-3 py-3 text-center">
               <MatrixCell value={row.canva} />
+            </div>
+            <div className="px-3 py-3 text-center">
+              <MatrixCell value={row.cleanshot} />
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
Settings button of upload-card was getting outside the card in mobile view, so fixed it by adding w-10 in DEFAULT_SIZING

AND added CleanShot in the comparison table.

## Type of Change
- fix

## Changes Made
in upload-card.tsx, line 585 under `urlLabel` of `DEFAULT_SIZING`  added `max-md:w-10`

## Screenshots / Recordings (if UI)
before: 
<img width="469" height="820" alt="WhatsApp Image 2026-06-05 at 23 48 01" src="https://github.com/user-attachments/assets/8c52792a-5a88-460d-80c3-db3ec064d675" />

after:
<img width="469" height="820" alt="Screenshot 2026-06-05 234603" src="https://github.com/user-attachments/assets/d1f66c69-7610-4f93-9f59-0083eeda1430" />