### PR TITLE
feat: render X/Twitter posts as exportable mockups (#11)

### DIFF
--- a/app/api/tweet/route.ts
+++ b/app/api/tweet/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-import type { TweetData } from "@/lib/editor/state-types"
+import type { TweetData, TweetMedia } from "@/lib/editor/state-types"
 import { syndicationToken, tweetUrlSchema } from "@/lib/editor/tweet-url"
 import { enforceRateLimit, getClientIp } from "@/lib/rate-limit"
 
@@ -24,6 +24,26 @@ type SyndicationTweet = {
   conversation_count?: number
   reply_count?: number
   user?: SyndicationUser
+  photos?: SyndicationPhoto[]
+  mediaDetails?: SyndicationMediaDetail[]
+}
+
+type SyndicationPhoto = {
+  url?: string
+  width?: number
+  height?: number
+  alt_text?: string
+}
+
+type SyndicationMediaDetail = {
+  type?: string
+  media_url_https?: string
+  media_url?: string
+  url?: string
+  width?: number
+  height?: number
+  ext_alt_text?: string
+  alt_text?: string
 }
 
 /** Twitter avatars come back at `_normal` (48px); request the larger crop. */
@@ -32,16 +52,60 @@ function upgradeAvatar(url: string | undefined): string {
   return url.replace(/_normal(\.\w+)$/, "_400x400$1")
 }
 
+function normalizeMedia(raw: SyndicationTweet): TweetMedia[] {
+  const photosFromField = (raw.photos ?? [])
+    .map((photo): TweetMedia | null =>
+      photo.url
+        ? {
+            type: "photo",
+            url: photo.url,
+            width: photo.width,
+            height: photo.height,
+            alt: photo.alt_text,
+          }
+        : null
+    )
+    .filter((media): media is TweetMedia => Boolean(media))
+
+  const photosFromDetails = (raw.mediaDetails ?? [])
+    .filter((media) => media.type === "photo" || media.media_url_https)
+    .map((media): TweetMedia | null => {
+      const url = media.media_url_https ?? media.media_url ?? media.url
+      if (!url) return null
+      return {
+        type: "photo",
+        url,
+        width: media.width,
+        height: media.height,
+        alt: media.ext_alt_text ?? media.alt_text,
+      }
+    })
+    .filter((media): media is TweetMedia => Boolean(media))
+
+  const seen = new Set<string>()
+  return [...photosFromField, ...photosFromDetails].filter((media) => {
+    if (seen.has(media.url)) return false
+    seen.add(media.url)
+    return true
+  })
+}
+
+function normalizeTweetText(text: string, hasMedia: boolean): string {
+  if (!hasMedia) return text
+  return text.replace(/\s*https:\/\/t\.co\/\S+\s*$/i, "").trimEnd()
+}
+
 function normalize(raw: SyndicationTweet, id: string): TweetData | null {
   if (!raw || raw.__typename === "TweetTombstone" || !raw.user) return null
   const user = raw.user
   const handle = user.screen_name ?? ""
+  const media = normalizeMedia(raw)
   return {
     id: raw.id_str ?? id,
     url: handle
       ? `https://x.com/${handle}/status/${id}`
       : `https://x.com/i/status/${id}`,
-    text: raw.text ?? raw.full_text ?? "",
+    text: normalizeTweetText(raw.text ?? raw.full_text ?? "", media.length > 0),
     author: {
       name: user.name ?? handle,
       handle,
@@ -49,6 +113,7 @@ function normalize(raw: SyndicationTweet, id: string): TweetData | null {
       verified: Boolean(user.verified || user.is_blue_verified),
     },
     createdAt: raw.created_at ?? "",
+    media,
     metrics: {
       likes: raw.favorite_count ?? 0,
       replies: raw.conversation_count ?? raw.reply_count ?? 0,

--- a/app/api/tweet/route.ts
+++ b/app/api/tweet/route.ts
@@ -1,0 +1,144 @@
+import { NextResponse } from "next/server"
+
+import type { TweetData } from "@/lib/editor/state-types"
+import { syndicationToken, tweetUrlSchema } from "@/lib/editor/tweet-url"
+import { enforceRateLimit, getClientIp } from "@/lib/rate-limit"
+
+const FETCH_TIMEOUT_MS = 10_000
+
+type SyndicationUser = {
+  name?: string
+  screen_name?: string
+  profile_image_url_https?: string
+  verified?: boolean
+  is_blue_verified?: boolean
+}
+
+type SyndicationTweet = {
+  __typename?: string
+  id_str?: string
+  text?: string
+  full_text?: string
+  created_at?: string
+  favorite_count?: number
+  conversation_count?: number
+  reply_count?: number
+  user?: SyndicationUser
+}
+
+/** Twitter avatars come back at `_normal` (48px); request the larger crop. */
+function upgradeAvatar(url: string | undefined): string {
+  if (!url) return ""
+  return url.replace(/_normal(\.\w+)$/, "_400x400$1")
+}
+
+function normalize(raw: SyndicationTweet, id: string): TweetData | null {
+  if (!raw || raw.__typename === "TweetTombstone" || !raw.user) return null
+  const user = raw.user
+  const handle = user.screen_name ?? ""
+  return {
+    id: raw.id_str ?? id,
+    url: handle
+      ? `https://x.com/${handle}/status/${id}`
+      : `https://x.com/i/status/${id}`,
+    text: raw.text ?? raw.full_text ?? "",
+    author: {
+      name: user.name ?? handle,
+      handle,
+      avatarUrl: upgradeAvatar(user.profile_image_url_https),
+      verified: Boolean(user.verified || user.is_blue_verified),
+    },
+    createdAt: raw.created_at ?? "",
+    metrics: {
+      likes: raw.favorite_count ?? 0,
+      replies: raw.conversation_count ?? raw.reply_count ?? 0,
+    },
+  }
+}
+
+export async function GET(request: Request) {
+  const limited = await enforceRateLimit({
+    limiter: "HEAVY_RATE_LIMITER",
+    scope: "tweet-fetch",
+    id: getClientIp(request.headers),
+  })
+  if (limited) return limited
+
+  const { searchParams } = new URL(request.url)
+  const parsed = tweetUrlSchema.safeParse(searchParams.get("url") ?? "")
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid X post link" },
+      { status: 400 }
+    )
+  }
+
+  const id = parsed.data
+  const endpoint = new URL("https://cdn.syndication.twimg.com/tweet-result")
+  endpoint.searchParams.set("id", id)
+  endpoint.searchParams.set("token", syndicationToken(id))
+  endpoint.searchParams.set("lang", "en")
+
+  let response: Response
+  try {
+    response = await fetch(endpoint, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (compatible; Tokokino/1.0; +https://tokokino.com)",
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      return NextResponse.json(
+        { error: "X took too long to respond" },
+        { status: 504 }
+      )
+    }
+    return NextResponse.json(
+      { error: "Could not load that post" },
+      { status: 502 }
+    )
+  }
+
+  if (response.status === 404) {
+    return NextResponse.json(
+      { error: "Post not found or unavailable" },
+      { status: 404 }
+    )
+  }
+  if (!response.ok) {
+    return NextResponse.json(
+      { error: "Could not load that post" },
+      { status: 502 }
+    )
+  }
+
+  let raw: SyndicationTweet
+  try {
+    raw = await response.json()
+  } catch {
+    return NextResponse.json(
+      { error: "Could not read that post" },
+      { status: 502 }
+    )
+  }
+
+  const tweet = normalize(raw, id)
+  if (!tweet) {
+    return NextResponse.json(
+      { error: "That post is deleted, private, or unavailable" },
+      { status: 404 }
+    )
+  }
+
+  return NextResponse.json(
+    { tweet },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+      },
+    }
+  )
+}

--- a/components/editor/aspect-popover.tsx
+++ b/components/editor/aspect-popover.tsx
@@ -73,7 +73,7 @@ const SECTIONS: AspectSection[] = [
     label: "X (Twitter)",
     icon: RiTwitterXLine,
     options: [
-      { id: "x-post", name: "Tweet Image", ratio: "16:9", w: 1600, h: 900 },
+      { id: "x-post", name: "Post", ratio: "1:1", w: 1080, h: 1080 },
       {
         id: "x-profile",
         name: "Profile Photo",

--- a/components/editor/bulk-canvas-flow.tsx
+++ b/components/editor/bulk-canvas-flow.tsx
@@ -174,11 +174,14 @@ function CanvasNodeToolbar({
                   This will remove the canvas and all its content.
                 </AlertDialogDescription>
               </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogFooter className="grid grid-cols-2 gap-2 sm:flex">
+                <AlertDialogCancel className="cursor-pointer">
+                  Cancel
+                </AlertDialogCancel>
                 <AlertDialogAction
+                  variant="destructive"
                   onClick={() => removeCanvas(canvasId)}
-                  className="text-destructive-foreground bg-destructive hover:bg-destructive/90"
+                  className="cursor-pointer"
                 >
                   Delete
                 </AlertDialogAction>

--- a/components/editor/canvas/box-empty-state.tsx
+++ b/components/editor/canvas/box-empty-state.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { RiAddLine } from "@remixicon/react"
 
 import { cn } from "@/lib/utils"
+import type { TweetCardSettings } from "@/lib/editor/tweet-settings"
 import { EmptyStateBackdrop } from "./empty-state-backdrop"
 import {
   UploadCard,
@@ -15,7 +16,7 @@ type BoxEmptyStateProps = {
   isDragOver?: boolean
   onBrowse: () => void
   onCapture?: (url: string, settings: CaptureSettings) => void | Promise<void>
-  onLoadTweet?: (url: string) => Promise<void>
+  onLoadTweet?: (url: string, settings?: TweetCardSettings) => Promise<void>
   url?: string
   onUrlChange?: (value: string) => void
   /** Force compact `+` trigger. Otherwise auto-detected by container width. */

--- a/components/editor/canvas/box-empty-state.tsx
+++ b/components/editor/canvas/box-empty-state.tsx
@@ -15,6 +15,7 @@ type BoxEmptyStateProps = {
   isDragOver?: boolean
   onBrowse: () => void
   onCapture?: (url: string, settings: CaptureSettings) => void | Promise<void>
+  onLoadTweet?: (url: string) => Promise<void>
   url?: string
   onUrlChange?: (value: string) => void
   /** Force compact `+` trigger. Otherwise auto-detected by container width. */
@@ -43,6 +44,7 @@ export function BoxEmptyState({
   plainWideCard = false,
   defaultCaptureDevice,
   captureStateKey,
+  onLoadTweet,
 }: BoxEmptyStateProps) {
   const handleCapture = onCapture
     ? (url: string, settings: CaptureSettings) => onCapture(url, settings)
@@ -84,6 +86,7 @@ export function BoxEmptyState({
             isDragOver={isDragOver}
             onBrowse={onBrowse}
             onCapture={handleCapture}
+            onLoadTweet={onLoadTweet}
             showHint
             defaultDevice={defaultCaptureDevice}
             captureStateKey={captureStateKey}
@@ -104,6 +107,7 @@ export function BoxEmptyState({
               isDragOver={isDragOver}
               onBrowse={onBrowse}
               onCapture={handleCapture}
+              onLoadTweet={onLoadTweet}
               showHint
               defaultDevice={defaultCaptureDevice}
               captureStateKey={captureStateKey}
@@ -120,6 +124,7 @@ export function BoxEmptyState({
               isDragOver={isDragOver}
               onBrowse={onBrowse}
               onCapture={handleCapture}
+              onLoadTweet={onLoadTweet}
               showHint
               defaultDevice={defaultCaptureDevice}
               captureStateKey={captureStateKey}

--- a/components/editor/canvas/canvas-empty-state.tsx
+++ b/components/editor/canvas/canvas-empty-state.tsx
@@ -14,6 +14,7 @@ type CanvasEmptyStateProps = {
   isDragOver: boolean
   onBrowse: () => void
   onCapture?: (url: string, settings: CaptureSettings) => void | Promise<void>
+  onLoadTweet?: (url: string) => Promise<void>
   defaultCaptureDevice?: CaptureDevice
   captureStateKey?: string
   isActive?: boolean
@@ -45,6 +46,7 @@ export function CanvasEmptyState({
   isDragOver,
   onBrowse,
   onCapture,
+  onLoadTweet,
   defaultCaptureDevice,
   captureStateKey,
   isActive = false,
@@ -148,6 +150,7 @@ export function CanvasEmptyState({
             isDragOver={isDragOver}
             onBrowse={onBrowse}
             onCapture={onCapture}
+            onLoadTweet={onLoadTweet}
             compact={useCompact}
             defaultCaptureDevice={defaultCaptureDevice}
             captureStateKey={captureStateKey}
@@ -191,6 +194,7 @@ export function CanvasEmptyState({
           isDragOver={isDragOver}
           onBrowse={onBrowse}
           onCapture={onCapture}
+          onLoadTweet={onLoadTweet}
           compact={useCompact}
           defaultCaptureDevice={defaultCaptureDevice}
           captureStateKey={captureStateKey}

--- a/components/editor/canvas/canvas-empty-state.tsx
+++ b/components/editor/canvas/canvas-empty-state.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 import { useEditor } from "@/lib/editor/store"
+import type { TweetCardSettings } from "@/lib/editor/tweet-settings"
 import { BoxEmptyState } from "./box-empty-state"
 import { frameFitStyle, framePositionTransform } from "./helpers"
 import { InnerLightingOverlay } from "./inner-lighting-overlay"
@@ -14,7 +15,7 @@ type CanvasEmptyStateProps = {
   isDragOver: boolean
   onBrowse: () => void
   onCapture?: (url: string, settings: CaptureSettings) => void | Promise<void>
-  onLoadTweet?: (url: string) => Promise<void>
+  onLoadTweet?: (url: string, settings?: TweetCardSettings) => Promise<void>
   defaultCaptureDevice?: CaptureDevice
   captureStateKey?: string
   isActive?: boolean

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -58,6 +58,8 @@ import {
   ScreenshotBrowserFrame,
 } from "./screenshot-browser-frame"
 import { ScreenshotMockup } from "./screenshot-mockup"
+import { TweetCardView } from "./tweet-card"
+import { fetchTweetData } from "@/lib/editor/load-tweet"
 import {
   downscaleImageFromUrl,
   getOptimizedUrlSync,
@@ -113,6 +115,8 @@ function CanvasViewInner({
     setFrame,
     frameAddress,
     setFrameAddress,
+    tweet,
+    setTweet,
     portrait,
     enhance,
     annotation,
@@ -322,6 +326,15 @@ function CanvasViewInner({
       }
     },
     [setMainScreenshotImage]
+  )
+
+  const handleLoadTweet = React.useCallback(
+    async (url: string) => {
+      // fetchTweetData throws a user-facing Error; let the caller surface it.
+      const data = await fetchTweetData(url)
+      setTweet({ data, theme: "dark", showMetrics: true, showAvatar: true })
+    },
+    [setTweet]
   )
 
   const isAuto = aspect.id === "auto" || aspect.w === 0 || aspect.h === 0
@@ -709,7 +722,16 @@ function CanvasViewInner({
                 zIndex: 60 + screenshotLayer.zIndex,
               }}
             >
-              {screenshot ? (
+              {tweet ? (
+                <TweetCardView
+                  tweet={tweet}
+                  transform={transform}
+                  borderRadius={borderRadius}
+                  boxShadow={shadowBoxShadowCss(computedShadow)}
+                  enhanceFilter={enhanceFilter}
+                  screenshotLayer={screenshotLayer}
+                />
+              ) : screenshot ? (
                 browserFrame ? (
                   <ScreenshotBrowserFrame
                     screenshot={screenshot}
@@ -921,6 +943,7 @@ function CanvasViewInner({
                   isDragOver={isDragOver}
                   onBrowse={() => fileInputRef.current?.click()}
                   onCapture={handleCaptureWebsite}
+                  onLoadTweet={handleLoadTweet}
                   defaultCaptureDevice={captureDefaultDevice}
                   captureStateKey={mainCaptureStateKey}
                   innerLightingStyle={innerLightingStyle}

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -61,6 +61,11 @@ import { ScreenshotMockup } from "./screenshot-mockup"
 import { TweetCardView } from "./tweet-card"
 import { fetchTweetData } from "@/lib/editor/load-tweet"
 import {
+  DEFAULT_TWEET_SETTINGS,
+  tweetSettingsFromCard,
+  type TweetCardSettings,
+} from "@/lib/editor/tweet-settings"
+import {
   downscaleImageFromUrl,
   getOptimizedUrlSync,
 } from "@/lib/editor/image-resize"
@@ -117,6 +122,7 @@ function CanvasViewInner({
     setFrameAddress,
     tweet,
     setTweet,
+    clearTweet,
     portrait,
     enhance,
     annotation,
@@ -329,12 +335,26 @@ function CanvasViewInner({
   )
 
   const handleLoadTweet = React.useCallback(
-    async (url: string) => {
+    async (
+      url: string,
+      settings: TweetCardSettings = DEFAULT_TWEET_SETTINGS
+    ) => {
       // fetchTweetData throws a user-facing Error; let the caller surface it.
       const data = await fetchTweetData(url)
-      setTweet({ data, theme: "dark", showMetrics: true, showAvatar: true })
+      setTweet({ data, ...settings })
     },
     [setTweet]
+  )
+
+  const handleReplaceTweet = React.useCallback(
+    async (url: string, settings?: TweetCardSettings) => {
+      await handleLoadTweet(
+        url,
+        settings ??
+          (tweet ? tweetSettingsFromCard(tweet) : DEFAULT_TWEET_SETTINGS)
+      )
+    },
+    [handleLoadTweet, tweet]
   )
 
   const isAuto = aspect.id === "auto" || aspect.w === 0 || aspect.h === 0
@@ -522,6 +542,8 @@ function CanvasViewInner({
     typeof positionedStyle?.top === "number"
       ? positionedStyle.top + effectiveOffset.y
       : undefined
+  const mainContentLeftPct = 50 + (effectiveOffset.x / widthPx) * 100
+  const mainContentTopPct = 50 + (effectiveOffset.y / heightPx) * 100
 
   const {
     isAnnotating,
@@ -730,6 +752,30 @@ function CanvasViewInner({
                   boxShadow={shadowBoxShadowCss(computedShadow)}
                   enhanceFilter={enhanceFilter}
                   screenshotLayer={screenshotLayer}
+                  innerLightingStyle={innerLightingStyle}
+                  leftPct={mainContentLeftPct}
+                  topPct={mainContentTopPct}
+                  isSelected={isScreenshotSelected && isActive}
+                  isDragging={isScreenshotDragging}
+                  activeTool={activeTool}
+                  onSelect={handleScreenshotClickSelect}
+                  onPointerDown={(e) => {
+                    if (document.activeElement instanceof HTMLElement) {
+                      document.activeElement.blur()
+                    }
+                    startMockupDrag(e)
+                  }}
+                  onPointerMove={moveMockup}
+                  onPointerUp={stopMockupDrag}
+                  onReplace={handleReplaceTweet}
+                  onReplaceFile={readFile}
+                  onCaptureWebsite={handleCaptureWebsite}
+                  captureDefaultDevice={captureDefaultDevice}
+                  captureStateKey={mainCaptureStateKey}
+                  onDelete={() => {
+                    setIsScreenshotSelected(false)
+                    clearTweet()
+                  }}
                 />
               ) : screenshot ? (
                 browserFrame ? (
@@ -774,6 +820,7 @@ function CanvasViewInner({
                       setScreenshot(null)
                     }}
                     onCaptureWebsite={handleCaptureWebsite}
+                    onLoadTweet={handleLoadTweet}
                     captureDefaultDevice={captureDefaultDevice}
                     captureStateKey={mainCaptureStateKey}
                     innerLightingStyle={innerLightingStyle}
@@ -799,6 +846,7 @@ function CanvasViewInner({
                     imageRef={imageRef}
                     scopeToMinSide={shouldScopeFrame}
                     onCaptureWebsite={handleCaptureWebsite}
+                    onLoadTweet={handleLoadTweet}
                     captureDefaultDevice={captureDefaultDevice}
                     captureStateKey={mainCaptureStateKey}
                     onSelect={handleScreenshotClickSelect}
@@ -862,6 +910,7 @@ function CanvasViewInner({
                       setScreenshot(null)
                     }}
                     onCaptureWebsite={handleCaptureWebsite}
+                    onLoadTweet={handleLoadTweet}
                     captureDefaultDevice={captureDefaultDevice}
                     captureStateKey={mainCaptureStateKey}
                     innerLightingStyle={innerLightingStyle}

--- a/components/editor/canvas/screenshot-bare.tsx
+++ b/components/editor/canvas/screenshot-bare.tsx
@@ -6,6 +6,7 @@ import { ShimmerImage } from "@/components/ui/shimmer-image"
 import { cn } from "@/lib/utils"
 import type { EditorTool, ScreenshotLayer } from "@/lib/editor/store"
 import { ScreenshotEditMenu } from "./screenshot-edit-menu"
+import type { TweetCardSettings } from "@/lib/editor/tweet-settings"
 import type { CaptureDevice, CaptureSettings } from "./upload-card"
 
 type PlacementDims = {
@@ -44,6 +45,7 @@ type ScreenshotBareProps = {
     url: string,
     settings: CaptureSettings
   ) => void | Promise<void>
+  onLoadTweet?: (url: string, settings?: TweetCardSettings) => Promise<void>
   captureDefaultDevice?: CaptureDevice
   captureStateKey?: string
   shadowBoxTarget?: boolean
@@ -77,6 +79,7 @@ export function ScreenshotBare({
   onReplaceFile,
   onDelete,
   onCaptureWebsite,
+  onLoadTweet,
   captureDefaultDevice,
   captureStateKey,
   shadowBoxTarget = false,
@@ -195,6 +198,7 @@ export function ScreenshotBare({
             onReplaceFile={onReplaceFile}
             onDelete={onDelete}
             onCaptureWebsite={onCaptureWebsite}
+            onLoadTweet={onLoadTweet}
             captureDefaultDevice={captureDefaultDevice}
             captureStateKey={captureStateKey}
           />

--- a/components/editor/canvas/screenshot-browser-frame.tsx
+++ b/components/editor/canvas/screenshot-browser-frame.tsx
@@ -9,6 +9,7 @@ import {
   type CaptureDevice,
   type CaptureSettings,
 } from "@/components/editor/canvas/upload-card"
+import type { TweetCardSettings } from "@/lib/editor/tweet-settings"
 import { Arc } from "@/components/ui/arc"
 import { Chrome } from "@/components/ui/chrome"
 import { Safari } from "@/components/ui/safari"
@@ -69,6 +70,7 @@ type ScreenshotBrowserFrameProps = {
     url: string,
     settings: CaptureSettings
   ) => void | Promise<void>
+  onLoadTweet?: (url: string, settings?: TweetCardSettings) => Promise<void>
   captureDefaultDevice?: CaptureDevice
   captureStateKey?: string
   showHoverActions?: boolean
@@ -127,6 +129,7 @@ export function ScreenshotBrowserFrame({
   onReplaceFile,
   onDelete,
   onCaptureWebsite,
+  onLoadTweet,
   captureDefaultDevice,
   captureStateKey,
   showHoverActions = true,
@@ -265,6 +268,7 @@ export function ScreenshotBrowserFrame({
               onReplaceFile={onReplaceFile}
               onDelete={onDelete}
               onCaptureWebsite={onCaptureWebsite}
+              onLoadTweet={onLoadTweet}
               captureDefaultDevice={captureDefaultDevice}
               captureStateKey={captureStateKey}
             />

--- a/components/editor/canvas/screenshot-edit-menu.tsx
+++ b/components/editor/canvas/screenshot-edit-menu.tsx
@@ -14,6 +14,7 @@ import {
   type CaptureDevice,
   type CaptureSettings,
 } from "@/components/editor/canvas/upload-card"
+import type { TweetCardSettings } from "@/lib/editor/tweet-settings"
 import { ScrollFadeBody } from "@/components/editor/scroll-fade"
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
 import {
@@ -43,6 +44,7 @@ type ScreenshotEditMenuProps = {
     url: string,
     settings: CaptureSettings
   ) => void | Promise<void>
+  onLoadTweet?: (url: string, settings?: TweetCardSettings) => Promise<void>
   captureDefaultDevice?: CaptureDevice
   captureStateKey?: string
 }
@@ -55,6 +57,7 @@ export function ScreenshotEditMenu({
   onDelete,
   showDelete = true,
   onCaptureWebsite,
+  onLoadTweet,
   captureDefaultDevice,
   captureStateKey,
 }: ScreenshotEditMenuProps) {
@@ -137,6 +140,7 @@ export function ScreenshotEditMenu({
               defaultDevice={captureDefaultDevice}
               captureStateKey={resolvedCaptureStateKey}
               onCapture={onCaptureWebsite}
+              onLoadTweet={onLoadTweet}
             />
             <div
               className={cn(

--- a/components/editor/canvas/screenshot-mockup.tsx
+++ b/components/editor/canvas/screenshot-mockup.tsx
@@ -16,6 +16,7 @@ import {
 } from "./helpers"
 import { InnerLightingOverlay } from "./inner-lighting-overlay"
 import { ScreenshotEditMenu } from "./screenshot-edit-menu"
+import type { TweetCardSettings } from "@/lib/editor/tweet-settings"
 import type { CaptureDevice, CaptureSettings } from "./upload-card"
 
 type DeviceMockupSpec = (typeof DEVICE_MOCKUP_SPECS)[string]
@@ -59,6 +60,7 @@ type ScreenshotMockupProps = {
     url: string,
     settings: CaptureSettings
   ) => void | Promise<void>
+  onLoadTweet?: (url: string, settings?: TweetCardSettings) => Promise<void>
   captureDefaultDevice?: CaptureDevice
   captureStateKey?: string
   showHoverActions?: boolean
@@ -94,6 +96,7 @@ export function ScreenshotMockup({
   onReplaceFile,
   onDelete,
   onCaptureWebsite,
+  onLoadTweet,
   captureDefaultDevice,
   captureStateKey,
   showHoverActions = true,
@@ -251,6 +254,7 @@ export function ScreenshotMockup({
                   onReplaceFile={onReplaceFile}
                   onDelete={onDelete}
                   onCaptureWebsite={onCaptureWebsite}
+                  onLoadTweet={onLoadTweet}
                   captureDefaultDevice={captureDefaultDevice}
                   captureStateKey={captureStateKey}
                 />
@@ -276,6 +280,7 @@ export function ScreenshotMockup({
               onReplaceFile={onReplaceFile}
               onDelete={onDelete}
               onCaptureWebsite={onCaptureWebsite}
+              onLoadTweet={onLoadTweet}
               captureDefaultDevice={captureDefaultDevice}
               captureStateKey={captureStateKey}
             />

--- a/components/editor/canvas/tweet-card.tsx
+++ b/components/editor/canvas/tweet-card.tsx
@@ -1,0 +1,255 @@
+"use client"
+
+import * as React from "react"
+import { RiTwitterXLine } from "@remixicon/react"
+
+import type { ScreenshotLayer, TweetCard, TweetTheme } from "@/lib/editor/store"
+import { cn } from "@/lib/utils"
+
+type ThemePalette = {
+  bg: string
+  text: string
+  sub: string
+  border: string
+  link: string
+}
+
+const THEMES: Record<TweetTheme, ThemePalette> = {
+  light: {
+    bg: "#ffffff",
+    text: "#0f1419",
+    sub: "#536471",
+    border: "#cfd9de",
+    link: "#1d9bf0",
+  },
+  dim: {
+    bg: "#15202b",
+    text: "#f7f9f9",
+    sub: "#8b98a5",
+    border: "#38444d",
+    link: "#1d9bf0",
+  },
+  dark: {
+    bg: "#000000",
+    text: "#e7e9ea",
+    sub: "#71767b",
+    border: "#2f3336",
+    link: "#1d9bf0",
+  },
+}
+
+const VERIFIED_PATH =
+  "M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.689.878.635.132 1.294.084 1.902-.14.27.586.7 1.084 1.24 1.439.541.354 1.168.551 1.814.569.647-.016 1.276-.213 1.817-.567s.972-.853 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"
+
+function VerifiedBadge({ color }: { color: string }) {
+  return (
+    <svg
+      viewBox="0 0 22 22"
+      aria-label="Verified account"
+      className="ml-0.5 inline-block size-[1.05em] shrink-0 translate-y-[0.08em]"
+      fill={color}
+    >
+      <path d={VERIFIED_PATH} />
+    </svg>
+  )
+}
+
+function ReplyIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-[1.05em] shrink-0"
+      aria-hidden
+    >
+      <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8z" />
+    </svg>
+  )
+}
+
+function LikeIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-[1.05em] shrink-0"
+      aria-hidden
+    >
+      <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+    </svg>
+  )
+}
+
+function formatCount(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "0"
+  if (n < 1000) return String(n)
+  if (n < 1_000_000) {
+    const k = n / 1000
+    return `${k.toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, "")}K`
+  }
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`
+}
+
+function formatDate(raw: string): string {
+  if (!raw) return ""
+  const d = new Date(raw)
+  if (Number.isNaN(d.getTime())) return ""
+  const time = d.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  })
+  const date = d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+  return `${time} · ${date}`
+}
+
+const ENTITY_RE = /(https?:\/\/\S+|www\.\S+|@\w{1,15}|#[\p{L}\p{N}_]+)/gu
+
+function isEntity(token: string): boolean {
+  return /^(https?:\/\/|www\.|@\w|#[\p{L}\p{N}_])/u.test(token)
+}
+
+/** Renders tweet text with URLs, @mentions and #hashtags tinted in link color. */
+function renderTweetText(text: string, link: string): React.ReactNode {
+  return text.split(ENTITY_RE).map((token, i) => {
+    if (!token) return null
+    if (isEntity(token)) {
+      return (
+        <span key={i} style={{ color: link }}>
+          {token}
+        </span>
+      )
+    }
+    return <React.Fragment key={i}>{token}</React.Fragment>
+  })
+}
+
+type TweetCardViewProps = {
+  tweet: TweetCard
+  transform: string
+  borderRadius: number
+  boxShadow?: string
+  enhanceFilter?: string
+  screenshotLayer: ScreenshotLayer
+  innerLightingStyle?: React.CSSProperties | null
+}
+
+export function TweetCardView({
+  tweet,
+  transform,
+  borderRadius,
+  boxShadow,
+  enhanceFilter,
+  screenshotLayer,
+}: TweetCardViewProps) {
+  const { data, theme, showMetrics, showAvatar } = tweet
+  const t = THEMES[theme] ?? THEMES.dark
+
+  const cardStyle: React.CSSProperties = {
+    background: t.bg,
+    color: t.text,
+    border: `1px solid ${t.border}`,
+    borderRadius,
+    boxShadow,
+    transform,
+    transformStyle: "preserve-3d",
+    filter: enhanceFilter || undefined,
+    opacity: screenshotLayer.hidden ? 0 : screenshotLayer.opacity / 100,
+    width: "min(98cqw, 996px)",
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+  }
+  if (screenshotLayer.blendMode && screenshotLayer.blendMode !== "normal") {
+    cardStyle.mixBlendMode = screenshotLayer.blendMode
+  }
+
+  const date = formatDate(data.createdAt)
+
+  return (
+    <div
+      className="pointer-events-none flex h-full w-full items-center justify-center"
+      style={{ containerType: "size" }}
+    >
+      <div className="overflow-hidden p-4" style={cardStyle}>
+        <div className="flex items-start gap-3">
+          {showAvatar ? (
+            data.author.avatarUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={data.author.avatarUrl}
+                alt={data.author.name}
+                width={56}
+                height={56}
+                className="size-14 shrink-0 rounded-full object-cover"
+                draggable={false}
+              />
+            ) : (
+              <div
+                className="size-14 shrink-0 rounded-full"
+                style={{ background: t.border }}
+              />
+            )
+          ) : null}
+          <div className="min-w-0 flex-1 leading-tight">
+            <div
+              className="flex items-center text-[20px] font-bold"
+              style={{ color: t.text }}
+            >
+              <span className="truncate">{data.author.name}</span>
+              {data.author.verified ? <VerifiedBadge color={t.link} /> : null}
+            </div>
+            {data.author.handle ? (
+              <div className="truncate text-[18px]" style={{ color: t.sub }}>
+                @{data.author.handle}
+              </div>
+            ) : null}
+          </div>
+          <RiTwitterXLine
+            className="size-[28px] shrink-0"
+            style={{ color: t.text }}
+          />
+        </div>
+
+        {data.text ? (
+          <p className="mt-3 text-[20px] leading-normal break-words whitespace-pre-wrap">
+            {renderTweetText(data.text, t.link)}
+          </p>
+        ) : null}
+
+        <div className="mt-3 flex flex-col gap-2">
+          {showMetrics ? (
+            <div
+              className="flex items-center gap-5 text-[18px]"
+              style={{ color: t.sub }}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <ReplyIcon />
+                {formatCount(data.metrics.replies)}
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <LikeIcon />
+                {formatCount(data.metrics.likes)}
+              </span>
+            </div>
+          ) : null}
+          {date ? (
+            <div className={cn("text-[16px]")} style={{ color: t.sub }}>
+              {date}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/editor/canvas/tweet-card.tsx
+++ b/components/editor/canvas/tweet-card.tsx
@@ -1,9 +1,27 @@
 "use client"
 
 import * as React from "react"
-import { RiTwitterXLine } from "@remixicon/react"
+import { RiDeleteBinLine, RiPencilLine, RiTwitterXLine } from "@remixicon/react"
 
-import type { ScreenshotLayer, TweetCard, TweetTheme } from "@/lib/editor/store"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  UploadCard,
+  type CaptureDevice,
+  type CaptureSettings,
+} from "@/components/editor/canvas/upload-card"
+import { InnerLightingOverlay } from "@/components/editor/canvas/inner-lighting-overlay"
+import type { TweetCardSettings } from "@/lib/editor/tweet-settings"
+import type {
+  EditorTool,
+  ScreenshotLayer,
+  TweetCard,
+  TweetTheme,
+} from "@/lib/editor/store"
+import { DEFAULT_TWEET_FONT_FAMILY } from "@/lib/editor/tweet-settings"
 import { cn } from "@/lib/utils"
 
 type ThemePalette = {
@@ -135,6 +153,19 @@ function renderTweetText(text: string, link: string): React.ReactNode {
   })
 }
 
+function mediaGridClass(count: number) {
+  if (count === 1) return "grid-cols-1"
+  if (count >= 3) return "grid-cols-2 grid-rows-2 aspect-[1.5/1]"
+  return "grid-cols-2"
+}
+
+function mediaItemClass(count: number, index: number) {
+  if (count === 1) return "aspect-[16/9]"
+  if (count === 2) return "aspect-[1.42/1]"
+  if (count === 3 && index === 0) return "row-span-2"
+  return ""
+}
+
 type TweetCardViewProps = {
   tweet: TweetCard
   transform: string
@@ -143,6 +174,24 @@ type TweetCardViewProps = {
   enhanceFilter?: string
   screenshotLayer: ScreenshotLayer
   innerLightingStyle?: React.CSSProperties | null
+  leftPct: number
+  topPct: number
+  isSelected?: boolean
+  isDragging?: boolean
+  activeTool?: EditorTool
+  onSelect?: (e: React.MouseEvent<HTMLDivElement>) => void
+  onPointerDown?: (e: React.PointerEvent<HTMLDivElement>) => void
+  onPointerMove?: (e: React.PointerEvent<HTMLDivElement>) => void
+  onPointerUp?: (e: React.PointerEvent<HTMLDivElement>) => void
+  onReplace?: (url: string, settings?: TweetCardSettings) => Promise<void>
+  onReplaceFile?: (file: File) => void
+  onCaptureWebsite?: (
+    url: string,
+    settings: CaptureSettings
+  ) => void | Promise<void>
+  captureDefaultDevice?: CaptureDevice
+  captureStateKey?: string
+  onDelete?: () => void
 }
 
 export function TweetCardView({
@@ -152,9 +201,29 @@ export function TweetCardView({
   boxShadow,
   enhanceFilter,
   screenshotLayer,
+  innerLightingStyle,
+  leftPct,
+  topPct,
+  isSelected = false,
+  isDragging = false,
+  activeTool = "pointer",
+  onSelect,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onReplace,
+  onReplaceFile,
+  onCaptureWebsite,
+  captureDefaultDevice,
+  captureStateKey,
+  onDelete,
 }: TweetCardViewProps) {
+  const [editOpen, setEditOpen] = React.useState(false)
+  const replaceInputRef = React.useRef<HTMLInputElement>(null)
   const { data, theme, showMetrics, showAvatar } = tweet
   const t = THEMES[theme] ?? THEMES.dark
+  const media = (tweet.showImages ?? true) ? (data.media ?? []).slice(0, 4) : []
+  const showTimestamp = tweet.showTimestamp ?? true
 
   const cardStyle: React.CSSProperties = {
     background: t.bg,
@@ -167,8 +236,7 @@ export function TweetCardView({
     filter: enhanceFilter || undefined,
     opacity: screenshotLayer.hidden ? 0 : screenshotLayer.opacity / 100,
     width: "min(98cqw, 996px)",
-    fontFamily:
-      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+    fontFamily: tweet.fontFamily ?? DEFAULT_TWEET_FONT_FAMILY,
   }
   if (screenshotLayer.blendMode && screenshotLayer.blendMode !== "normal") {
     cardStyle.mixBlendMode = screenshotLayer.blendMode
@@ -178,10 +246,47 @@ export function TweetCardView({
 
   return (
     <div
-      className="pointer-events-none flex h-full w-full items-center justify-center"
+      className="pointer-events-none absolute inset-0"
       style={{ containerType: "size" }}
     >
-      <div className="overflow-hidden p-4" style={cardStyle}>
+      <input
+        ref={replaceInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0]
+          if (file) {
+            onReplaceFile?.(file)
+            setEditOpen(false)
+          }
+          e.target.value = ""
+        }}
+      />
+      <div
+        data-editor-shadow-box-target
+        data-tweet-card
+        data-selection-border={isSelected ? "true" : undefined}
+        onClick={onSelect}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        className={cn(
+          "group/tweet pointer-events-auto absolute overflow-hidden p-4",
+          onPointerDown
+            ? isDragging
+              ? "cursor-grabbing"
+              : "cursor-grab"
+            : "cursor-default"
+        )}
+        style={{
+          ...cardStyle,
+          left: `var(--editor-main-position-x, ${leftPct}%)`,
+          top: `var(--editor-main-position-y, ${topPct}%)`,
+          transform: `translate(-50%, -50%) ${transform}`,
+        }}
+      >
         <div className="flex items-start gap-3">
           {showAvatar ? (
             data.author.avatarUrl ? (
@@ -227,6 +332,30 @@ export function TweetCardView({
           </p>
         ) : null}
 
+        {media.length > 0 ? (
+          <div
+            className={cn(
+              "mt-3 grid gap-2 overflow-hidden rounded-[18px] border",
+              mediaGridClass(media.length)
+            )}
+            style={{ borderColor: t.border }}
+          >
+            {media.map((item, index) => (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                key={item.url}
+                src={item.url}
+                alt={item.alt ?? ""}
+                draggable={false}
+                className={cn(
+                  "h-full min-h-0 w-full object-cover",
+                  mediaItemClass(media.length, index)
+                )}
+              />
+            ))}
+          </div>
+        ) : null}
+
         <div className="mt-3 flex flex-col gap-2">
           {showMetrics ? (
             <div
@@ -243,12 +372,91 @@ export function TweetCardView({
               </span>
             </div>
           ) : null}
-          {date ? (
+          {showTimestamp && date ? (
             <div className={cn("text-[16px]")} style={{ color: t.sub }}>
               {date}
             </div>
           ) : null}
         </div>
+
+        <InnerLightingOverlay
+          style={innerLightingStyle}
+          className="rounded-[inherit]"
+        />
+
+        {activeTool === "pointer" && !screenshotLayer.hidden ? (
+          <div
+            data-export-hidden="true"
+            className={cn(
+              "pointer-events-none absolute inset-0 z-20 flex items-center justify-center transition-opacity duration-200",
+              editOpen || isSelected
+                ? "opacity-100"
+                : "opacity-0 group-hover/tweet:opacity-100",
+              isDragging && !editOpen && "opacity-0!"
+            )}
+          >
+            <Popover open={editOpen} onOpenChange={setEditOpen}>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Edit X post"
+                  title="Edit X post"
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onPointerUp={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setEditOpen((open) => !open)
+                  }}
+                  className="pointer-events-auto flex size-10 items-center justify-center rounded-full bg-background text-foreground shadow-xl ring-2 ring-foreground/15 transition-[ring-color] hover:ring-foreground/30 sm:size-14"
+                >
+                  <RiPencilLine className="size-5 sm:size-7" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                data-export-hidden="true"
+                align="center"
+                side="bottom"
+                sideOffset={10}
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
+                onOpenAutoFocus={(e) => e.preventDefault()}
+                className="w-[320px] gap-0 rounded-2xl border border-border bg-popover p-0 shadow-2xl"
+              >
+                <div className="overflow-hidden rounded-2xl">
+                  <UploadCard
+                    onBrowse={() => replaceInputRef.current?.click()}
+                    onCapture={onCaptureWebsite}
+                    onLoadTweet={
+                      onReplace
+                        ? async (url, settings) => {
+                            await onReplace(url, settings)
+                          }
+                        : undefined
+                    }
+                    defaultDevice={captureDefaultDevice}
+                    captureStateKey={captureStateKey}
+                  />
+                  {onDelete ? (
+                    <div className="border-t border-border/60 p-2.5">
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          setEditOpen(false)
+                          onDelete()
+                        }}
+                        className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-destructive/10 text-[13px] font-medium text-destructive transition-all hover:bg-destructive/18 hover:text-destructive"
+                      >
+                        <RiDeleteBinLine className="size-4" />
+                        Remove post
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/components/editor/canvas/tweet-url-popover.tsx
+++ b/components/editor/canvas/tweet-url-popover.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import * as React from "react"
+import { RiLoader4Line, RiTwitterXLine } from "@remixicon/react"
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { tweetUrlSchema } from "@/lib/editor/tweet-url"
+import { cn } from "@/lib/utils"
+
+type TweetUrlPopoverProps = {
+  /** Resolves the pasted link into a loaded post. Throws to show an error. */
+  onLoad: (url: string) => Promise<void>
+  children: React.ReactNode
+  side?: "top" | "bottom" | "left" | "right"
+  align?: "start" | "center" | "end"
+}
+
+export function TweetUrlPopover({
+  onLoad,
+  children,
+  side = "bottom",
+  align = "center",
+}: TweetUrlPopoverProps) {
+  const [open, setOpen] = React.useState(false)
+  const [url, setUrl] = React.useState("")
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+
+  const parsed = React.useMemo(() => tweetUrlSchema.safeParse(url), [url])
+  const invalid = url.trim().length > 0 && !parsed.success
+  const canSubmit = parsed.success && !loading
+
+  const submit = React.useCallback(async () => {
+    if (!parsed.success || loading) return
+    setLoading(true)
+    setError(null)
+    try {
+      await onLoad(url.trim())
+      setOpen(false)
+      setUrl("")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not load that post")
+    } finally {
+      setLoading(false)
+    }
+  }, [parsed, loading, onLoad, url])
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) setError(null)
+      }}
+    >
+      <PopoverTrigger asChild onPointerDown={(e) => e.stopPropagation()}>
+        {children}
+      </PopoverTrigger>
+      <PopoverContent
+        side={side}
+        align={align}
+        sideOffset={8}
+        onPointerDown={(e) => e.stopPropagation()}
+        className="w-[300px] gap-3 p-3"
+      >
+        <div className="flex items-center gap-2">
+          <span className="grid size-7 shrink-0 place-items-center rounded-md bg-foreground/5 text-foreground">
+            <RiTwitterXLine className="size-4" />
+          </span>
+          <div className="min-w-0">
+            <p className="text-[13px] leading-tight font-medium">
+              Embed an X post
+            </p>
+            <p className="text-[11px] leading-tight text-muted-foreground">
+              Paste a link to a public post
+            </p>
+          </div>
+        </div>
+        <input
+          type="text"
+          inputMode="url"
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus
+          placeholder="https://x.com/…/status/…"
+          aria-label="X post link"
+          aria-invalid={invalid}
+          value={url}
+          onChange={(e) => {
+            setUrl(e.target.value)
+            setError(null)
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void submit()
+          }}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            "h-9 w-full rounded-md border bg-foreground/4 px-2.5 text-[13px] text-foreground placeholder:text-muted-foreground/50 focus:ring-1 focus:outline-none",
+            invalid
+              ? "border-destructive/60 focus:ring-destructive/40"
+              : "border-border focus:border-foreground/30 focus:ring-foreground/20"
+          )}
+        />
+        {error ? (
+          <p className="text-[11px] leading-tight text-destructive">{error}</p>
+        ) : null}
+        <button
+          type="button"
+          disabled={!canSubmit}
+          onClick={(e) => {
+            e.stopPropagation()
+            void submit()
+          }}
+          className={cn(
+            "flex h-9 w-full items-center justify-center gap-2 rounded-md bg-primary text-[13px] font-medium text-white transition hover:brightness-110",
+            !canSubmit && "cursor-default opacity-60 hover:brightness-100"
+          )}
+        >
+          {loading ? <RiLoader4Line className="size-4 animate-spin" /> : null}
+          {loading ? "Loading…" : "Load post"}
+        </button>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/editor/canvas/upload-card.tsx
+++ b/components/editor/canvas/upload-card.tsx
@@ -7,6 +7,7 @@ import {
   RiLink,
   RiLoader4Line,
   RiSettings3Line,
+  RiTwitterXLine,
   RiUploadLine,
 } from "@remixicon/react"
 
@@ -20,6 +21,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 import { captureUrlSchema } from "@/lib/editor/capture-url"
+import { TweetUrlPopover } from "./tweet-url-popover"
 
 export type CaptureDevice = "desktop" | "mobile"
 export type CaptureDelay = "none" | "2s" | "5s"
@@ -262,6 +264,8 @@ type UploadCardProps = {
   isDragOver?: boolean
   onBrowse: () => void
   onCapture?: (url: string, settings: CaptureSettings) => void | Promise<void>
+  /** When provided, shows an "Embed X post" entry that loads a tweet mockup. */
+  onLoadTweet?: (url: string) => Promise<void>
   showHint?: boolean
   /** Pass custom className overrides for the outer card shell */
   className?: string
@@ -279,6 +283,7 @@ export function UploadCard({
   isDragOver = false,
   onBrowse,
   onCapture,
+  onLoadTweet,
   showHint = false,
   className,
   fluid = false,
@@ -454,6 +459,7 @@ export function UploadCard({
               isDragOver={isDragOver}
               onBrowse={onBrowse}
               onCapture={onCapture}
+              onLoadTweet={onLoadTweet}
               showHint={showHint}
               defaultDevice={defaultDevice}
               captureStateKey={captureStateKey}
@@ -539,6 +545,19 @@ export function UploadCard({
         )}
         {captureLabel}
       </button>
+      {onLoadTweet ? (
+        <TweetUrlPopover onLoad={onLoadTweet} side="bottom" align="center">
+          <button
+            type="button"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+            className={cn(sizing.captureButton)}
+          >
+            <RiTwitterXLine className={sizing.icon} />
+            Embed X post
+          </button>
+        </TweetUrlPopover>
+      ) : null}
       {showHint && (
         <div className={sizing.hintBox}>
           <span className={sizing.hintText}>

--- a/components/editor/canvas/upload-card.tsx
+++ b/components/editor/canvas/upload-card.tsx
@@ -20,8 +20,24 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import {
+  TweetFontSelect,
+  TweetThemeSelect,
+} from "@/components/editor/tweet-font-select"
 import { captureUrlSchema } from "@/lib/editor/capture-url"
-import { TweetUrlPopover } from "./tweet-url-popover"
+import { tweetUrlSchema } from "@/lib/editor/tweet-url"
+import {
+  DEFAULT_TWEET_SETTINGS,
+  type TweetCardSettings,
+} from "@/lib/editor/tweet-settings"
 
 export type CaptureDevice = "desktop" | "mobile"
 export type CaptureDelay = "none" | "2s" | "5s"
@@ -132,6 +148,9 @@ function ToggleChip({ active, onClick, children, layoutId }: ToggleChipProps) {
 function CaptureSettingsPopover({
   settings,
   onChange,
+  tweetMode = false,
+  tweetSettings,
+  onTweetSettingsChange,
   triggerClassName,
   iconClassName,
 }: {
@@ -140,9 +159,175 @@ function CaptureSettingsPopover({
     key: K,
     value: CaptureSettings[K]
   ) => void
+  tweetMode?: boolean
+  tweetSettings: TweetCardSettings
+  onTweetSettingsChange: <K extends keyof TweetCardSettings>(
+    key: K,
+    value: TweetCardSettings[K]
+  ) => void
   triggerClassName?: string
   iconClassName?: string
 }) {
+  const content = tweetMode ? (
+    <div className="flex flex-col divide-y divide-neutral-200 dark:divide-white/10">
+      <div className="flex items-center justify-between gap-3 px-4 py-3">
+        <span className="text-[13px] text-neutral-500 dark:text-white/55">
+          Theme
+        </span>
+        <TweetThemeSelect
+          value={tweetSettings.theme}
+          onValueChange={(value) => onTweetSettingsChange("theme", value)}
+          triggerClassName="w-[154px] border-neutral-200 bg-neutral-50 text-neutral-900 shadow-none hover:bg-neutral-100 dark:border-white/10 dark:bg-white/8 dark:text-white dark:hover:bg-white/12"
+          contentClassName="w-[180px]"
+        />
+      </div>
+      <div className="flex items-center justify-between px-4 py-3">
+        <span className="text-[13px] text-neutral-500 dark:text-white/55">
+          Avatar
+        </span>
+        <Switch
+          checked={tweetSettings.showAvatar}
+          onCheckedChange={(value) =>
+            onTweetSettingsChange("showAvatar", value)
+          }
+        />
+      </div>
+      <div className="flex items-center justify-between px-4 py-3">
+        <span className="text-[13px] text-neutral-500 dark:text-white/55">
+          Images
+        </span>
+        <Switch
+          checked={tweetSettings.showImages}
+          onCheckedChange={(value) =>
+            onTweetSettingsChange("showImages", value)
+          }
+        />
+      </div>
+      <div className="flex items-center justify-between px-4 py-3">
+        <span className="text-[13px] text-neutral-500 dark:text-white/55">
+          Stats
+        </span>
+        <Switch
+          checked={tweetSettings.showMetrics}
+          onCheckedChange={(value) =>
+            onTweetSettingsChange("showMetrics", value)
+          }
+        />
+      </div>
+      <div className="flex items-center justify-between px-4 py-3">
+        <span className="text-[13px] text-neutral-500 dark:text-white/55">
+          Date & time
+        </span>
+        <Switch
+          checked={tweetSettings.showTimestamp}
+          onCheckedChange={(value) =>
+            onTweetSettingsChange("showTimestamp", value)
+          }
+        />
+      </div>
+      <div className="flex items-center justify-between gap-3 px-4 py-3">
+        <span className="text-[13px] text-neutral-500 dark:text-white/55">
+          Font
+        </span>
+        <TweetFontSelect
+          value={tweetSettings.fontFamily}
+          onValueChange={(value) => onTweetSettingsChange("fontFamily", value)}
+          triggerClassName="w-[154px] border-neutral-200 bg-neutral-50 text-neutral-900 shadow-none hover:bg-neutral-100 dark:border-white/10 dark:bg-white/8 dark:text-white dark:hover:bg-white/12"
+        />
+      </div>
+    </div>
+  ) : (
+    <div className="flex flex-col divide-y divide-neutral-200 dark:divide-white/10">
+      <div className="flex items-center justify-between px-4 py-3">
+        <span className="text-[13px] text-neutral-500 dark:text-white/55">
+          Device
+        </span>
+        <LayoutGroup id="capture-device">
+          <div className="flex items-center gap-0.5 rounded-md bg-neutral-100 p-0.5 dark:bg-white/8">
+            {(["desktop", "mobile"] as CaptureDevice[]).map((d) => (
+              <ToggleChip
+                key={d}
+                active={settings.device === d}
+                layoutId="capture-device-pill"
+                onClick={() => {
+                  const isMobile = d === "mobile"
+                  onChange("device", d)
+                  onChange("aspectRatio", isMobile ? "9:19.5" : "16:9")
+                  onChange("width", isMobile ? 390 : 1280)
+                }}
+              >
+                {d === "desktop" ? "Desktop" : "Mobile"}
+              </ToggleChip>
+            ))}
+          </div>
+        </LayoutGroup>
+      </div>
+      <div className="flex items-center justify-between px-4 py-3">
+        <span className="text-[13px] text-neutral-500 dark:text-white/55">
+          Aspect Ratio
+        </span>
+        <LayoutGroup id="capture-aspect">
+          <div className="flex items-center gap-0.5 rounded-md bg-neutral-100 p-0.5 dark:bg-white/8">
+            {(settings.device === "mobile"
+              ? MOBILE_ASPECT_RATIOS
+              : DESKTOP_ASPECT_RATIOS
+            ).map((r) => (
+              <ToggleChip
+                key={r}
+                active={settings.aspectRatio === r}
+                layoutId="capture-aspect-pill"
+                onClick={() => onChange("aspectRatio", r)}
+              >
+                {r}
+              </ToggleChip>
+            ))}
+          </div>
+        </LayoutGroup>
+      </div>
+      <div className="flex items-center justify-between px-4 py-3">
+        <span className="text-[13px] text-neutral-500 dark:text-white/55">
+          Width
+        </span>
+        <LayoutGroup id="capture-width">
+          <div className="flex items-center gap-0.5 rounded-md bg-neutral-100 p-0.5 dark:bg-white/8">
+            {(settings.device === "mobile"
+              ? MOBILE_WIDTHS
+              : DESKTOP_WIDTHS
+            ).map((w) => (
+              <ToggleChip
+                key={w}
+                active={settings.width === w}
+                layoutId="capture-width-pill"
+                onClick={() => onChange("width", w)}
+              >
+                {w}
+              </ToggleChip>
+            ))}
+          </div>
+        </LayoutGroup>
+      </div>
+      <div className="flex items-center justify-between px-4 py-3">
+        <span className="text-[13px] text-neutral-500 dark:text-white/55">
+          Delay
+        </span>
+        <LayoutGroup id="capture-delay">
+          <div className="flex items-center gap-0.5 rounded-md bg-neutral-100 p-0.5 dark:bg-white/8">
+            {(["none", "2s", "5s"] as CaptureDelay[]).map((d) => (
+              <ToggleChip
+                key={d}
+                active={settings.delay === d}
+                layoutId="capture-delay-pill"
+                onClick={() => onChange("delay", d)}
+              >
+                {d === "none" ? "None" : d}
+              </ToggleChip>
+            ))}
+          </div>
+        </LayoutGroup>
+      </div>
+    </div>
+  )
+
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -166,95 +351,7 @@ function CaptureSettingsPopover({
         onPointerDown={(e) => e.stopPropagation()}
         className="w-[280px] rounded-md border border-neutral-200 bg-white p-0 text-neutral-950 shadow-2xl ring-0 backdrop-blur-xl dark:border-white/10 dark:bg-neutral-950 dark:text-white"
       >
-        <div className="flex flex-col divide-y divide-neutral-200 dark:divide-white/10">
-          <div className="flex items-center justify-between px-4 py-3">
-            <span className="text-[13px] text-neutral-500 dark:text-white/55">
-              Device
-            </span>
-            <LayoutGroup id="capture-device">
-              <div className="flex items-center gap-0.5 rounded-md bg-neutral-100 p-0.5 dark:bg-white/8">
-                {(["desktop", "mobile"] as CaptureDevice[]).map((d) => (
-                  <ToggleChip
-                    key={d}
-                    active={settings.device === d}
-                    layoutId="capture-device-pill"
-                    onClick={() => {
-                      const isMobile = d === "mobile"
-                      onChange("device", d)
-                      onChange("aspectRatio", isMobile ? "9:19.5" : "16:9")
-                      onChange("width", isMobile ? 390 : 1280)
-                    }}
-                  >
-                    {d === "desktop" ? "Desktop" : "Mobile"}
-                  </ToggleChip>
-                ))}
-              </div>
-            </LayoutGroup>
-          </div>
-          <div className="flex items-center justify-between px-4 py-3">
-            <span className="text-[13px] text-neutral-500 dark:text-white/55">
-              Aspect Ratio
-            </span>
-            <LayoutGroup id="capture-aspect">
-              <div className="flex items-center gap-0.5 rounded-md bg-neutral-100 p-0.5 dark:bg-white/8">
-                {(settings.device === "mobile"
-                  ? MOBILE_ASPECT_RATIOS
-                  : DESKTOP_ASPECT_RATIOS
-                ).map((r) => (
-                  <ToggleChip
-                    key={r}
-                    active={settings.aspectRatio === r}
-                    layoutId="capture-aspect-pill"
-                    onClick={() => onChange("aspectRatio", r)}
-                  >
-                    {r}
-                  </ToggleChip>
-                ))}
-              </div>
-            </LayoutGroup>
-          </div>
-          <div className="flex items-center justify-between px-4 py-3">
-            <span className="text-[13px] text-neutral-500 dark:text-white/55">
-              Width
-            </span>
-            <LayoutGroup id="capture-width">
-              <div className="flex items-center gap-0.5 rounded-md bg-neutral-100 p-0.5 dark:bg-white/8">
-                {(settings.device === "mobile"
-                  ? MOBILE_WIDTHS
-                  : DESKTOP_WIDTHS
-                ).map((w) => (
-                  <ToggleChip
-                    key={w}
-                    active={settings.width === w}
-                    layoutId="capture-width-pill"
-                    onClick={() => onChange("width", w)}
-                  >
-                    {w}
-                  </ToggleChip>
-                ))}
-              </div>
-            </LayoutGroup>
-          </div>
-          <div className="flex items-center justify-between px-4 py-3">
-            <span className="text-[13px] text-neutral-500 dark:text-white/55">
-              Delay
-            </span>
-            <LayoutGroup id="capture-delay">
-              <div className="flex items-center gap-0.5 rounded-md bg-neutral-100 p-0.5 dark:bg-white/8">
-                {(["none", "2s", "5s"] as CaptureDelay[]).map((d) => (
-                  <ToggleChip
-                    key={d}
-                    active={settings.delay === d}
-                    layoutId="capture-delay-pill"
-                    onClick={() => onChange("delay", d)}
-                  >
-                    {d === "none" ? "None" : d}
-                  </ToggleChip>
-                ))}
-              </div>
-            </LayoutGroup>
-          </div>
-        </div>
+        {content}
       </PopoverContent>
     </Popover>
   )
@@ -264,8 +361,8 @@ type UploadCardProps = {
   isDragOver?: boolean
   onBrowse: () => void
   onCapture?: (url: string, settings: CaptureSettings) => void | Promise<void>
-  /** When provided, shows an "Embed X post" entry that loads a tweet mockup. */
-  onLoadTweet?: (url: string) => Promise<void>
+  /** When provided, X/Twitter status URLs load a tweet card instead of a screenshot. */
+  onLoadTweet?: (url: string, settings?: TweetCardSettings) => Promise<void>
   showHint?: boolean
   /** Pass custom className overrides for the outer card shell */
   className?: string
@@ -300,6 +397,10 @@ export function UploadCard({
       captureSessions.get(captureStateKey ?? "")?.settings ??
       initialCaptureSettings(defaultDevice)
   )
+  const [tweetSettings, setTweetSettings] = React.useState<TweetCardSettings>(
+    DEFAULT_TWEET_SETTINGS
+  )
+  const [tweetError, setTweetError] = React.useState<string | null>(null)
   const persistedCaptureRef = React.useRef(
     captureSessions.has(captureStateKey ?? "")
   )
@@ -345,7 +446,15 @@ export function UploadCard({
     setSettings((prev) => ({ ...prev, [key]: value }))
   }
 
+  function handleTweetSettingChange<K extends keyof TweetCardSettings>(
+    key: K,
+    value: TweetCardSettings[K]
+  ) {
+    setTweetSettings((prev) => ({ ...prev, [key]: value }))
+  }
+
   function handleUrlChange(value: string) {
+    setTweetError(null)
     if (!value.startsWith(PREFIX)) {
       setUrl(PREFIX)
       return
@@ -357,10 +466,28 @@ export function UploadCard({
   }
 
   const parsedUrl = React.useMemo(() => captureUrlSchema.safeParse(url), [url])
+  const parsedTweet = React.useMemo(() => tweetUrlSchema.safeParse(url), [url])
   const hasUrlInput = url !== PREFIX
+  const isTweetUrl = Boolean(onLoadTweet && parsedTweet.success)
 
   async function handleCapture(e: React.MouseEvent | React.KeyboardEvent) {
     e.stopPropagation()
+    if (isTweetUrl) {
+      if (!onLoadTweet || isCapturing) return
+      setIsCapturing(true)
+      setTweetError(null)
+      try {
+        await onLoadTweet(url.trim(), tweetSettings)
+        setUrl(PREFIX)
+      } catch (err) {
+        setTweetError(
+          err instanceof Error ? err.message : "Could not load that post"
+        )
+      } finally {
+        setIsCapturing(false)
+      }
+      return
+    }
     if (!parsedUrl.success || isCapturing || !onCapture) return
     const captureUrl = parsedUrl.data
     setUrl(captureUrl)
@@ -378,10 +505,16 @@ export function UploadCard({
     }
   }
 
-  const captureDisabled = !onCapture || !parsedUrl.success || isCapturing
+  const captureDisabled = isTweetUrl
+    ? isCapturing
+    : !onCapture || !parsedUrl.success || isCapturing
   const captureLabel = isCapturing
-    ? "Capturing screenshot…"
-    : "Capture Screenshot"
+    ? isTweetUrl
+      ? "Loading X post…"
+      : "Capturing screenshot…"
+    : isTweetUrl
+      ? "Load X post"
+      : "Capture Screenshot"
 
   const [compactOpen, setCompactOpen] = React.useState(false)
   const compactTriggerRef = React.useRef<HTMLButtonElement>(null)
@@ -520,6 +653,9 @@ export function UploadCard({
         <CaptureSettingsPopover
           settings={settings}
           onChange={handleSettingChange}
+          tweetMode={isTweetUrl}
+          tweetSettings={tweetSettings}
+          onTweetSettingsChange={handleTweetSettingChange}
           triggerClassName={sizing.settingsTrigger}
           iconClassName={sizing.settingsIcon}
         />
@@ -540,23 +676,17 @@ export function UploadCard({
       >
         {isCapturing ? (
           <RiLoader4Line className={cn(sizing.icon, "animate-spin")} />
+        ) : isTweetUrl ? (
+          <RiTwitterXLine className={sizing.icon} />
         ) : (
           <RiCameraLine className={sizing.icon} />
         )}
         {captureLabel}
       </button>
-      {onLoadTweet ? (
-        <TweetUrlPopover onLoad={onLoadTweet} side="bottom" align="center">
-          <button
-            type="button"
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={(e) => e.stopPropagation()}
-            className={cn(sizing.captureButton)}
-          >
-            <RiTwitterXLine className={sizing.icon} />
-            Embed X post
-          </button>
-        </TweetUrlPopover>
+      {tweetError ? (
+        <p className="px-1 text-[11px] leading-tight text-destructive">
+          {tweetError}
+        </p>
       ) : null}
       {showHint && (
         <div className={sizing.hintBox}>

--- a/components/editor/effects-sidebar.tsx
+++ b/components/editor/effects-sidebar.tsx
@@ -51,6 +51,7 @@ export function EffectsSidebar({
   const bulkEditMode = useEditorStore((s) => s.bulkEditMode)
   const frame = useActiveCanvasField((c) => c.frame)
   const objectFit = useActiveCanvasField((c) => c.objectFit)
+  const tweet = useActiveCanvasField((c) => c.tweet)
   const setAspect = useEditorStore((s) => s.setAspect)
   const setCanvasAspect = useEditorStore((s) => s.setCanvasAspect)
   const setFrameForMatchingScreenshots = useEditorStore(
@@ -63,7 +64,8 @@ export function EffectsSidebar({
     activeFrameRef.current = activeFrame
   })
 
-  const aspect = bulkEditMode ? (canvasAspect ?? globalAspect) : globalAspect
+  const aspect =
+    bulkEditMode || tweet ? (canvasAspect ?? globalAspect) : globalAspect
   const projectName = currentDraftName?.trim()
 
   const [customSize, setCustomSize] = React.useState<{
@@ -159,6 +161,9 @@ export function EffectsSidebar({
             align={popoverAlign}
             previewImage={selectedSlot ? selectedSlot.src : undefined}
             imageFit={selectedSlot?.objectFit ?? objectFit ?? "cover"}
+            disabled={Boolean(tweet)}
+            disabledLabel="Disabled for X posts"
+            disabledTooltip="Frames are disabled for X posts because the post card already provides the frame and spacing."
             onChange={(nextFrame) => {
               setFrameForMatchingScreenshots(nextFrame)
               showCompatibilityWarning(

--- a/components/editor/floating-toolbar-parts/default-toolbar-contents.tsx
+++ b/components/editor/floating-toolbar-parts/default-toolbar-contents.tsx
@@ -132,13 +132,20 @@ export function DefaultToolbarContents() {
   const activeEnhance = enhance
   const hasDeviceFrame = activeFrame.id !== "none"
   const hasMainScreenshotTarget =
-    Boolean(screenshot) || hasDeviceFrame || screenshotSlots.length > 0
-  const hasMainScreenshot = Boolean(screenshot) || hasDeviceFrame
+    Boolean(screenshot) ||
+    Boolean(tweet) ||
+    hasDeviceFrame ||
+    screenshotSlots.length > 0
+  const hasMainScreenshot =
+    Boolean(screenshot) || Boolean(tweet) || hasDeviceFrame
   const hasScalableContent = selectedSlot
     ? true
     : hasMainScreenshotTarget || Boolean(tweet)
   const hasAnyScreenshotContent =
-    Boolean(screenshot) || hasDeviceFrame || screenshotSlots.length > 0
+    Boolean(screenshot) ||
+    Boolean(tweet) ||
+    hasDeviceFrame ||
+    screenshotSlots.length > 0
   const screenshotBoxCount =
     (hasMainScreenshot ? 1 : 0) + screenshotSlots.length
   const canGroupAllScreenshots = screenshotBoxCount > 1
@@ -159,7 +166,7 @@ export function DefaultToolbarContents() {
                   ? "slotGroup"
                   : bulkEditMode
                     ? "canvas"
-                    : screenshot || hasDeviceFrame
+                    : screenshot || tweet || hasDeviceFrame
                       ? "screenshot"
                       : null
 
@@ -657,9 +664,11 @@ export function DefaultToolbarContents() {
                 : positionTarget === "allScreenshots"
                   ? "all screenshots"
                   : positionTarget === "screenshot"
-                    ? hasDeviceFrame
-                      ? "device frame"
-                      : "screenshot"
+                    ? tweet
+                      ? "tweet"
+                      : hasDeviceFrame
+                        ? "device frame"
+                        : "screenshot"
                     : null
 
   const handleAssetUpload = (file: File) => {

--- a/components/editor/floating-toolbar-parts/default-toolbar-contents.tsx
+++ b/components/editor/floating-toolbar-parts/default-toolbar-contents.tsx
@@ -68,6 +68,7 @@ export function DefaultToolbarContents() {
     setSelectedAssetId,
     setIsScreenshotSelected,
     screenshot,
+    tweet,
     frame,
     enhance,
     setEnhance,
@@ -133,7 +134,9 @@ export function DefaultToolbarContents() {
   const hasMainScreenshotTarget =
     Boolean(screenshot) || hasDeviceFrame || screenshotSlots.length > 0
   const hasMainScreenshot = Boolean(screenshot) || hasDeviceFrame
-  const hasScalableContent = selectedSlot ? true : hasMainScreenshotTarget
+  const hasScalableContent = selectedSlot
+    ? true
+    : hasMainScreenshotTarget || Boolean(tweet)
   const hasAnyScreenshotContent =
     Boolean(screenshot) || hasDeviceFrame || screenshotSlots.length > 0
   const screenshotBoxCount =

--- a/components/editor/floating-toolbar-parts/screenshot-media-pill.tsx
+++ b/components/editor/floating-toolbar-parts/screenshot-media-pill.tsx
@@ -38,6 +38,7 @@ export function ScreenshotMediaPill() {
     setIsScreenshotSelected,
     setActiveTool,
     screenshot,
+    tweet,
     objectFit,
     setObjectFit,
     frame,
@@ -64,12 +65,15 @@ export function ScreenshotMediaPill() {
   const isDisabled =
     presetTab === "multi" ||
     presetTab === "triple" ||
+    Boolean(tweet) ||
     screenshotSlots.length >= MAX_SCREENSHOT_SLOTS
 
   const slotTooltip = isDisabled
-    ? presetTab === "multi" || presetTab === "triple"
-      ? `Disabled in ${presetTab === "triple" ? "Triple" : "Multi"} preset mode`
-      : `Maximum ${MAX_SCREENSHOT_SLOTS} screenshot boxes`
+    ? tweet
+      ? "Disabled for X posts"
+      : presetTab === "multi" || presetTab === "triple"
+        ? `Disabled in ${presetTab === "triple" ? "Triple" : "Multi"} preset mode`
+        : `Maximum ${MAX_SCREENSHOT_SLOTS} screenshot boxes`
     : "Add a screenshot slot"
 
   const hasDeviceFrame = frame.id !== "none"

--- a/components/editor/frame-popover.tsx
+++ b/components/editor/frame-popover.tsx
@@ -33,6 +33,11 @@ import {
   SelectTrigger,
 } from "@/components/ui/select"
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import {
   DEVICE_MOCKUPS,
   getDeviceMockup,
   getDeviceMockupAsset,
@@ -236,12 +241,18 @@ export function FramePopover({
   previewImage,
   imageFit = "cover",
   align = "start",
+  disabled = false,
+  disabledLabel = "Unavailable",
+  disabledTooltip,
 }: {
   value: DeviceFrame
   onChange: (frame: DeviceFrame) => void
   previewImage?: string | null
   imageFit?: ImageFit
   align?: "start" | "end"
+  disabled?: boolean
+  disabledLabel?: string
+  disabledTooltip?: React.ReactNode
 }) {
   const [open, setOpen] = React.useState(false)
   const [query, setQuery] = React.useState("")
@@ -301,36 +312,59 @@ export function FramePopover({
     [onChange, value.color]
   )
 
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          className={cn(
-            "group flex h-11 w-full items-center gap-2.5 rounded-lg bg-secondary/40 px-3 text-left transition-colors hover:bg-secondary/70",
-            open && "bg-secondary/70"
-          )}
-        >
-          <span className="inline-flex size-5 items-center justify-center text-foreground/60">
-            <CurrentIcon className="size-4" />
+  const trigger = (
+    <PopoverTrigger asChild>
+      <button
+        type="button"
+        aria-disabled={disabled}
+        className={cn(
+          "group flex h-11 w-full items-center gap-2.5 rounded-lg bg-secondary/40 px-3 text-left transition-colors hover:bg-secondary/70",
+          open && "bg-secondary/70",
+          disabled && "cursor-not-allowed opacity-55 hover:bg-secondary/40"
+        )}
+      >
+        <span className="inline-flex size-5 items-center justify-center text-foreground/60">
+          <CurrentIcon className="size-4" />
+        </span>
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-[13px] font-medium text-foreground">
+            {current.name}
           </span>
-          <span className="flex min-w-0 flex-1 flex-col">
-            <span className="truncate text-[13px] font-medium text-foreground">
-              {current.name}
+          {disabled ? (
+            <span className="truncate text-[11px] text-muted-foreground">
+              {disabledLabel}
             </span>
-            {current.colors.length > 0 ? (
-              <span className="truncate text-[11px] text-muted-foreground">
-                {formatColor(currentColor)}
-              </span>
-            ) : null}
-          </span>
-          <RiArrowRightSLine
-            className={cn(
-              "size-4 text-muted-foreground/60 transition-transform duration-200",
-              open && "rotate-90"
-            )}
-          />
-        </button>
-      </PopoverTrigger>
+          ) : current.colors.length > 0 ? (
+            <span className="truncate text-[11px] text-muted-foreground">
+              {formatColor(currentColor)}
+            </span>
+          ) : null}
+        </span>
+        <RiArrowRightSLine
+          className={cn(
+            "size-4 text-muted-foreground/60 transition-transform duration-200",
+            open && "rotate-90"
+          )}
+        />
+      </button>
+    </PopoverTrigger>
+  )
+
+  return (
+    <Popover
+      open={open && !disabled}
+      onOpenChange={(next) => setOpen(disabled ? false : next)}
+    >
+      {disabled && disabledTooltip ? (
+        <Tooltip>
+          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={8}>
+            {disabledTooltip}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        trigger
+      )}
 
       <PopoverContent
         side="bottom"

--- a/components/editor/inspector.tsx
+++ b/components/editor/inspector.tsx
@@ -8,6 +8,7 @@ import {
   RiPaletteLine,
   RiRotateLockLine,
   RiSunLine,
+  RiTwitterXLine,
 } from "@remixicon/react"
 
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -21,14 +22,18 @@ import { PaddingSection } from "./inspector/padding-section"
 import { Section } from "./inspector/primitives"
 import { ShadowSection } from "./inspector/shadow-section"
 import { TiltSection } from "./inspector/tilt-section"
+import { TweetSection } from "./inspector/tweet-section"
 
 export function Inspector({ className }: { className?: string }) {
   const frameId = useActiveCanvasField((c) => c.frame.id)
+  const hasTweet = useActiveCanvasField((c) => c.tweet !== null)
   const screenshotBoxCount = useActiveCanvasField(
     (c) => (c.screenshot ? 1 : 0) + c.screenshotSlots.length
   )
   const hasDeviceFrame = frameId !== "none"
-  const showPadding = screenshotBoxCount <= 1
+  // A device frame and screenshot padding are screenshot-only concepts; the
+  // tweet card is styled through its own section instead.
+  const showPadding = !hasTweet && screenshotBoxCount <= 1
 
   return (
     <aside
@@ -43,6 +48,15 @@ export function Inspector({ className }: { className?: string }) {
 
       <ScrollArea className="min-h-0 flex-1">
         <div className="px-3 py-3 pb-24 xl:px-4">
+          {hasTweet ? (
+            <>
+              <Section icon={RiTwitterXLine} title="X Post" defaultOpen>
+                <TweetSection />
+              </Section>
+              <div className="my-3 h-px bg-border/50" />
+            </>
+          ) : null}
+
           <Section icon={RiPaletteLine} title="Background" defaultOpen>
             <BackgroundSection />
           </Section>
@@ -53,7 +67,7 @@ export function Inspector({ className }: { className?: string }) {
           </Section>
           <div className="my-3 h-px bg-border/50" />
 
-          {!hasDeviceFrame ? (
+          {!hasDeviceFrame && !hasTweet ? (
             <>
               <Section icon={RiBrushLine} title="Border" defaultOpen>
                 <BorderSection />

--- a/components/editor/inspector/tweet-section.tsx
+++ b/components/editor/inspector/tweet-section.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import * as React from "react"
+import { RiDeleteBinLine, RiRefreshLine } from "@remixicon/react"
+
+import { TweetUrlPopover } from "@/components/editor/canvas/tweet-url-popover"
+import { Switch } from "@/components/ui/switch"
+import { fetchTweetData } from "@/lib/editor/load-tweet"
+import type { TweetTheme } from "@/lib/editor/store"
+import { useActiveCanvasField, useEditorStore } from "@/lib/editor/store"
+import { cn } from "@/lib/utils"
+
+const THEME_OPTIONS: { id: TweetTheme; label: string; swatch: string }[] = [
+  { id: "light", label: "Light", swatch: "#ffffff" },
+  { id: "dim", label: "Dim", swatch: "#15202b" },
+  { id: "dark", label: "Dark", swatch: "#000000" },
+]
+
+function Row({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-[12px] text-muted-foreground">{label}</span>
+      {children}
+    </div>
+  )
+}
+
+export function TweetSection() {
+  const tweet = useActiveCanvasField((c) => c.tweet)
+  const setTweet = useEditorStore((s) => s.setTweet)
+  const updateTweet = useEditorStore((s) => s.updateTweet)
+  const clearTweet = useEditorStore((s) => s.clearTweet)
+
+  // "Replace post" keeps the current theme/toggles and swaps only the data.
+  const handleReplace = React.useCallback(
+    async (url: string) => {
+      const data = await fetchTweetData(url)
+      setTweet(
+        tweet
+          ? { ...tweet, data }
+          : { data, theme: "dark", showMetrics: true, showAvatar: true }
+      )
+    },
+    [setTweet, tweet]
+  )
+
+  if (!tweet) return null
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <span className="mb-2 block text-[11px] tracking-tight text-muted-foreground">
+          Theme
+        </span>
+        <div className="grid grid-cols-3 gap-2">
+          {THEME_OPTIONS.map((opt) => {
+            const active = tweet.theme === opt.id
+            return (
+              <button
+                key={opt.id}
+                type="button"
+                onClick={() => updateTweet({ theme: opt.id })}
+                className={cn(
+                  "flex items-center justify-center gap-1.5 rounded-md border py-1.5 text-[11px] font-medium transition-all",
+                  active
+                    ? "border-primary/40 bg-primary/5 text-primary ring-1 ring-primary/20"
+                    : "border-border/60 bg-secondary/20 text-muted-foreground hover:border-foreground/30"
+                )}
+              >
+                <span
+                  className="size-3 rounded-full border border-black/10 dark:border-white/15"
+                  style={{ background: opt.swatch }}
+                />
+                {opt.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <Row label="Show metrics">
+        <Switch
+          checked={tweet.showMetrics}
+          onCheckedChange={(v) => updateTweet({ showMetrics: v })}
+        />
+      </Row>
+      <Row label="Show avatar">
+        <Switch
+          checked={tweet.showAvatar}
+          onCheckedChange={(v) => updateTweet({ showAvatar: v })}
+        />
+      </Row>
+
+      <div className="grid grid-cols-2 gap-2 pt-1">
+        <TweetUrlPopover onLoad={handleReplace} side="top" align="start">
+          <button
+            type="button"
+            className="flex items-center justify-center gap-1.5 rounded-md border border-border/60 bg-secondary/20 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground"
+          >
+            <RiRefreshLine className="size-3.5" />
+            Replace
+          </button>
+        </TweetUrlPopover>
+        <button
+          type="button"
+          onClick={() => clearTweet()}
+          className="flex items-center justify-center gap-1.5 rounded-md border border-border/60 bg-secondary/20 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:border-destructive/40 hover:text-destructive"
+        >
+          <RiDeleteBinLine className="size-3.5" />
+          Remove
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/editor/inspector/tweet-section.tsx
+++ b/components/editor/inspector/tweet-section.tsx
@@ -1,20 +1,14 @@
 "use client"
 
 import * as React from "react"
-import { RiDeleteBinLine, RiRefreshLine } from "@remixicon/react"
 
-import { TweetUrlPopover } from "@/components/editor/canvas/tweet-url-popover"
 import { Switch } from "@/components/ui/switch"
-import { fetchTweetData } from "@/lib/editor/load-tweet"
-import type { TweetTheme } from "@/lib/editor/store"
+import {
+  TweetFontSelect,
+  TweetThemeSelect,
+} from "@/components/editor/tweet-font-select"
 import { useActiveCanvasField, useEditorStore } from "@/lib/editor/store"
-import { cn } from "@/lib/utils"
-
-const THEME_OPTIONS: { id: TweetTheme; label: string; swatch: string }[] = [
-  { id: "light", label: "Light", swatch: "#ffffff" },
-  { id: "dim", label: "Dim", swatch: "#15202b" },
-  { id: "dark", label: "Dark", swatch: "#000000" },
-]
+import { DEFAULT_TWEET_SETTINGS } from "@/lib/editor/tweet-settings"
 
 function Row({
   label,
@@ -33,89 +27,49 @@ function Row({
 
 export function TweetSection() {
   const tweet = useActiveCanvasField((c) => c.tweet)
-  const setTweet = useEditorStore((s) => s.setTweet)
   const updateTweet = useEditorStore((s) => s.updateTweet)
-  const clearTweet = useEditorStore((s) => s.clearTweet)
-
-  // "Replace post" keeps the current theme/toggles and swaps only the data.
-  const handleReplace = React.useCallback(
-    async (url: string) => {
-      const data = await fetchTweetData(url)
-      setTweet(
-        tweet
-          ? { ...tweet, data }
-          : { data, theme: "dark", showMetrics: true, showAvatar: true }
-      )
-    },
-    [setTweet, tweet]
-  )
 
   if (!tweet) return null
 
   return (
     <div className="space-y-3">
-      <div>
-        <span className="mb-2 block text-[11px] tracking-tight text-muted-foreground">
-          Theme
-        </span>
-        <div className="grid grid-cols-3 gap-2">
-          {THEME_OPTIONS.map((opt) => {
-            const active = tweet.theme === opt.id
-            return (
-              <button
-                key={opt.id}
-                type="button"
-                onClick={() => updateTweet({ theme: opt.id })}
-                className={cn(
-                  "flex items-center justify-center gap-1.5 rounded-md border py-1.5 text-[11px] font-medium transition-all",
-                  active
-                    ? "border-primary/40 bg-primary/5 text-primary ring-1 ring-primary/20"
-                    : "border-border/60 bg-secondary/20 text-muted-foreground hover:border-foreground/30"
-                )}
-              >
-                <span
-                  className="size-3 rounded-full border border-black/10 dark:border-white/15"
-                  style={{ background: opt.swatch }}
-                />
-                {opt.label}
-              </button>
-            )
-          })}
-        </div>
-      </div>
-
-      <Row label="Show metrics">
-        <Switch
-          checked={tweet.showMetrics}
-          onCheckedChange={(v) => updateTweet({ showMetrics: v })}
+      <Row label="Theme">
+        <TweetThemeSelect
+          value={tweet.theme}
+          onValueChange={(theme) => updateTweet({ theme })}
         />
       </Row>
+
       <Row label="Show avatar">
         <Switch
           checked={tweet.showAvatar}
           onCheckedChange={(v) => updateTweet({ showAvatar: v })}
         />
       </Row>
-
-      <div className="grid grid-cols-2 gap-2 pt-1">
-        <TweetUrlPopover onLoad={handleReplace} side="top" align="start">
-          <button
-            type="button"
-            className="flex items-center justify-center gap-1.5 rounded-md border border-border/60 bg-secondary/20 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground"
-          >
-            <RiRefreshLine className="size-3.5" />
-            Replace
-          </button>
-        </TweetUrlPopover>
-        <button
-          type="button"
-          onClick={() => clearTweet()}
-          className="flex items-center justify-center gap-1.5 rounded-md border border-border/60 bg-secondary/20 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:border-destructive/40 hover:text-destructive"
-        >
-          <RiDeleteBinLine className="size-3.5" />
-          Remove
-        </button>
-      </div>
+      <Row label="Images">
+        <Switch
+          checked={tweet.showImages ?? true}
+          onCheckedChange={(v) => updateTweet({ showImages: v })}
+        />
+      </Row>
+      <Row label="Stats">
+        <Switch
+          checked={tweet.showMetrics}
+          onCheckedChange={(v) => updateTweet({ showMetrics: v })}
+        />
+      </Row>
+      <Row label="Date & time">
+        <Switch
+          checked={tweet.showTimestamp ?? true}
+          onCheckedChange={(v) => updateTweet({ showTimestamp: v })}
+        />
+      </Row>
+      <Row label="Font">
+        <TweetFontSelect
+          value={tweet.fontFamily ?? DEFAULT_TWEET_SETTINGS.fontFamily}
+          onValueChange={(fontFamily) => updateTweet({ fontFamily })}
+        />
+      </Row>
     </div>
   )
 }

--- a/components/editor/layers-popover.tsx
+++ b/components/editor/layers-popover.tsx
@@ -36,6 +36,7 @@ import {
   RiPencilRulerLine,
   RiSmartphoneLine,
   RiText,
+  RiTwitterXLine,
 } from "@remixicon/react"
 
 import {
@@ -56,7 +57,13 @@ import { getDeviceMockup } from "@/lib/mockups"
 import { BROWSER_FRAMES } from "@/lib/browser-frame"
 import { cn } from "@/lib/utils"
 
-type EditableLayerType = "screenshot" | "slot" | "asset" | "text" | "annotation"
+type EditableLayerType =
+  | "screenshot"
+  | "tweet"
+  | "slot"
+  | "asset"
+  | "text"
+  | "annotation"
 
 type EditorLayer = {
   key: string
@@ -143,6 +150,7 @@ export function LayersPanelContent({ flat }: { flat?: boolean }) {
     setActiveCanvasId,
     frame,
     setFrame,
+    tweet,
   } = useEditor()
   const canvasIds = useEditorStore(
     useShallow((s) => s.present.canvases.map((canvas) => canvas.id))
@@ -166,6 +174,22 @@ export function LayersPanelContent({ flat }: { flat?: boolean }) {
         opacity: screenshotLayer.opacity,
         blendMode: screenshotLayer.blendMode,
         thumbnail: screenshot,
+      })
+    }
+
+    if (tweet) {
+      next.push({
+        key: "tweet:main",
+        id: "main",
+        type: "tweet",
+        name: "X Post",
+        meta: tweet.data.author.handle
+          ? `@${tweet.data.author.handle}`
+          : "Tweet card",
+        zIndex: screenshotLayer.zIndex,
+        hidden: screenshotLayer.hidden,
+        opacity: screenshotLayer.opacity,
+        blendMode: screenshotLayer.blendMode,
       })
     }
 
@@ -260,8 +284,10 @@ export function LayersPanelContent({ flat }: { flat?: boolean }) {
     screenshotLayer,
     screenshotSlots,
     texts,
+    tweet,
   ])
 
+  const mainContentLayerKey = tweet ? "tweet:main" : "screenshot:main"
   const activeKey =
     selectedLayerKey ??
     (selectedAssetId
@@ -273,7 +299,7 @@ export function LayersPanelContent({ flat }: { flat?: boolean }) {
           : selectedScreenshotSlotId
             ? `slot:${selectedScreenshotSlotId}`
             : isScreenshotSelected
-              ? "screenshot:main"
+              ? mainContentLayerKey
               : (layers[0]?.key ?? null))
 
   const sensors = useSensors(
@@ -294,7 +320,8 @@ export function LayersPanelContent({ flat }: { flat?: boolean }) {
       ...(patch.blendMode !== undefined ? { blendMode: patch.blendMode } : {}),
     }
 
-    if (layer.type === "screenshot") updateScreenshotLayer(layerPatch)
+    if (layer.type === "screenshot" || layer.type === "tweet")
+      updateScreenshotLayer(layerPatch)
     if (layer.type === "slot") {
       // Slot rows show the canvas-shared opacity/blendMode; edits to those
       // route to the canvas layer. zIndex/hidden remain per-slot.
@@ -364,7 +391,9 @@ export function LayersPanelContent({ flat }: { flat?: boolean }) {
   function selectLayer(layer: EditorLayer) {
     setSelectedLayerKey(layer.key)
     setActiveTool("pointer")
-    setIsScreenshotSelected(layer.type === "screenshot")
+    setIsScreenshotSelected(
+      layer.type === "screenshot" || layer.type === "tweet"
+    )
     setSelectedScreenshotSlotId(layer.type === "slot" ? layer.id : null)
     setSelectedAssetId(layer.type === "asset" ? layer.id : null)
     setSelectedTextId(layer.type === "text" ? layer.id : null)
@@ -453,7 +482,7 @@ export function LayersPanelContent({ flat }: { flat?: boolean }) {
                 onOpacityChange={(opacity) => updateLayer(layer, { opacity })}
                 onBlendChange={(blendMode) => updateLayer(layer, { blendMode })}
                 onDelete={
-                  layer.type !== "screenshot"
+                  layer.type !== "screenshot" && layer.type !== "tweet"
                     ? () => deleteLayer(layer)
                     : undefined
                 }
@@ -786,6 +815,7 @@ function LayerIcon({ type }: { type: EditableLayerType }) {
   if (type === "text") return <RiText className="size-3.5" />
   if (type === "annotation") return <RiPencilRulerLine className="size-3.5" />
   if (type === "slot") return <RiGalleryLine className="size-3.5" />
+  if (type === "tweet") return <RiTwitterXLine className="size-3.5" />
   return <RiImage2Line className="size-3.5" />
 }
 

--- a/components/editor/mobile-controls/categories.ts
+++ b/components/editor/mobile-controls/categories.ts
@@ -16,6 +16,7 @@ import {
   RiStackLine,
   RiSunLine,
   RiText,
+  RiTwitterXLine,
 } from "@remixicon/react"
 
 import type { EnhancePreset } from "@/lib/editor/store"
@@ -37,6 +38,7 @@ export type CategoryId =
   | "border"
   | "padding"
   | "shadow"
+  | "tweet"
   | "transform"
 
 export type Category = {
@@ -67,6 +69,7 @@ export const DESIGN_CATEGORIES: Category[] = [
 ]
 
 export const TOOLS_CATEGORIES: Category[] = [
+  { id: "tweet", label: "X Post", icon: RiTwitterXLine },
   { id: "background", label: "Background", icon: RiPaletteLine },
   { id: "backdrop", label: "Backdrop", icon: RiSunLine },
   { id: "border", label: "Border", icon: RiBrushLine },

--- a/components/editor/mobile-controls/index.tsx
+++ b/components/editor/mobile-controls/index.tsx
@@ -85,6 +85,7 @@ export function MobileControls({
   const frame = useActiveCanvasField((c) => c.frame)
   const objectFit = useActiveCanvasField((c) => c.objectFit)
   const screenshot = useActiveCanvasField((c) => c.screenshot)
+  const tweet = useActiveCanvasField((c) => c.tweet)
   const screenshotSlots = useActiveCanvasField((c) => c.screenshotSlots)
   const scale = useActiveCanvasField((c) => c.scale)
   const texts = useActiveCanvasField((c) => c.texts)
@@ -190,6 +191,9 @@ export function MobileControls({
   const categories = (
     tab === "design" ? DESIGN_CATEGORIES : TOOLS_CATEGORIES
   ).filter((c) => {
+    if (c.id === "tweet") return Boolean(tweet)
+    if (tweet && (c.id === "frame" || c.id === "fit" || c.id === "layout"))
+      return false
     if (c.id === "border") return showBorder
     if (c.id === "padding") return showPadding
     return true
@@ -308,6 +312,10 @@ export function MobileControls({
   )
 
   const addSlot = React.useCallback(() => {
+    if (tweet) {
+      toast.error("X posts use one content slot")
+      return
+    }
     const id = addScreenshotSlot()
     if (!id) {
       toast.error(`Screenshot box limit reached (${MAX_SCREENSHOT_SLOTS})`)
@@ -322,6 +330,7 @@ export function MobileControls({
     setToolsOpen(false)
   }, [
     addScreenshotSlot,
+    tweet,
     setActiveTool,
     setIsScreenshotSelected,
     setSelectedAnnotationShapeId,
@@ -598,6 +607,7 @@ export function MobileControls({
                         label="Extra Shot"
                         icon={RiGalleryLine}
                         disabled={
+                          Boolean(tweet) ||
                           screenshotSlots.length >= MAX_SCREENSHOT_SLOTS
                         }
                         onClick={addSlot}

--- a/components/editor/mobile-controls/inline-options.tsx
+++ b/components/editor/mobile-controls/inline-options.tsx
@@ -9,6 +9,7 @@ import { BorderSection } from "@/components/editor/inspector/border-section"
 import { PaddingSection } from "@/components/editor/inspector/padding-section"
 import { ShadowSection } from "@/components/editor/inspector/shadow-section"
 import { TiltSection } from "@/components/editor/inspector/tilt-section"
+import { TweetSection } from "@/components/editor/inspector/tweet-section"
 import type { AspectState } from "@/lib/editor/store"
 import { cn } from "@/lib/utils"
 
@@ -71,6 +72,7 @@ export function InlineOptions({
         {id === "border" ? <BorderSection /> : null}
         {id === "padding" ? <PaddingSection /> : null}
         {id === "shadow" ? <ShadowSection /> : null}
+        {id === "tweet" ? <TweetSection /> : null}
         {id === "transform" ? <TiltSection /> : null}
       </div>
     </div>

--- a/components/editor/mobile-controls/move-panel.tsx
+++ b/components/editor/mobile-controls/move-panel.tsx
@@ -53,12 +53,16 @@ export function MobileMovePanel() {
       )
     : null
   const hasDeviceFrame = editor.frame.id !== "none"
-  const hasMainTarget = Boolean(editor.screenshot) || hasDeviceFrame
+  const hasTweet = Boolean(editor.tweet)
+  const hasMainTarget = Boolean(editor.screenshot) || hasTweet || hasDeviceFrame
   const hasSlotGroup = editor.screenshotSlots.length > 0
   // The frame-less main screenshot is positioned in real stage pixels (not the
   // base-canvas space), so it needs the DOM-measured placement math below.
   const isBareMainTarget =
-    hasMainTarget && !hasDeviceFrame && editor.screenshotSlots.length === 0
+    !hasTweet &&
+    hasMainTarget &&
+    !hasDeviceFrame &&
+    editor.screenshotSlots.length === 0
   const targetLabel = selectedText
     ? "text"
     : selectedAsset
@@ -67,13 +71,15 @@ export function MobileMovePanel() {
         ? "annotation"
         : selectedSlot
           ? "screenshot box"
-          : hasMainTarget
-            ? hasDeviceFrame
-              ? "device frame"
-              : "screenshot"
-            : hasSlotGroup
-              ? "screenshot boxes"
-              : "nothing"
+          : hasTweet
+            ? "tweet"
+            : hasMainTarget
+              ? hasDeviceFrame
+                ? "device frame"
+                : "screenshot"
+              : hasSlotGroup
+                ? "screenshot boxes"
+                : "nothing"
 
   const getActiveCanvasElement = React.useCallback(() => {
     if (typeof document === "undefined" || !activeCanvasId) return null

--- a/components/editor/present-presets-section.tsx
+++ b/components/editor/present-presets-section.tsx
@@ -138,13 +138,18 @@ export function PresentPresetsSection({
   const displayActiveCustomPresetId = bulkEditMode
     ? (bulkPresetUi?.activeCustomPresetId ?? null)
     : activeCustomPresetId
+  const hasTweet = Boolean(canvas.tweet)
 
   const handleTabChange = React.useCallback(
     (nextTab: PresetTab) => {
+      if (hasTweet && (nextTab === "multi" || nextTab === "triple")) {
+        toast("X posts use one content slot")
+        return
+      }
       setTab(nextTab)
       rememberBulkPresetUi(emptyCanvasPresetUi(nextTab))
     },
-    [rememberBulkPresetUi, setTab]
+    [hasTweet, rememberBulkPresetUi, setTab]
   )
 
   React.useEffect(() => {
@@ -276,6 +281,10 @@ export function PresentPresetsSection({
   const applyLayoutPreset = React.useCallback(
     (preset: LayoutPreset) => {
       const canvas = canvasRef.current
+      if (canvas.tweet) {
+        toast("X posts use one content slot")
+        return
+      }
       const aspect = aspectRef.current
       if (canvas.screenshotSlots.length > preset.slots.length) {
         setPendingLayoutPreset(preset)
@@ -333,6 +342,10 @@ export function PresentPresetsSection({
   const applyCustomPreset = React.useCallback(
     (preset: CustomPresetSummary) => {
       const geometry = preset.geometry
+      if (canvasRef.current.tweet && geometry.slots.length > 0) {
+        toast("X posts use one content slot")
+        return
+      }
       // Geometry includes a snapshot of every styling field on the canvas
       // (background, backdrop, border, shadow, overlay, portrait, padding,
       // radius, frame, text/asset/annotation layers, etc.) — not just the
@@ -481,6 +494,7 @@ export function PresentPresetsSection({
         <TabTriggerRow
           tab={displayTab}
           slotCount={canvas.screenshotSlots.length}
+          hasTweet={hasTweet}
           onTabChange={handleTabChange}
         />
       </div>

--- a/components/editor/present-presets-section/cards.tsx
+++ b/components/editor/present-presets-section/cards.tsx
@@ -15,6 +15,12 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { Skeleton } from "@/components/ui/skeleton"
 import { remoteImagePreviewUrl } from "@/lib/editor/image-resize"
 import {
@@ -387,6 +393,10 @@ const CustomPresetCard = React.memo(function CustomPresetCard({
   }, [canvas, preset])
 
   const [deleteOpen, setDeleteOpen] = React.useState(false)
+  const disabledReason =
+    canvas.tweet && preset.geometry.slots.length > 0
+      ? "X posts use one content slot."
+      : undefined
 
   return (
     <div className="group/preset relative">
@@ -398,6 +408,7 @@ const CustomPresetCard = React.memo(function CustomPresetCard({
         intrinsicSize="auto 220px"
         eager={horizontal}
         name={preset.name}
+        disabledReason={disabledReason}
       >
         <CanvasPresetPreview
           aspect={aspect}
@@ -479,6 +490,7 @@ const PresetCardShell = React.memo(function PresetCardShell({
   intrinsicSize,
   name,
   eager = false,
+  disabledReason,
   children,
 }: {
   active: boolean
@@ -488,21 +500,25 @@ const PresetCardShell = React.memo(function PresetCardShell({
   intrinsicSize: string
   name: string
   eager?: boolean
+  disabledReason?: string
   children: React.ReactNode
 }) {
   const shellRef = React.useRef<HTMLDivElement>(null)
   const deferredVisible = useDeferredVisibility(shellRef)
   const visible = eager || deferredVisible
+  const disabled = Boolean(disabledReason)
 
-  return (
+  const shell = (
     <div
       ref={shellRef}
       role="button"
-      tabIndex={0}
+      tabIndex={disabled ? -1 : 0}
       aria-label={ariaLabel}
       aria-pressed={active}
-      onClick={onApply}
+      aria-disabled={disabled || undefined}
+      onClick={disabled ? undefined : onApply}
       onKeyDown={(e) => {
+        if (disabled) return
         if (e.key !== "Enter" && e.key !== " ") return
         e.preventDefault()
         onApply()
@@ -516,10 +532,13 @@ const PresetCardShell = React.memo(function PresetCardShell({
             }
       }
       className={cn(
-        "group w-full cursor-pointer overflow-hidden rounded-[8px] border bg-white/[0.045] p-1.5 text-left transition-colors",
-        active
+        "group w-full overflow-hidden rounded-[8px] border bg-white/[0.045] p-1.5 text-left transition-colors",
+        disabled
+          ? "cursor-not-allowed border-white/10 opacity-45"
+          : "cursor-pointer",
+        active && !disabled
           ? "border-primary ring-1 ring-primary/40"
-          : "border-white/12 hover:border-primary/55"
+          : !disabled && "border-white/12 hover:border-primary/55"
       )}
     >
       <div
@@ -545,6 +564,19 @@ const PresetCardShell = React.memo(function PresetCardShell({
         </span>
       </div>
     </div>
+  )
+
+  if (!disabledReason) return shell
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{shell}</TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6}>
+          {disabledReason}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 })
 
@@ -665,6 +697,9 @@ const LayoutPresetCard = React.memo(function LayoutPresetCard({
     () => onApply(preset),
     [onApply, preset]
   )
+  const disabledReason = canvas.tweet
+    ? "X posts use one content slot."
+    : undefined
 
   return (
     <PresetCardShell
@@ -675,6 +710,7 @@ const LayoutPresetCard = React.memo(function LayoutPresetCard({
       intrinsicSize="auto 220px"
       eager={horizontal}
       name={preset.name}
+      disabledReason={disabledReason}
     >
       <CanvasPresetPreview
         aspect={aspect}

--- a/components/editor/present-presets-section/tabs.tsx
+++ b/components/editor/present-presets-section/tabs.tsx
@@ -223,7 +223,12 @@ function TabIcon({ t, active }: { t: PresetTab; active: boolean }) {
   )
 }
 
-function isTabDisabled(t: PresetTab, slotCount: number): boolean {
+function isTabDisabled(
+  t: PresetTab,
+  slotCount: number,
+  hasTweet: boolean
+): boolean {
+  if (hasTweet && (t === "multi" || t === "triple")) return true
   if (t === "multi") return slotCount > 2
   if (t === "triple") return slotCount > 2
   return false
@@ -234,10 +239,12 @@ const PRESET_TABS: PresetTab[] = ["single", "multi", "triple", "custom"]
 export function TabTriggerRow({
   tab,
   slotCount,
+  hasTweet = false,
   onTabChange,
 }: {
   tab: PresetTab
   slotCount: number
+  hasTweet?: boolean
   onTabChange: (t: PresetTab) => void
 }) {
   const [open, setOpen] = React.useState(false)
@@ -283,11 +290,13 @@ export function TabTriggerRow({
               <TooltipProvider>
                 <div className="grid grid-cols-2 gap-1.5">
                   {PRESET_TABS.map((t) => {
-                    const disabled = isTabDisabled(t, slotCount)
+                    const disabled = isTabDisabled(t, slotCount, hasTweet)
                     const disabledReason =
-                      t === "multi"
-                        ? "Multi supports up to 2 screenshot boxes. Delete slots to switch."
-                        : "Triple supports up to 3 screenshot boxes. Delete a slot to switch."
+                      hasTweet && (t === "multi" || t === "triple")
+                        ? "X posts use one content slot."
+                        : t === "multi"
+                          ? "Multi supports up to 2 screenshot boxes. Delete slots to switch."
+                          : "Triple supports up to 3 screenshot boxes. Delete a slot to switch."
                     return (
                       <Tooltip key={t} open={disabled ? undefined : false}>
                         <TooltipTrigger asChild>

--- a/components/editor/top-bar/index.tsx
+++ b/components/editor/top-bar/index.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/lib/editor/export"
 import { readImageFileAsDataUrl } from "@/lib/editor/image-resize"
 import { saveCurrentEditorDraft, useEditorStore } from "@/lib/editor/store"
+import { tweetSettingsFromCard } from "@/lib/editor/tweet-settings"
 import type {
   CurrentDraftInfo,
   CustomPresetGeometry,
@@ -436,6 +437,9 @@ export function TopBar() {
           annotations: activeCanvas.annotations,
           annotationShapes: activeCanvas.annotationShapes,
           aspect: activeCanvas.aspect,
+          tweetSettings: activeCanvas.tweet
+            ? tweetSettingsFromCard(activeCanvas.tweet)
+            : undefined,
         },
       }
 
@@ -546,6 +550,9 @@ export function TopBar() {
           annotations: activeCanvas.annotations,
           annotationShapes: activeCanvas.annotationShapes,
           aspect: activeCanvas.aspect,
+          tweetSettings: activeCanvas.tweet
+            ? tweetSettingsFromCard(activeCanvas.tweet)
+            : undefined,
         },
       }
       setIsPresetSaving(true)

--- a/components/editor/tweet-font-select.tsx
+++ b/components/editor/tweet-font-select.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import * as React from "react"
+import { RiArrowDownSLine, RiCheckLine } from "@remixicon/react"
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  TWEET_FONT_OPTIONS,
+  TWEET_THEME_OPTIONS,
+  type TweetCardSettings,
+} from "@/lib/editor/tweet-settings"
+import { cn } from "@/lib/utils"
+
+type TweetFontSelectProps = {
+  value: TweetCardSettings["fontFamily"]
+  onValueChange: (value: TweetCardSettings["fontFamily"]) => void
+  triggerClassName?: string
+  contentClassName?: string
+}
+
+export function TweetFontSelect({
+  value,
+  onValueChange,
+  triggerClassName,
+  contentClassName,
+}: TweetFontSelectProps) {
+  const [open, setOpen] = React.useState(false)
+  const activeFont =
+    TWEET_FONT_OPTIONS.find((font) => font.css === value) ??
+    TWEET_FONT_OPTIONS[0]
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          onPointerDown={(e) => e.stopPropagation()}
+          className={cn(
+            "flex h-8 w-[156px] items-center justify-between gap-2 rounded-md border border-border/70 bg-secondary/20 px-2 text-left text-[12px] text-foreground transition-colors outline-none hover:bg-secondary/40",
+            triggerClassName
+          )}
+        >
+          <span
+            className="min-w-0 truncate"
+            style={{ fontFamily: activeFont?.css }}
+          >
+            {activeFont?.label ?? "Choose font"}
+          </span>
+          <RiArrowDownSLine
+            className={cn(
+              "size-3.5 shrink-0 text-muted-foreground transition-transform",
+              open && "rotate-180"
+            )}
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        side="bottom"
+        sideOffset={6}
+        onPointerDown={(e) => e.stopPropagation()}
+        className={cn(
+          "z-1200 w-[216px] overflow-hidden rounded-lg border-border/70 bg-popover p-1 shadow-xl",
+          contentClassName
+        )}
+      >
+        <div className="h-48 touch-pan-y overflow-y-auto overscroll-contain pr-1">
+          {TWEET_FONT_OPTIONS.map((font) => {
+            const active = font.css === value
+            return (
+              <button
+                key={font.id}
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onValueChange(font.css)
+                  setOpen(false)
+                }}
+                className={cn(
+                  "flex min-h-8 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors",
+                  active
+                    ? "bg-primary/10 text-primary"
+                    : "text-foreground hover:bg-accent"
+                )}
+              >
+                <span className="grid size-4 shrink-0 place-items-center">
+                  {active ? <RiCheckLine className="size-4" /> : null}
+                </span>
+                <span className="truncate" style={{ fontFamily: font.css }}>
+                  {font.label}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+type TweetThemeSelectProps = {
+  value: TweetCardSettings["theme"]
+  onValueChange: (value: TweetCardSettings["theme"]) => void
+  triggerClassName?: string
+  contentClassName?: string
+}
+
+export function TweetThemeSelect({
+  value,
+  onValueChange,
+  triggerClassName,
+  contentClassName,
+}: TweetThemeSelectProps) {
+  const [open, setOpen] = React.useState(false)
+  const activeTheme =
+    TWEET_THEME_OPTIONS.find((theme) => theme.id === value) ??
+    TWEET_THEME_OPTIONS[0]
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          onPointerDown={(e) => e.stopPropagation()}
+          className={cn(
+            "flex h-8 w-[156px] items-center justify-between gap-2 rounded-md border border-border/70 bg-secondary/20 px-2 text-left text-[12px] text-foreground transition-colors outline-none hover:bg-secondary/40",
+            triggerClassName
+          )}
+        >
+          <span className="flex min-w-0 items-center gap-2 truncate">
+            <span
+              className="size-3 shrink-0 rounded-full border border-black/10 dark:border-white/15"
+              style={{ background: activeTheme?.swatch }}
+            />
+            <span className="truncate">{activeTheme?.label ?? "Theme"}</span>
+          </span>
+          <RiArrowDownSLine
+            className={cn(
+              "size-3.5 shrink-0 text-muted-foreground transition-transform",
+              open && "rotate-180"
+            )}
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        side="bottom"
+        sideOffset={6}
+        onPointerDown={(e) => e.stopPropagation()}
+        className={cn(
+          "z-1200 w-[180px] overflow-hidden rounded-lg border-border/70 bg-popover p-1 shadow-xl",
+          contentClassName
+        )}
+      >
+        <div className="max-h-48 touch-pan-y overflow-y-auto overscroll-contain pr-1">
+          {TWEET_THEME_OPTIONS.map((theme) => {
+            const active = theme.id === value
+            return (
+              <button
+                key={theme.id}
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onValueChange(theme.id)
+                  setOpen(false)
+                }}
+                className={cn(
+                  "flex min-h-8 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors",
+                  active
+                    ? "bg-primary/10 text-primary"
+                    : "text-foreground hover:bg-accent"
+                )}
+              >
+                <span
+                  className="size-3 shrink-0 rounded-full border border-black/10 dark:border-white/15"
+                  style={{ background: theme.swatch }}
+                />
+                <span className="min-w-0 flex-1 truncate">{theme.label}</span>
+                <span className="grid size-4 shrink-0 place-items-center">
+                  {active ? <RiCheckLine className="size-4" /> : null}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/lib/editor/load-tweet.ts
+++ b/lib/editor/load-tweet.ts
@@ -1,0 +1,17 @@
+import type { TweetData } from "./state-types"
+
+/**
+ * Fetches and normalizes an X post via our `/api/tweet` proxy. Throws an
+ * `Error` with a user-facing message on failure so callers can surface it.
+ */
+export async function fetchTweetData(url: string): Promise<TweetData> {
+  const res = await fetch(`/api/tweet?url=${encodeURIComponent(url)}`)
+  const data = (await res.json().catch(() => null)) as {
+    tweet?: TweetData
+    error?: string
+  } | null
+  if (!res.ok || !data?.tweet) {
+    throw new Error(data?.error ?? "Could not load that post")
+  }
+  return data.tweet
+}

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -377,6 +377,33 @@ export type ScreenshotSlot = {
 
 export type CanvasPosition = { x: number; y: number }
 
+export type TweetAuthor = {
+  name: string
+  handle: string
+  avatarUrl: string
+  verified: boolean
+}
+
+export type TweetData = {
+  id: string
+  url: string
+  text: string
+  author: TweetAuthor
+  createdAt: string
+  // The free syndication endpoint only exposes likes + replies reliably;
+  // reposts/views require the paid X API and are intentionally omitted.
+  metrics: { likes: number; replies: number }
+}
+
+export type TweetTheme = "light" | "dim" | "dark"
+
+export type TweetCard = {
+  data: TweetData
+  theme: TweetTheme
+  showMetrics: boolean
+  showAvatar: boolean
+}
+
 export type CanvasState = {
   id: string
   position: CanvasPosition
@@ -405,6 +432,9 @@ export type CanvasState = {
   annotationShapes: AnnotationShape[]
   screenshotSlots: ScreenshotSlot[]
   frameAddress: string
+  // An X/Twitter post rendered as the canvas's main content. Mutually
+  // exclusive with `screenshot`: setting one clears the other.
+  tweet: TweetCard | null
   objectFit?: "contain" | "cover" | "fill"
   aspect?: AspectState
 }

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -384,12 +384,21 @@ export type TweetAuthor = {
   verified: boolean
 }
 
+export type TweetMedia = {
+  type: "photo"
+  url: string
+  width?: number
+  height?: number
+  alt?: string
+}
+
 export type TweetData = {
   id: string
   url: string
   text: string
   author: TweetAuthor
   createdAt: string
+  media?: TweetMedia[]
   // The free syndication endpoint only exposes likes + replies reliably;
   // reposts/views require the paid X API and are intentionally omitted.
   metrics: { likes: number; replies: number }
@@ -402,6 +411,9 @@ export type TweetCard = {
   theme: TweetTheme
   showMetrics: boolean
   showAvatar: boolean
+  showImages?: boolean
+  showTimestamp?: boolean
+  fontFamily?: string
 }
 
 export type CanvasState = {

--- a/lib/editor/store.tsx
+++ b/lib/editor/store.tsx
@@ -78,6 +78,7 @@ import type {
   Shadow,
   TextElement,
   Tilt,
+  TweetCard,
 } from "./state-types"
 
 export * from "./state-types"
@@ -286,6 +287,9 @@ export type EditorActions = {
   setFrame: (f: DeviceFrame, canvasId?: string) => void
   setFrameForMatchingScreenshots: (f: DeviceFrame, canvasId?: string) => void
   setFrameAddress: (address: string, canvasId?: string) => void
+  setTweet: (card: TweetCard, canvasId?: string) => void
+  updateTweet: (patch: Partial<TweetCard>, canvasId?: string) => void
+  clearTweet: (canvasId?: string) => void
   setObjectFit: (fit: "contain" | "cover" | "fill", canvasId?: string) => void
   bringScreenshotToFront: (canvasId?: string) => void
   sendScreenshotToBack: (canvasId?: string) => void
@@ -664,6 +668,8 @@ export const useEditorStore = create<EditorStore>((set, get) => {
           screenshot,
           originalScreenshot: screenshot,
           lastCropRegion: null,
+          // A screenshot replaces any tweet as the canvas's main content.
+          tweet: screenshot ? null : canvas.tweet,
           objectFit: canvas.objectFit ?? "contain",
           screenshotLayer: {
             ...canvas.screenshotLayer,
@@ -1062,6 +1068,27 @@ export const useEditorStore = create<EditorStore>((set, get) => {
       ),
     setFrameAddress: (address, canvasId) =>
       commitCanvas(canvasId, { frameAddress: address }, "frame-address"),
+    setTweet: (card, canvasId) =>
+      commitCanvas(
+        canvasId,
+        {
+          // A tweet replaces the screenshot as the canvas's main content.
+          tweet: card,
+          screenshot: null,
+          originalScreenshot: null,
+          lastCropRegion: null,
+          screenshotSlots: [],
+        },
+        null
+      ),
+    updateTweet: (patch, canvasId) =>
+      commitCanvas(
+        canvasId,
+        (canvas) =>
+          canvas.tweet ? { tweet: { ...canvas.tweet, ...patch } } : {},
+        "tweet"
+      ),
+    clearTweet: (canvasId) => commitCanvas(canvasId, { tweet: null }, null),
     setObjectFit: (fit, canvasId) =>
       commitCanvas(canvasId, { objectFit: fit }, "objectFit"),
     bringScreenshotToFront: (canvasId) =>

--- a/lib/editor/store.tsx
+++ b/lib/editor/store.tsx
@@ -7,6 +7,7 @@ import {
   PRESENT_PRESETS,
   resolvePresentPresetScale,
 } from "./present-presets"
+import type { TweetCardSettings } from "./tweet-settings"
 import {
   resolveActivePresetGeometry,
   resolveMainOffsetPx,
@@ -80,6 +81,8 @@ import type {
   Tilt,
   TweetCard,
 } from "./state-types"
+
+const TWEET_POST_ASPECT: AspectState = { id: "x-post", w: 1080, h: 1080 }
 
 export * from "./state-types"
 export {
@@ -188,6 +191,7 @@ export type CustomPresetCanvasStyle = {
   annotations: AnnotationStroke[]
   annotationShapes: AnnotationShape[]
   aspect?: AspectState
+  tweetSettings?: TweetCardSettings
 }
 
 export type CustomPresetGeometry = {
@@ -581,30 +585,30 @@ export const useEditorStore = create<EditorStore>((set, get) => {
           if (canvas.id !== targetId) return canvas
 
           const existingSlots = canvas.screenshotSlots
-          const slots: ScreenshotSlot[] = snapshot.slots.map(
-            (config, index) => {
-              const previous = existingSlots[index]
-              return {
-                id: previous?.id ?? makeId(),
-                src: previous?.src ?? null,
-                xPct: config.xPct,
-                yPct: config.yPct,
-                widthPct: config.widthPct ?? previous?.widthPct ?? 60,
-                heightPct: config.heightPct ?? previous?.heightPct ?? 28,
-                rotation: config.rotation,
-                tilt: config.tilt,
-                scale: config.scale,
-                zIndex:
-                  config.zIndex ??
-                  previous?.zIndex ??
-                  computeNextLayerZ(canvas) + index,
-                filter: config.filter ?? previous?.filter ?? "none",
-                hidden: config.hidden ?? previous?.hidden,
-                objectFit: config.objectFit ?? previous?.objectFit,
-                shadow: config.shadow ?? previous?.shadow,
-              }
-            }
-          )
+          const slots: ScreenshotSlot[] = canvas.tweet
+            ? []
+            : snapshot.slots.map((config, index) => {
+                const previous = existingSlots[index]
+                return {
+                  id: previous?.id ?? makeId(),
+                  src: previous?.src ?? null,
+                  xPct: config.xPct,
+                  yPct: config.yPct,
+                  widthPct: config.widthPct ?? previous?.widthPct ?? 60,
+                  heightPct: config.heightPct ?? previous?.heightPct ?? 28,
+                  rotation: config.rotation,
+                  tilt: config.tilt,
+                  scale: config.scale,
+                  zIndex:
+                    config.zIndex ??
+                    previous?.zIndex ??
+                    computeNextLayerZ(canvas) + index,
+                  filter: config.filter ?? previous?.filter ?? "none",
+                  hidden: config.hidden ?? previous?.hidden,
+                  objectFit: config.objectFit ?? previous?.objectFit,
+                  shadow: config.shadow ?? previous?.shadow,
+                }
+              })
 
           const offset = resolveMainOffsetPx(snapshot.mainOffset)
 
@@ -629,7 +633,7 @@ export const useEditorStore = create<EditorStore>((set, get) => {
               : {}),
             ...(style?.shadow ? { shadow: style.shadow } : {}),
             ...(style?.overlay ? { overlay: style.overlay } : {}),
-            ...(style?.frame ? { frame: style.frame } : {}),
+            ...(style?.frame && !canvas.tweet ? { frame: style.frame } : {}),
             ...(style?.portrait ? { portrait: style.portrait } : {}),
             ...(style?.enhance ? { enhance: style.enhance } : {}),
             ...(style?.objectFit ? { objectFit: style.objectFit } : {}),
@@ -645,12 +649,15 @@ export const useEditorStore = create<EditorStore>((set, get) => {
               ? { annotationShapes: style.annotationShapes }
               : {}),
             ...(style?.aspect ? { aspect: style.aspect } : {}),
+            ...(style?.tweetSettings && canvas.tweet
+              ? { tweet: { ...canvas.tweet, ...style.tweetSettings } }
+              : {}),
             // geometry
             tilt: snapshot.canvasTilt,
             scale: snapshot.canvasScale,
             screenshotPosition: style?.screenshotPosition ?? "center",
             screenshotOffset: offset,
-            screenshotSlots: slots,
+            screenshotSlots: canvas.tweet ? [] : slots,
             // always preserved from the live canvas
             screenshot: canvas.screenshot,
             originalScreenshot: canvas.originalScreenshot,
@@ -1045,42 +1052,78 @@ export const useEditorStore = create<EditorStore>((set, get) => {
     setFrame: (f, canvasId) =>
       commitCanvas(
         canvasId,
-        (canvas, state) =>
-          applySharedFrameToCanvas(
+        (canvas, state) => {
+          if (canvas.tweet) {
+            return {
+              frame: { id: "none", color: "black", orientation: "vertical" },
+              frameAddress: "",
+            }
+          }
+          return applySharedFrameToCanvas(
             canvas,
             state,
             f,
             get().activeLayoutPresetId
-          ),
+          )
+        },
         "frame"
       ),
     setFrameForMatchingScreenshots: (f, canvasId) =>
       commitCanvas(
         canvasId,
-        (canvas, state) =>
-          applySharedFrameToCanvas(
+        (canvas, state) => {
+          if (canvas.tweet) {
+            return {
+              frame: { id: "none", color: "black", orientation: "vertical" },
+              frameAddress: "",
+            }
+          }
+          return applySharedFrameToCanvas(
             canvas,
             state,
             f,
             get().activeLayoutPresetId
-          ),
+          )
+        },
         "frame"
       ),
     setFrameAddress: (address, canvasId) =>
       commitCanvas(canvasId, { frameAddress: address }, "frame-address"),
-    setTweet: (card, canvasId) =>
-      commitCanvas(
-        canvasId,
-        {
-          // A tweet replaces the screenshot as the canvas's main content.
-          tweet: card,
-          screenshot: null,
-          originalScreenshot: null,
-          lastCropRegion: null,
-          screenshotSlots: [],
-        },
-        null
-      ),
+    setTweet: (card, canvasId) => {
+      commit((state) => {
+        const targetId = canvasId ?? state.activeCanvasId
+        return {
+          aspect: { ...TWEET_POST_ASPECT },
+          canvases: state.canvases.map((canvas) =>
+            canvas.id === targetId
+              ? {
+                  ...canvas,
+                  // A tweet replaces the screenshot as the canvas's main content.
+                  tweet: card,
+                  screenshot: null,
+                  originalScreenshot: null,
+                  lastCropRegion: null,
+                  screenshotSlots: [],
+                  frame: {
+                    id: "none",
+                    color: "black",
+                    orientation: "vertical",
+                  },
+                  frameAddress: "",
+                  screenshotPosition: "center",
+                  screenshotOffset: { x: 0, y: 0 },
+                  aspect: undefined,
+                }
+              : canvas
+          ),
+        }
+      }, null)
+      set({
+        presetTab: "single",
+        activeLayoutPresetId: null,
+        activeCustomPresetId: null,
+      })
+    },
     updateTweet: (patch, canvasId) =>
       commitCanvas(
         canvasId,
@@ -1551,7 +1594,11 @@ export const useEditorStore = create<EditorStore>((set, get) => {
       const target = get().present.canvases.find(
         (canvas) => canvas.id === targetId
       )
-      if (!target || target.screenshotSlots.length >= MAX_SCREENSHOT_SLOTS) {
+      if (
+        !target ||
+        target.tweet ||
+        target.screenshotSlots.length >= MAX_SCREENSHOT_SLOTS
+      ) {
         return null
       }
       const id = makeId()

--- a/lib/editor/store/defaults.ts
+++ b/lib/editor/store/defaults.ts
@@ -103,6 +103,7 @@ export const DEFAULT_CANVAS_BASE: Omit<CanvasState, "id" | "position"> = {
   annotationShapes: [],
   screenshotSlots: [],
   frameAddress: "",
+  tweet: null,
 }
 
 export const createCanvas = (

--- a/lib/editor/store/use-editor.tsx
+++ b/lib/editor/store/use-editor.tsx
@@ -234,6 +234,7 @@ export function useEditor(): EditorContext {
     annotationShapes: canvas.annotationShapes,
     screenshotSlots: canvas.screenshotSlots,
     objectFit: canvas.objectFit,
+    tweet: canvas.tweet,
 
     isPreviewMode,
     isPreviewAutoScroll,
@@ -325,6 +326,10 @@ export function useEditor(): EditorContext {
       store.setObjectFit(fit, canvasId ?? targetId),
     setFrameAddress: (address, canvasId) =>
       store.setFrameAddress(address, canvasId ?? targetId),
+    setTweet: (card, canvasId) => store.setTweet(card, canvasId ?? targetId),
+    updateTweet: (patch, canvasId) =>
+      store.updateTweet(patch, canvasId ?? targetId),
+    clearTweet: (canvasId) => store.clearTweet(canvasId ?? targetId),
     bringScreenshotToFront: (canvasId) =>
       store.bringScreenshotToFront(canvasId ?? targetId),
     sendScreenshotToBack: (canvasId) =>

--- a/lib/editor/tweet-settings.ts
+++ b/lib/editor/tweet-settings.ts
@@ -1,0 +1,71 @@
+import type { FontFamilyOption, TweetCard, TweetTheme } from "./state-types"
+import { FONT_FAMILIES } from "./fonts"
+
+export type TweetCardSettings = {
+  theme: TweetTheme
+  showMetrics: boolean
+  showAvatar: boolean
+  showImages: boolean
+  showTimestamp: boolean
+  fontFamily: string
+}
+
+export const DEFAULT_TWEET_FONT_FAMILY =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
+
+export const DEFAULT_TWEET_SETTINGS: TweetCardSettings = {
+  theme: "dark",
+  showMetrics: true,
+  showAvatar: true,
+  showImages: true,
+  showTimestamp: true,
+  fontFamily: DEFAULT_TWEET_FONT_FAMILY,
+}
+
+export const TWEET_THEME_OPTIONS: {
+  id: TweetTheme
+  label: string
+  swatch: string
+}[] = [
+  { id: "dark", label: "Dark", swatch: "#000000" },
+  { id: "light", label: "Light", swatch: "#ffffff" },
+  { id: "dim", label: "Dim", swatch: "#15202b" },
+]
+
+const TWEET_FONT_LABELS = [
+  "Inter",
+  "Geist",
+  "Roboto",
+  "Poppins",
+  "Outfit",
+  "Space Grotesk",
+  "Nunito",
+  "Playfair Display",
+  "Lora",
+  "Fira Code",
+  "Geist Mono",
+] as const
+
+export const TWEET_FONT_OPTIONS: FontFamilyOption[] = [
+  {
+    id: "tweet-default",
+    label: "X Default",
+    css: DEFAULT_TWEET_FONT_FAMILY,
+    category: "system",
+  },
+  ...TWEET_FONT_LABELS.map((label) =>
+    FONT_FAMILIES.find((font) => font.label === label)
+  ).filter((font): font is FontFamilyOption => Boolean(font)),
+  ...FONT_FAMILIES.filter((font) => font.category === "system"),
+]
+
+export function tweetSettingsFromCard(tweet: TweetCard): TweetCardSettings {
+  return {
+    theme: tweet.theme,
+    showMetrics: tweet.showMetrics,
+    showAvatar: tweet.showAvatar,
+    showImages: tweet.showImages ?? true,
+    showTimestamp: tweet.showTimestamp ?? true,
+    fontFamily: tweet.fontFamily ?? DEFAULT_TWEET_FONT_FAMILY,
+  }
+}

--- a/lib/editor/tweet-url.ts
+++ b/lib/editor/tweet-url.ts
@@ -1,0 +1,36 @@
+import { z } from "zod/v4"
+
+/** An x.com / twitter.com status link, e.g. https://x.com/jack/status/20. */
+const STATUS_RE = /(?:twitter\.com|x\.com)\/[^/?#]+\/status(?:es)?\/(\d+)/i
+/** A bare numeric tweet id pasted on its own. */
+const BARE_ID_RE = /^\d{1,20}$/
+
+/** Extracts the numeric tweet id from a full URL or a bare id, else null. */
+export function parseTweetId(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  if (BARE_ID_RE.test(trimmed)) return trimmed
+  return trimmed.match(STATUS_RE)?.[1] ?? null
+}
+
+/** Validates user input and resolves it to a tweet id. */
+export const tweetUrlSchema = z
+  .string()
+  .trim()
+  .min(1, "Paste an X post link")
+  .transform((value, ctx) => {
+    const id = parseTweetId(value)
+    if (!id) {
+      ctx.addIssue({ code: "custom", message: "Enter a valid X post link" })
+      return z.NEVER
+    }
+    return id
+  })
+
+/**
+ * Token expected by the public X syndication endpoint. Deterministically
+ * derived from the tweet id (mirrors react-tweet) — no auth/secret required.
+ */
+export function syndicationToken(id: string): string {
+  return ((Number(id) / 1e15) * Math.PI).toString(36).replace(/(0+|\.)/g, "")
+}


### PR DESCRIPTION
## Summary

Adds the ability to turn an X/Twitter post into a polished, exportable mockup. Paste a
post link on an empty canvas and it renders as a styled tweet card that becomes the
canvas's main content — inheriting the existing background, padding, shadow, tilt/scale,
border-radius, zoom and export, exactly like a screenshot. Implements #11.

## Type of Change

- [ ] fix
- [ ] refactor
- [ ] delete
- [ ] optimised
- [ ] docs

> Note: this is a **feature / enhancement** (new functionality) — none of the boxes
> above fit; the commit is prefixed `feat:`.

## Related Issues

Closes #11

## Changes Made

- **New `/api/tweet` route** — validates an X/Twitter link, derives the public X
  *syndication* token (no API key/secret needed), fetches the post and normalizes it to
  `{ text, author, avatar, verified, createdAt, likes, replies }`. Rate-limited via the
  existing `HEAVY_RATE_LIMITER`; handles 400 (bad link) / 404 (deleted/private) / 504 /
  502.
- **State** — new `tweet: TweetCard | null` on `CanvasState`, **mutually exclusive** with
  `screenshot` (setting one clears the other). Store actions `setTweet` / `updateTweet` /
  `clearTweet`. Plain JSON, so it persists via the existing IndexedDB layer for free.
- **Render** — `TweetCardView` renders the card (avatar, name/@handle, verified badge, X
  logo, body text with link/mention/hashtag highlighting, date + reply/like metrics) as
  real DOM, so `html-to-image` export works untouched and the avatar is proxied through
  the existing `/api/export/image`. Light / Dim / Dark themes.
- **Entry point** — an "Embed X post" button on the empty-canvas upload card opens a
  paste-URL popover.
- **Customization** — new **X Post** inspector panel: theme, show/hide metrics, show/hide
  avatar, Replace, Remove. Floating-toolbar zoom (±) buttons now resize the tweet card.
- **Metrics** — likes + replies only; the free syndication endpoint doesn't expose
  reposts/views (those require the paid X API).

## Screenshots / Recordings (if UI)
<img width="1910" height="960" alt="image" src="https://github.com/user-attachments/assets/36a6bab3-86ed-4e01-a46d-8b83ba842fc8" />
<img width="1919" height="968" alt="image" src="https://github.com/user-attachments/assets/1dddd4eb-60d0-43e2-bd56-bb675c8f655a" />


## Checklist

- [x] I ran `pnpm lint`
- [x] I ran `pnpm typecheck`
- [ ] I ran `pnpm test`
- [x] I did not include secrets or sensitive data
- [ ] I updated docs when behavior changed
- [x] I kept this PR focused and reasonably small