### PR TITLE
feat: per-clip transition (easing curve + speed) for the Animate timeline

### DIFF
--- a/components/editor/animate/animate-bar.tsx
+++ b/components/editor/animate/animate-bar.tsx
@@ -10,6 +10,7 @@ import {
 import { cn } from "@/lib/utils"
 
 import { AnimateControls } from "./animate-controls"
+import { ClipTransitionButton } from "./clip-transition-toolbar"
 import { RAZOR_CURSOR, TimelineClip } from "./timeline-clip"
 import { TimelineRuler } from "./timeline-ruler"
 import { useAnimateTimeline } from "./use-animate-timeline"
@@ -51,6 +52,8 @@ export function AnimateBar() {
     ghostWidthPx,
     clips,
     selectedClipId,
+    selectedClip,
+    updateAnimationClip,
     draggingClipId,
     interactingClipId,
     clipsAnimated,
@@ -98,6 +101,15 @@ export function AnimateBar() {
         onTogglePlay={toggle}
         onToggleRazor={toggleRazor}
         onReset={reset}
+        transitionControl={
+          selectedClip ? (
+            <ClipTransitionButton
+              clip={selectedClip}
+              onUpdate={(patch) => updateAnimationClip(selectedClip.id, patch)}
+              disabled={isPlaying}
+            />
+          ) : null
+        }
       />
 
       {/* Scrollable timeline — ruler + tracks share one horizontal scroll so

--- a/components/editor/animate/animate-controls.tsx
+++ b/components/editor/animate/animate-controls.tsx
@@ -31,6 +31,8 @@ type AnimateControlsProps = {
   onTogglePlay: () => void
   onToggleRazor: () => void
   onReset: () => void
+  /** Selected clip's transition button — only present while a clip is selected. */
+  transitionControl?: React.ReactNode
 }
 
 const iconButton =
@@ -51,9 +53,13 @@ export function AnimateControls({
   onTogglePlay,
   onToggleRazor,
   onReset,
+  transitionControl,
 }: AnimateControlsProps) {
   return (
-    <div className="flex items-center gap-1.5">
+    // 3-column grid: the center controls stay centered no matter what the side
+    // cells hold, so the transition button appearing on the right never shifts
+    // the play controls (a plain flex + mx-auto re-centered on every toggle).
+    <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-1.5">
       <input
         ref={audioInputRef}
         type="file"
@@ -62,19 +68,21 @@ export function AnimateControls({
         onChange={onPickAudio}
       />
 
-      <button
-        type="button"
-        onClick={onExit}
-        aria-label="Exit animate"
-        className={cn(
-          iconButton,
-          "bg-foreground/8 text-foreground hover:bg-foreground/15"
-        )}
-      >
-        <RiArrowLeftLine className="size-[18px]" />
-      </button>
+      <div className="flex items-center justify-self-start">
+        <button
+          type="button"
+          onClick={onExit}
+          aria-label="Exit animate"
+          className={cn(
+            iconButton,
+            "bg-foreground/8 text-foreground hover:bg-foreground/15"
+          )}
+        >
+          <RiArrowLeftLine className="size-[18px]" />
+        </button>
+      </div>
 
-      <div className="mx-auto flex items-center gap-1.5">
+      <div className="flex items-center gap-1.5">
         <button
           type="button"
           onClick={onToggleAudio}
@@ -150,9 +158,15 @@ export function AnimateControls({
         </button>
       </div>
 
-      <span className="font-mono text-[11px] text-muted-foreground tabular-nums">
-        {formatTime(playheadMs)} / {formatShort(durationMs)}
-      </span>
+      {/* Right cell: the selected clip's transition control on the left, then
+          the playhead / total-duration readout on the right. Its own grid column
+          so it never moves the centered controls. */}
+      <div className="flex min-w-0 items-center justify-end gap-2 justify-self-end">
+        {transitionControl}
+        <span className="shrink-0 font-mono text-[11px] text-muted-foreground tabular-nums">
+          {formatTime(playheadMs)} / {formatShort(durationMs)}
+        </span>
+      </div>
     </div>
   )
 }

--- a/components/editor/animate/clip-transition-toolbar.tsx
+++ b/components/editor/animate/clip-transition-toolbar.tsx
@@ -1,0 +1,199 @@
+"use client"
+
+import * as React from "react"
+import { RiArrowGoBackLine } from "@remixicon/react"
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { Slider } from "@/components/ui/slider"
+import {
+  CLIP_EASING_KINDS,
+  CLIP_EASING_LABELS,
+  clipEasingKind,
+  clipSpeed,
+  DEFAULT_CLIP_EASING,
+  DEFAULT_CLIP_SPEED,
+  effectiveActiveMs,
+  MAX_CLIP_SPEED,
+  MIN_CLIP_SPEED,
+  type ClipEasingKind,
+} from "@/lib/editor/clip-easing"
+import type { AnimationClip } from "@/lib/editor/state-types"
+import { cn } from "@/lib/utils"
+
+import { EasingCurve } from "./easing-curve"
+
+type ClipTransitionButtonProps = {
+  clip: AnimationClip
+  onUpdate: (patch: Partial<AnimationClip>) => void
+  /** While playing, keep the control visible but non-interactive. */
+  disabled?: boolean
+  className?: string
+}
+
+/**
+ * The selected clip's transition control, shown inline in the animate controls
+ * bar: a curve + duration button that opens the Transition popover (easing curve
+ * + speed). Applies to every animation type — position, zoom, background, etc.
+ */
+export function ClipTransitionButton({
+  clip,
+  onUpdate,
+  disabled = false,
+  className,
+}: ClipTransitionButtonProps) {
+  const kind = clipEasingKind(clip)
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    // Controlled so hitting play (which disables the trigger) also force-closes
+    // an already-open popover instead of leaving it floating.
+    <Popover
+      open={open && !disabled}
+      onOpenChange={(next) => {
+        if (!disabled) setOpen(next)
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          title="Transition"
+          disabled={disabled}
+          className={cn(
+            "flex h-8 cursor-pointer items-center gap-1.5 rounded-md bg-foreground/8 px-2.5 text-[13px] font-medium text-foreground transition-colors hover:bg-foreground/15 disabled:pointer-events-none disabled:opacity-50",
+            className
+          )}
+        >
+          <span className="flex size-4 items-center justify-center">
+            <EasingCurve kind={kind} strokeClassName="stroke-foreground/70" />
+          </span>
+          <span className="tabular-nums">{effectiveActiveMs(clip)}ms</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="center"
+        sideOffset={10}
+        className="w-60 rounded-md p-2.5 pb-3"
+      >
+        <TransitionPanel clip={clip} onUpdate={onUpdate} />
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function TransitionPanel({
+  clip,
+  onUpdate,
+}: {
+  clip: AnimationClip
+  onUpdate: (patch: Partial<AnimationClip>) => void
+}) {
+  const kind = clipEasingKind(clip)
+  const speed = clipSpeed(clip)
+  const [hovered, setHovered] = React.useState<ClipEasingKind | null>(null)
+
+  const reset = () =>
+    onUpdate({ easing: DEFAULT_CLIP_EASING, speed: DEFAULT_CLIP_SPEED })
+
+  // The slider is driven by the effective transition duration in ms, not the raw
+  // speed multiplier: RIGHT (max) = the full clip window (speed 1), and dragging
+  // LEFT shortens it (higher speed) — so "1200ms" reads as a full bar you reduce.
+  const fullMs = Math.max(1, Math.round(clip.durationMs))
+  const minMs = Math.max(1, Math.round(clip.durationMs / MAX_CLIP_SPEED))
+  const maxMs = Math.max(minMs + 1, fullMs)
+  const activeMs = Math.min(maxMs, Math.max(minMs, effectiveActiveMs(clip)))
+  const onSpeedMs = (ms: number) => {
+    const next = clip.durationMs / Math.max(1, ms)
+    onUpdate({
+      speed: Math.min(MAX_CLIP_SPEED, Math.max(MIN_CLIP_SPEED, next)),
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex items-center justify-between">
+        <span className="text-[13px] font-semibold text-foreground">
+          Transition
+        </span>
+        <button
+          type="button"
+          aria-label="Reset transition"
+          onClick={reset}
+          className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+        >
+          <RiArrowGoBackLine className="size-3.5" />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-3 gap-1.5">
+        {CLIP_EASING_KINDS.map((k) => {
+          const active = k === kind
+          return (
+            <button
+              key={k}
+              type="button"
+              onClick={() => onUpdate({ easing: k })}
+              onPointerEnter={() => setHovered(k)}
+              onPointerLeave={() => setHovered((h) => (h === k ? null : h))}
+              onFocus={() => setHovered(k)}
+              onBlur={() => setHovered((h) => (h === k ? null : h))}
+              className="group flex flex-col items-center gap-1 outline-none"
+            >
+              <span
+                className={cn(
+                  "flex aspect-square w-full items-center justify-center rounded-md border p-2 transition-colors",
+                  active
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border/60 bg-muted/40 group-hover:border-border group-focus-visible:border-ring"
+                )}
+              >
+                <EasingCurve
+                  kind={k}
+                  animate={hovered === k}
+                  speed={speed}
+                  strokeClassName={
+                    active
+                      ? "stroke-primary-foreground"
+                      : "stroke-foreground/45"
+                  }
+                  dotClassName={
+                    active ? "fill-primary-foreground" : "fill-primary"
+                  }
+                />
+              </span>
+              <span
+                className={cn(
+                  "text-[11px] transition-colors",
+                  active
+                    ? "font-medium text-foreground"
+                    : "text-muted-foreground"
+                )}
+              >
+                {CLIP_EASING_LABELS[k]}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="flex flex-col gap-1.5 pt-0.5">
+        <div className="flex items-center justify-between text-[11px]">
+          <span className="text-muted-foreground">Speed</span>
+          <span className="text-foreground tabular-nums">{activeMs}ms</span>
+        </div>
+        <Slider
+          value={[activeMs]}
+          min={minMs}
+          max={maxMs}
+          step={1}
+          aria-label="Transition speed"
+          onValueChange={([v]) => onSpeedMs(v)}
+        />
+      </div>
+    </div>
+  )
+}

--- a/components/editor/animate/easing-curve.tsx
+++ b/components/editor/animate/easing-curve.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  easingDotAt,
+  easingSvgPath,
+  type ClipEasingKind,
+} from "@/lib/editor/clip-easing"
+import { cn } from "@/lib/utils"
+
+const PAD = 18
+// Time for the dot to cross the whole curve at speed 1 (the full clip window).
+const FULL_SWEEP_MS = 1150
+// Constant loop length so every tile pulses at the same cadence; the leftover
+// after the (speed-shortened) sweep is a hold at the end — that pause is what
+// reads as "finishes early then waits".
+const LOOP_MS = 1650
+
+type EasingCurveProps = {
+  kind: ClipEasingKind
+  /** Run the moving-dot preview (true while the tile is hovered/focused). */
+  animate?: boolean
+  /** Clip speed (1..5): compresses the sweep so a faster clip zips to the end
+   * then holds — so the preview reflects the current speed, not just the curve. */
+  speed?: number
+  className?: string
+  strokeClassName?: string
+  dotClassName?: string
+}
+
+/**
+ * The little transition-curve thumbnail. Draws the easing curve (x = time, y =
+ * eased output) and, while `animate` is on, sweeps a dot along it — faster when
+ * `speed` is higher — so its motion reveals both the curve's shape ("how
+ * instant") and how quickly the clip completes.
+ */
+export function EasingCurve({
+  kind,
+  animate = false,
+  speed = 1,
+  className,
+  strokeClassName,
+  dotClassName,
+}: EasingCurveProps) {
+  const path = React.useMemo(() => easingSvgPath(kind, 100, PAD), [kind])
+  const [t, setT] = React.useState(0)
+
+  const sweep = FULL_SWEEP_MS / Math.max(1, speed)
+  React.useEffect(() => {
+    if (!animate) return
+    const start = performance.now()
+    let raf = 0
+    const tick = (now: number) => {
+      const elapsed = (now - start) % LOOP_MS
+      setT(elapsed <= sweep ? elapsed / sweep : 1)
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [animate, sweep])
+
+  // The dot only shows while animating; `t` holds its last value between hovers
+  // (harmless — a fresh hover restarts the sweep from its own timestamp).
+  const dot = animate ? easingDotAt(kind, t, 100, PAD) : null
+
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      className={cn("h-full w-full overflow-visible", className)}
+      aria-hidden
+    >
+      <path
+        d={path}
+        fill="none"
+        strokeWidth={7}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={cn("stroke-foreground/40", strokeClassName)}
+      />
+      {dot && (
+        <circle
+          cx={dot.x}
+          cy={dot.y}
+          r={7}
+          className={cn("fill-primary", dotClassName)}
+        />
+      )}
+    </svg>
+  )
+}

--- a/components/editor/animate/use-animate-timeline.ts
+++ b/components/editor/animate/use-animate-timeline.ts
@@ -896,6 +896,12 @@ export function useAnimateTimeline() {
     []
   )
 
+  // The selected clip's data, surfaced for the floating transition toolbar.
+  const selectedClip = React.useMemo(
+    () => clips.find((c) => c.id === selectedClipId) ?? null,
+    [clips, selectedClipId]
+  )
+
   return {
     // playback + data
     playheadMs,
@@ -916,6 +922,8 @@ export function useAnimateTimeline() {
 
     // selection / labels
     selectedClipId,
+    selectedClip,
+    updateAnimationClip,
     draggingClipId,
     interactingClipId,
     clipsAnimated,

--- a/components/editor/top-bar/export-controls.tsx
+++ b/components/editor/top-bar/export-controls.tsx
@@ -583,8 +583,17 @@ export function ExportControls({
   // GIF only supports its centisecond-friendly rates; snap the persisted fps to
   // the options valid for the current format so a video rate (e.g. 30) picked
   // earlier resolves to the nearest GIF rate (25) when GIF is selected.
-  const animFpsOptions = fpsOptionsForFormat(animFormat)
-  const effectiveAnimFps = snapFpsToOptions(animFps, animFpsOptions)
+  // Memoized so the freshly-allocated options array has a stable identity — the
+  // React Compiler needs that to preserve the `handleExport` memoization (which
+  // depends on effectiveAnimFps).
+  const animFpsOptions = React.useMemo(
+    () => fpsOptionsForFormat(animFormat),
+    [animFormat]
+  )
+  const effectiveAnimFps = React.useMemo(
+    () => snapFpsToOptions(animFps, animFpsOptions),
+    [animFps, animFpsOptions]
+  )
   const [isExporting, setIsExporting] = React.useState(false)
   const [open, setOpen] = React.useState(false)
   const [bulkDialogOpen, setBulkDialogOpen] = React.useState(false)

--- a/components/editor/top-bar/open-project-dialog.tsx
+++ b/components/editor/top-bar/open-project-dialog.tsx
@@ -118,14 +118,12 @@ function DraftCard({
   draft,
   isCurrent,
   isOpening,
-  isDeleting,
   onOpen,
   onDelete,
 }: {
   draft: DraftListItem
   isCurrent: boolean
   isOpening: boolean
-  isDeleting: boolean
   onOpen: () => void
   onDelete: () => void
 }) {
@@ -138,13 +136,13 @@ function DraftCard({
       <button
         type="button"
         onClick={onOpen}
-        disabled={isOpening || isDeleting}
+        disabled={isOpening}
         className={cn(
           "flex w-full flex-col overflow-hidden rounded-xl border bg-secondary/30 text-left transition-colors",
           isCurrent
             ? "border-primary"
             : "border-border/50 hover:border-primary/55",
-          (isOpening || isDeleting) && "cursor-not-allowed opacity-60"
+          isOpening && "cursor-not-allowed opacity-60"
         )}
       >
         <div className="relative aspect-[16/10] w-full overflow-hidden bg-secondary/40">
@@ -187,7 +185,6 @@ function DraftCard({
           e.stopPropagation()
           onDelete()
         }}
-        disabled={isDeleting}
         aria-label={`Delete ${draft.name}`}
         className="absolute top-2 right-2 inline-flex size-7 items-center justify-center rounded-full border border-border/60 bg-background/85 text-muted-foreground opacity-100 shadow-sm transition-opacity hover:border-destructive/40 hover:bg-destructive/15 hover:text-destructive focus:opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
       >
@@ -298,8 +295,12 @@ function ProjectPagination({
   loading: boolean
   onPageChange: (page: number) => void
 }) {
-  // Nothing to paginate — keep the shell clean on empty states.
-  if (total <= 0 || loading) return null
+  // Nothing to paginate — keep the shell clean on empty states. Note we do NOT
+  // hide while `loading`: during a page change `total` stays put, so the bar
+  // must stay mounted (hiding it made it blink out and back on every page turn).
+  // On the very first load `total` is still 0, so the bar stays hidden behind
+  // the skeleton until results arrive.
+  if (total <= 0) return null
 
   const items = buildPageItems(page, totalPages)
   const canPrev = page > 1
@@ -319,7 +320,7 @@ function ProjectPagination({
               variant="ghost"
               size="sm"
               className="h-8 gap-1 px-2 text-[11px]"
-              disabled={!canPrev}
+              disabled={!canPrev || loading}
               onClick={() => onPageChange(page - 1)}
               aria-label="Go to previous page"
             >
@@ -342,6 +343,9 @@ function ProjectPagination({
                   className="size-8 text-[11px] tabular-nums"
                   aria-label={`Go to page ${item}`}
                   aria-current={item === page ? "page" : undefined}
+                  // Keep the active page interactive-looking; only lock the
+                  // others while a page is loading.
+                  disabled={loading && item !== page}
                   onClick={() => onPageChange(item)}
                 >
                   {item}
@@ -356,7 +360,7 @@ function ProjectPagination({
               variant="ghost"
               size="sm"
               className="h-8 gap-1 px-2 text-[11px]"
-              disabled={!canNext}
+              disabled={!canNext || loading}
               onClick={() => onPageChange(page + 1)}
               aria-label="Go to next page"
             >
@@ -392,7 +396,6 @@ export function OpenProjectDialog({
   const [drafts, setDrafts] = React.useState<DraftListItem[] | null>(null)
   const [error, setError] = React.useState<string | null>(null)
   const [busyId, setBusyId] = React.useState<string | null>(null)
-  const [deletingId, setDeletingId] = React.useState<string | null>(null)
   const [confirmDeleteId, setConfirmDeleteId] = React.useState<string | null>(
     null
   )
@@ -517,7 +520,16 @@ export function OpenProjectDialog({
   }
 
   const handleDelete = async (id: string) => {
-    setDeletingId(id)
+    // Optimistic: drop the card and decrement the count immediately, then call
+    // the API. Snapshots let us restore everything if the delete fails — same
+    // pattern as the shares gallery.
+    const snapshotDrafts = drafts
+    const snapshotTotal = total
+    const remaining = snapshotDrafts?.filter((d) => d.id !== id) ?? null
+
+    setDrafts(remaining)
+    setTotal((t) => Math.max(0, t - 1))
+
     try {
       const res = await fetch(`/api/drafts/${id}`, {
         method: "DELETE",
@@ -530,20 +542,16 @@ export function OpenProjectDialog({
         throw new Error(data?.error ?? "Could not delete draft")
       }
       toast.success("Draft removed")
-      setTotal((t) => Math.max(0, t - 1))
-      setDrafts((prev) => {
-        const next = prev?.filter((d) => d.id !== id) ?? prev
-        // If this page is now empty and we're past page 1, step back.
-        if (next && next.length === 0 && page > 1) {
-          setPage((p) => Math.max(1, p - 1))
-        }
-        return next
-      })
+      // If the page emptied out, step back so we don't sit on a blank page.
+      if (remaining && remaining.length === 0 && page > 1) {
+        setPage((p) => Math.max(1, p - 1))
+      }
     } catch (err) {
       console.error(err)
+      // Revert the optimistic removal.
+      setDrafts(snapshotDrafts)
+      setTotal(snapshotTotal)
       toast.error(err instanceof Error ? err.message : "Could not delete draft")
-    } finally {
-      setDeletingId(null)
     }
   }
 
@@ -713,7 +721,6 @@ export function OpenProjectDialog({
                           draft={draft}
                           isCurrent={currentDraftId === draft.id}
                           isOpening={busyId === draft.id}
-                          isDeleting={deletingId === draft.id}
                           onOpen={() => void handleOpen(draft.id)}
                           onDelete={() => setConfirmDeleteId(draft.id)}
                         />

--- a/components/share/share-plyr-player.tsx
+++ b/components/share/share-plyr-player.tsx
@@ -76,7 +76,10 @@ export function SharePlyrPlayer({
         resetOnEnd: false,
         // Reserve space before intrinsic size is known.
         ratio: "16:9",
-        keyboard: { focused: true, global: false },
+        // `global` lets Space / arrows / F etc. work without first clicking the
+        // player — the share page has a single player, so there's nothing to
+        // conflict with. `focused` keeps them working once it does have focus.
+        keyboard: { focused: true, global: true },
       })
       playerRef.current = player
 

--- a/components/ui/shimmer-image.tsx
+++ b/components/ui/shimmer-image.tsx
@@ -10,17 +10,33 @@ type ShimmerImageProps = Omit<
 > & {
   src: string
   shimmer?: boolean
+  /**
+   * How long the image may load before the animated pulse appears. Fast/cached
+   * loads resolve first, so the pulse never flashes — which is what made grids
+   * of quick thumbnails look like they were flickering. A calm static
+   * placeholder still fills the box immediately.
+   */
+  shimmerDelayMs?: number
 }
 
 export const ShimmerImage = React.forwardRef<
   HTMLImageElement,
   ShimmerImageProps
 >(function ShimmerImage(
-  { src, shimmer = true, className, style, onLoad, ...imgProps },
+  {
+    src,
+    shimmer = true,
+    shimmerDelayMs = 220,
+    className,
+    style,
+    onLoad,
+    ...imgProps
+  },
   ref
 ) {
   const imgRef = React.useRef<HTMLImageElement | null>(null)
   const [loaded, setLoaded] = React.useState(false)
+  const [pulse, setPulse] = React.useState(false)
 
   // Runs synchronously after DOM update but before paint.
   // If the image is already complete (cached / data URL), mark it loaded
@@ -33,6 +49,18 @@ export const ShimmerImage = React.forwardRef<
       setLoaded(false)
     }
   }, [src])
+
+  // Only animate the pulse once the image has been loading for a beat. A quick
+  // load flips `loaded` before the timer fires, so the pulse never starts and
+  // the tile just shows a still placeholder → no fast flicker.
+  React.useEffect(() => {
+    if (loaded || !shimmer) {
+      setPulse(false)
+      return
+    }
+    const timer = window.setTimeout(() => setPulse(true), shimmerDelayMs)
+    return () => window.clearTimeout(timer)
+  }, [loaded, shimmer, shimmerDelayMs, src])
 
   const handleLoad = React.useCallback(
     (event: React.SyntheticEvent<HTMLImageElement>) => {
@@ -60,7 +88,13 @@ export const ShimmerImage = React.forwardRef<
       alt={imgProps.alt}
       onLoad={handleLoad}
       data-loaded={loaded ? "true" : "false"}
-      className={cn(shimmer && !loaded && "animate-pulse bg-muted", className)}
+      className={cn(
+        // Still, calm placeholder shows immediately; the pulse only kicks in if
+        // the load actually drags on (see the delay above).
+        shimmer && !loaded && "bg-muted",
+        pulse && !loaded && "animate-pulse",
+        className
+      )}
       style={style}
     />
   )

--- a/lib/editor/animation-playback.ts
+++ b/lib/editor/animation-playback.ts
@@ -7,6 +7,7 @@
 // turns that progress into concrete CSS override vars. Kept React-free so it's
 // testable and shared between live playback and (later) the exporter.
 
+import { clipProgressEase } from "./clip-easing"
 import { hexToRgb } from "./color-utils"
 import { DEFAULT_CANVAS_BASE } from "./store/defaults"
 import type {
@@ -231,6 +232,7 @@ export function lightingTargetMixAt(
     startMs: number
     durationMs: number
     value: BackdropLighting
+    ease?: (rawT: number) => number
   }[],
   timeMs: number,
   rest: BackdropLighting
@@ -253,6 +255,7 @@ export function lightingTargetMixAt(
         startMs: f.startMs,
         durationMs: f.durationMs,
         value: f.value.target === "inner" ? 1 : 0,
+        ease: f.ease,
       })),
       timeMs,
       restMix,
@@ -409,7 +412,12 @@ export function shadowBetween(from: Shadow, to: Shadow, p: number): Shadow {
  * Returns null when no keyframe animates the shadow (leave the committed value).
  */
 export function sampleShadowLayers(
-  frames: readonly { startMs: number; durationMs: number; value: Shadow }[],
+  frames: readonly {
+    startMs: number
+    durationMs: number
+    value: Shadow
+    ease?: (rawT: number) => number
+  }[],
   timeMs: number,
   rest: Shadow
 ): Shadow[] | null {
@@ -422,7 +430,8 @@ export function sampleShadowLayers(
     if (timeMs <= f.startMs + f.durationMs) {
       const from = i > 0 ? sorted[i - 1].value : rest
       const to = f.value
-      const p = easeOut(clamp01((timeMs - f.startMs) / f.durationMs))
+      const ease = f.ease ?? easeOut
+      const p = ease(clamp01((timeMs - f.startMs) / f.durationMs))
       const fromVisible = !shadowInvisible(from)
       const toVisible = !shadowInvisible(to)
       // Retract to nothing: fade the source out on its own type so it recedes
@@ -856,7 +865,14 @@ export function resolveAnimateOverlayStack(
  * This is the single source of truth for continuity + hold across the timeline.
  */
 export function sampleKeyframes<V>(
-  frames: readonly { startMs: number; durationMs: number; value: V }[],
+  frames: readonly {
+    startMs: number
+    durationMs: number
+    value: V
+    /** Per-clip progress remap (curve + speed). Falls back to the historic
+     * ease-out when a caller doesn't supply the owning clip's easing. */
+    ease?: (rawT: number) => number
+  }[],
   timeMs: number,
   rest: V,
   lerpValue: (from: V, to: V, p: number) => V
@@ -869,10 +885,11 @@ export function sampleKeyframes<V>(
     if (timeMs < f.startMs) return sorted[i - 1].value // gap → hold previous
     if (timeMs <= f.startMs + f.durationMs) {
       const from = i > 0 ? sorted[i - 1].value : rest
+      const ease = f.ease ?? easeOut
       return lerpValue(
         from,
         f.value,
-        easeOut(clamp01((timeMs - f.startMs) / f.durationMs))
+        ease(clamp01((timeMs - f.startMs) / f.durationMs))
       )
     }
   }
@@ -908,7 +925,7 @@ export function clipsProgressAt(
   for (const c of sorted) {
     if (timeMs < c.startMs) return 1 // in a gap that follows an earlier clip
     if (timeMs <= c.startMs + c.durationMs) {
-      return easeOut(clamp01((timeMs - c.startMs) / c.durationMs))
+      return clipProgressEase(c)((timeMs - c.startMs) / c.durationMs)
     }
   }
   return 1 // past every clip
@@ -951,7 +968,7 @@ export function activeClipAt(
     const c = sorted[i]
     if (timeMs < c.startMs) return at(Math.max(0, i - 1), 1)
     if (timeMs <= c.startMs + c.durationMs) {
-      return at(i, easeOut(clamp01((timeMs - c.startMs) / c.durationMs)))
+      return at(i, clipProgressEase(c)((timeMs - c.startMs) / c.durationMs))
     }
   }
   return at(sorted.length - 1, 1)

--- a/lib/editor/apply-animation-frame.ts
+++ b/lib/editor/apply-animation-frame.ts
@@ -65,6 +65,7 @@ import {
   SHADOW_FILTER_PREVIEW_VAR,
   SHADOW_PREVIEW_VAR,
 } from "@/lib/editor/css-utils"
+import { clipProgressEase } from "@/lib/editor/clip-easing"
 import { captureClipPose } from "@/lib/editor/store"
 import type {
   AnimationClip,
@@ -265,6 +266,7 @@ export function applyAnimationFrameAtTime({
           startMs: c.startMs,
           durationMs: c.durationMs,
           value: value(poseOf(c)),
+          ease: clipProgressEase(c),
         }))
 
     const restFor = <V>(
@@ -347,6 +349,7 @@ export function applyAnimationFrameAtTime({
           startMs: c.startMs,
           durationMs: c.durationMs,
           value: pointFor(pz.screenshotPosition, pz.screenshotOffset),
+          ease: clipProgressEase(c),
         }
       })
       const posRest = clipBaseline(
@@ -666,6 +669,7 @@ export function applyAnimationFrameAtTime({
             startMs: c.startMs,
             durationMs: c.durationMs,
             value: { tilt: sp.tilt, rotation: sp.rotation },
+            ease: clipProgressEase(c),
           }
         }),
       playheadMs,
@@ -694,6 +698,7 @@ export function applyAnimationFrameAtTime({
           startMs: c.startMs,
           durationMs: c.durationMs,
           value: slotPoseOf(c).scale,
+          ease: clipProgressEase(c),
         })),
       playheadMs,
       100,
@@ -723,6 +728,7 @@ export function applyAnimationFrameAtTime({
               xPct: sp.xPct ?? slot.xPct,
               yPct: sp.yPct ?? slot.yPct,
             },
+            ease: clipProgressEase(c),
           }
         }),
         playheadMs,
@@ -745,6 +751,7 @@ export function applyAnimationFrameAtTime({
           startMs: c.startMs,
           durationMs: c.durationMs,
           value: slotPoseOf(c).shadow ?? INVISIBLE_SHADOW,
+          ease: clipProgressEase(c),
         })),
       playheadMs,
       INVISIBLE_SHADOW
@@ -785,6 +792,7 @@ export function applyAnimationFrameAtTime({
           startMs: c.startMs,
           durationMs: c.durationMs,
           value: slotPoseOf(c).border ?? committedBorder,
+          ease: clipProgressEase(c),
         })),
       playheadMs,
       slotRestFor("border", (sp) => sp?.border, INVISIBLE_BORDER),
@@ -806,6 +814,7 @@ export function applyAnimationFrameAtTime({
           startMs: c.startMs,
           durationMs: c.durationMs,
           value: slotPoseOf(c).borderRadius ?? committedRadius,
+          ease: clipProgressEase(c),
         })),
       playheadMs,
       slotRestFor("borderRadius", (sp) => sp?.borderRadius, committedRadius),
@@ -825,6 +834,7 @@ export function applyAnimationFrameAtTime({
           startMs: c.startMs,
           durationMs: c.durationMs,
           value: slotPoseOf(c).padding ?? committedPadding,
+          ease: clipProgressEase(c),
         })),
       playheadMs,
       slotRestFor("padding", (sp) => sp?.padding, committedPadding),
@@ -844,6 +854,7 @@ export function applyAnimationFrameAtTime({
         startMs: c.startMs,
         durationMs: c.durationMs,
         value: slotPoseOf(c).lighting ?? REST_LIGHTING,
+        ease: clipProgressEase(c),
       }))
     if (slotLightingFrames.length > 0) {
       const restBase = slotRestFor(

--- a/lib/editor/clip-easing.ts
+++ b/lib/editor/clip-easing.ts
@@ -1,0 +1,149 @@
+// Per-clip transition easing + speed remap.
+//
+// Every animation clip eases its owned effects over its own window. Historically
+// that easing was a single hard-coded ease-out cubic shared by all clips; this
+// module makes the curve a per-clip choice (Linear / Cubic / In / Out / In Out /
+// Out Circ) and adds an independent SPEED remap that lets the transition finish
+// EARLY within the clip's window (then hold) WITHOUT moving the clip's keyframe
+// time. A 5 s clip can complete its motion in 1 s and hold for the remaining 4 s.
+//
+// The same helpers drive live playback, the exporter, and the little curve
+// thumbnails in the Transition popover — so the preview always matches output.
+
+import type { AnimationClip, ClipEasingKind } from "./state-types"
+
+export type { ClipEasingKind }
+
+/**
+ * The curve a clip uses when it hasn't picked one. `out` (ease-out cubic) is the
+ * motion every clip shipped with before per-clip easing existed, so undefined
+ * `easing` reads as this and old drafts animate identically.
+ */
+export const DEFAULT_CLIP_EASING: ClipEasingKind = "out"
+
+/** Speed remap bounds. 1 = the transition uses the clip's full window (original
+ * behaviour); higher finishes proportionally sooner (5 = in one-fifth of it). */
+export const MIN_CLIP_SPEED = 1
+export const MAX_CLIP_SPEED = 5
+export const DEFAULT_CLIP_SPEED = 1
+
+function clamp01(n: number): number {
+  return n < 0 ? 0 : n > 1 ? 1 : n
+}
+
+/** Raw easing functions on t ∈ [0,1] → [0,1]. */
+const EASING_FNS: Record<ClipEasingKind, (t: number) => number> = {
+  linear: (t) => t,
+  // Strong symmetric S — accelerate then decelerate (ease-in-out cubic).
+  cubic: (t) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2),
+  // Accelerate from rest (ease-in cubic).
+  in: (t) => t * t * t,
+  // Decelerate into the pose (ease-out cubic) — the historic default.
+  out: (t) => 1 - Math.pow(1 - t, 3),
+  // Gentle symmetric S (ease-in-out quad) — softer than `cubic`.
+  inOut: (t) => (t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2),
+  // Circular ease-out — a snappy, near-instant settle.
+  outCirc: (t) => Math.sqrt(1 - Math.pow(t - 1, 2)),
+}
+
+export const CLIP_EASING_KINDS: readonly ClipEasingKind[] = [
+  "linear",
+  "cubic",
+  "in",
+  "out",
+  "inOut",
+  "outCirc",
+]
+
+/** Human labels for the Transition popover tiles. */
+export const CLIP_EASING_LABELS: Record<ClipEasingKind, string> = {
+  linear: "Linear",
+  cubic: "Cubic",
+  in: "In",
+  out: "Out",
+  inOut: "In Out",
+  outCirc: "Out Circ",
+}
+
+/** The easing kind a clip resolves to (its own, or the default). */
+export function clipEasingKind(clip: {
+  easing?: ClipEasingKind
+}): ClipEasingKind {
+  return clip.easing ?? DEFAULT_CLIP_EASING
+}
+
+/** Clamp a raw speed into range, treating undefined as the default. */
+export function clipSpeed(clip: { speed?: number }): number {
+  const s = clip.speed ?? DEFAULT_CLIP_SPEED
+  if (!Number.isFinite(s)) return DEFAULT_CLIP_SPEED
+  return Math.min(MAX_CLIP_SPEED, Math.max(MIN_CLIP_SPEED, s))
+}
+
+/** The bare easing function for a kind (used by the curve thumbnails). */
+export function easingFn(kind: ClipEasingKind): (t: number) => number {
+  return EASING_FNS[kind]
+}
+
+/**
+ * The full progress remap for a clip: takes RAW local progress (0..1 across the
+ * clip's window) and returns the eased 0..1 the interpolators apply. Speed
+ * compresses the raw progress so the curve reaches 1 early (then holds), and the
+ * chosen curve shapes the ramp. This is the single function every sampler uses,
+ * so a clip's speed + curve affect every effect it animates identically.
+ */
+export function clipProgressEase(clip: {
+  easing?: ClipEasingKind
+  speed?: number
+}): (rawT: number) => number {
+  const fn = EASING_FNS[clipEasingKind(clip)]
+  const speed = clipSpeed(clip)
+  return (rawT) => fn(clamp01(rawT * speed))
+}
+
+/**
+ * The effective active duration (ms) a clip's transition actually plays over,
+ * given its speed — the rest of the window holds the pose. Shown in the UI so
+ * "finish in 1 s of a 5 s clip" reads directly.
+ */
+export function effectiveActiveMs(clip: AnimationClip): number {
+  return Math.round(clip.durationMs / clipSpeed(clip))
+}
+
+/**
+ * An SVG path string for a curve, drawn in a `size`×`size` box with `pad` inset
+ * on every edge. x = progress (0→1 left→right), y = eased output (inverted for
+ * SVG's y-down). Used by the Transition popover thumbnails and the hover dot.
+ */
+export function easingSvgPath(
+  kind: ClipEasingKind,
+  size = 100,
+  pad = 14,
+  samples = 32
+): string {
+  const fn = EASING_FNS[kind]
+  const span = size - pad * 2
+  const pts: string[] = []
+  for (let i = 0; i <= samples; i++) {
+    const t = i / samples
+    const x = pad + t * span
+    const y = pad + (1 - clamp01(fn(t))) * span
+    pts.push(`${i === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`)
+  }
+  return pts.join(" ")
+}
+
+/** The dot's {x,y} on the curve at progress t, in the same box as `easingSvgPath`. */
+export function easingDotAt(
+  kind: ClipEasingKind,
+  t: number,
+  size = 100,
+  pad = 14
+): { x: number; y: number } {
+  const fn = EASING_FNS[kind]
+  const span = size - pad * 2
+  const p = clamp01(t)
+  return {
+    x: pad + p * span,
+    y: pad + (1 - clamp01(fn(p))) * span,
+  }
+}

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -412,6 +412,15 @@ export type AnimationEffect =
   | "border"
   | "borderRadius"
 
+/** The selectable per-clip transition curves (see `clip-easing.ts`). */
+export type ClipEasingKind =
+  | "linear"
+  | "cubic"
+  | "in"
+  | "out"
+  | "inOut"
+  | "outCirc"
+
 /** A screenshot's animatable transform, captured for a clip's baseline. */
 export type ClipSlotPose = {
   tilt: Tilt
@@ -522,6 +531,18 @@ export type AnimationClip = {
    * drafts hydrate cleanly; read through `clipPose`, which prefers `pose`.
    */
   baseline?: ClipBaseline
+  /**
+   * Transition curve this clip eases its owned effects with. Optional so drafts
+   * saved before per-clip easing hydrate cleanly — read through `clipEasingKind`,
+   * which defaults to the historic ease-out. See `clip-easing.ts`.
+   */
+  easing?: ClipEasingKind
+  /**
+   * Speed remap (1..5): how quickly the transition completes WITHIN the clip's
+   * window without moving its keyframe time. 1 = uses the full window; higher
+   * finishes proportionally sooner then holds the pose. Read through `clipSpeed`.
+   */
+  speed?: number
 }
 
 /**

--- a/tests/lib/editor/animation-playback.test.ts
+++ b/tests/lib/editor/animation-playback.test.ts
@@ -202,6 +202,54 @@ describe("sampleKeyframes", () => {
   it("holds the last frame's value past the end", () => {
     expect(sampleKeyframes(frames, 9000, 0, num)).toBe(20)
   })
+
+  it("uses a frame's own ease over the default ease-out", () => {
+    const linear = [
+      { startMs: 0, durationMs: 1000, value: 10, ease: (t: number) => t },
+    ]
+    // Linear ease at 0.5 → lerp(0,10,0.5)=5, vs the ease-out default's 8.75.
+    expect(sampleKeyframes(linear, 500, 0, num)).toBeCloseTo(5, 5)
+  })
+})
+
+describe("per-clip easing & speed", () => {
+  it("clipsProgressAt applies a clip's linear easing instead of ease-out", () => {
+    const linear = [
+      clip({ id: "a", startMs: 0, durationMs: 1000, easing: "linear" }),
+    ]
+    expect(clipsProgressAt(linear, 500)).toBeCloseTo(0.5, 5)
+  })
+
+  it("clipsProgressAt still defaults to ease-out with no easing set", () => {
+    const dflt = [clip({ id: "a", startMs: 0, durationMs: 1000 })]
+    expect(clipsProgressAt(dflt, 500)).toBeCloseTo(EASED_HALF, 5)
+  })
+
+  it("clipsProgressAt completes early then holds when speed > 1", () => {
+    const fast = [
+      clip({
+        id: "a",
+        startMs: 0,
+        durationMs: 1000,
+        easing: "linear",
+        speed: 2,
+      }),
+    ]
+    // Speed 2 reaches the pose at half the window, then holds at 1.
+    expect(clipsProgressAt(fast, 250)).toBeCloseTo(0.5, 5)
+    expect(clipsProgressAt(fast, 500)).toBeCloseTo(1, 5)
+    expect(clipsProgressAt(fast, 750)).toBeCloseTo(1, 5)
+  })
+
+  it("activeClipAt reports the clip's eased progress", () => {
+    const linear = clip({
+      id: "a",
+      startMs: 0,
+      durationMs: 1000,
+      easing: "linear",
+    })
+    expect(activeClipAt([linear], 500)!.progress).toBeCloseTo(0.5, 5)
+  })
 })
 
 describe("resolveAnimateFilterStack", () => {

--- a/tests/lib/editor/clip-easing.test.ts
+++ b/tests/lib/editor/clip-easing.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  CLIP_EASING_KINDS,
+  CLIP_EASING_LABELS,
+  clipEasingKind,
+  clipProgressEase,
+  clipSpeed,
+  DEFAULT_CLIP_EASING,
+  DEFAULT_CLIP_SPEED,
+  easingDotAt,
+  easingFn,
+  easingSvgPath,
+  effectiveActiveMs,
+  MAX_CLIP_SPEED,
+  MIN_CLIP_SPEED,
+} from "@/lib/editor/clip-easing"
+import type { AnimationClip } from "@/lib/editor/state-types"
+
+const clip = (over: Partial<AnimationClip> = {}): AnimationClip => ({
+  id: "c",
+  startMs: 0,
+  durationMs: 1000,
+  ...over,
+})
+
+describe("clipEasingKind", () => {
+  it("defaults to the historic ease-out when unset", () => {
+    expect(clipEasingKind(clip())).toBe(DEFAULT_CLIP_EASING)
+    expect(DEFAULT_CLIP_EASING).toBe("out")
+  })
+
+  it("passes an explicit kind through", () => {
+    expect(clipEasingKind(clip({ easing: "linear" }))).toBe("linear")
+  })
+})
+
+describe("clipSpeed", () => {
+  it("defaults to 1 (full window) when unset", () => {
+    expect(clipSpeed(clip())).toBe(DEFAULT_CLIP_SPEED)
+    expect(DEFAULT_CLIP_SPEED).toBe(1)
+  })
+
+  it("clamps into [MIN, MAX]", () => {
+    expect(clipSpeed(clip({ speed: 0.2 }))).toBe(MIN_CLIP_SPEED)
+    expect(clipSpeed(clip({ speed: 99 }))).toBe(MAX_CLIP_SPEED)
+    expect(clipSpeed(clip({ speed: 3 }))).toBe(3)
+  })
+
+  it("falls back to the default for non-finite values", () => {
+    expect(clipSpeed(clip({ speed: Number.NaN }))).toBe(DEFAULT_CLIP_SPEED)
+    expect(clipSpeed(clip({ speed: Infinity }))).toBe(DEFAULT_CLIP_SPEED)
+  })
+})
+
+describe("easingFn", () => {
+  it("every curve pins the endpoints 0→0 and 1→1", () => {
+    for (const kind of CLIP_EASING_KINDS) {
+      const fn = easingFn(kind)
+      expect(fn(0)).toBeCloseTo(0, 6)
+      expect(fn(1)).toBeCloseTo(1, 6)
+    }
+  })
+
+  it("has the expected midpoints per curve", () => {
+    expect(easingFn("linear")(0.5)).toBeCloseTo(0.5, 6)
+    expect(easingFn("cubic")(0.5)).toBeCloseTo(0.5, 6) // symmetric S
+    expect(easingFn("in")(0.5)).toBeCloseTo(0.125, 6) // t^3
+    expect(easingFn("out")(0.5)).toBeCloseTo(0.875, 6) // 1-(1-t)^3
+    expect(easingFn("inOut")(0.5)).toBeCloseTo(0.5, 6) // symmetric S
+    expect(easingFn("outCirc")(0.5)).toBeCloseTo(Math.sqrt(0.75), 6)
+  })
+
+  it("is monotonically non-decreasing across the curve", () => {
+    for (const kind of CLIP_EASING_KINDS) {
+      const fn = easingFn(kind)
+      let prev = fn(0)
+      for (let i = 1; i <= 20; i++) {
+        const v = fn(i / 20)
+        expect(v).toBeGreaterThanOrEqual(prev - 1e-9)
+        prev = v
+      }
+    }
+  })
+})
+
+describe("clipProgressEase", () => {
+  it("an unset clip eases as ease-out over the full window", () => {
+    const p = clipProgressEase(clip())
+    expect(p(0)).toBeCloseTo(0, 6)
+    expect(p(0.5)).toBeCloseTo(0.875, 6)
+    expect(p(1)).toBeCloseTo(1, 6)
+  })
+
+  it("applies the chosen curve", () => {
+    const p = clipProgressEase(clip({ easing: "linear" }))
+    expect(p(0.5)).toBeCloseTo(0.5, 6)
+  })
+
+  it("speed compresses the ramp so it completes early then holds at 1", () => {
+    const p = clipProgressEase(clip({ easing: "linear", speed: 2 }))
+    // Reaches the pose at half the window (rawT 0.5), then holds.
+    expect(p(0.25)).toBeCloseTo(0.5, 6)
+    expect(p(0.5)).toBeCloseTo(1, 6)
+    expect(p(0.9)).toBeCloseTo(1, 6)
+  })
+
+  it("clamps raw progress outside [0,1]", () => {
+    const p = clipProgressEase(clip({ easing: "linear" }))
+    expect(p(-1)).toBeCloseTo(0, 6)
+    expect(p(2)).toBeCloseTo(1, 6)
+  })
+})
+
+describe("effectiveActiveMs", () => {
+  it("is the full duration at speed 1 and shrinks with speed", () => {
+    expect(effectiveActiveMs(clip({ durationMs: 1200 }))).toBe(1200)
+    expect(effectiveActiveMs(clip({ durationMs: 1200, speed: 2 }))).toBe(600)
+    expect(effectiveActiveMs(clip({ durationMs: 1200, speed: 5 }))).toBe(240)
+  })
+
+  it("returns a rounded integer for fractional windows", () => {
+    const ms = effectiveActiveMs(clip({ durationMs: 4488.33, speed: 5 }))
+    expect(Number.isInteger(ms)).toBe(true)
+  })
+})
+
+describe("labels & kinds", () => {
+  it("exposes exactly six kinds each with a label", () => {
+    expect(CLIP_EASING_KINDS).toHaveLength(6)
+    for (const kind of CLIP_EASING_KINDS) {
+      expect(CLIP_EASING_LABELS[kind]).toBeTruthy()
+    }
+  })
+})
+
+describe("easingSvgPath", () => {
+  it("starts with a move and has one line per sample", () => {
+    const path = easingSvgPath("linear", 100, 10, 4)
+    expect(path.startsWith("M")).toBe(true)
+    expect((path.match(/L/g) ?? []).length).toBe(4)
+  })
+
+  it("stays within the padded box", () => {
+    const path = easingSvgPath("out", 100, 12, 8)
+    const coords = path.replace(/[ML]/g, " ").trim().split(/\s+/).map(Number)
+    for (const n of coords) {
+      expect(n).toBeGreaterThanOrEqual(12 - 1e-6)
+      expect(n).toBeLessThanOrEqual(88 + 1e-6)
+    }
+  })
+})
+
+describe("easingDotAt", () => {
+  it("maps t=0 to bottom-left and t=1 to top-right of the padded box", () => {
+    const size = 100
+    const pad = 10
+    const start = easingDotAt("linear", 0, size, pad)
+    expect(start.x).toBeCloseTo(pad, 6)
+    expect(start.y).toBeCloseTo(size - pad, 6) // y is inverted (SVG y-down)
+
+    const end = easingDotAt("linear", 1, size, pad)
+    expect(end.x).toBeCloseTo(size - pad, 6)
+    expect(end.y).toBeCloseTo(pad, 6)
+  })
+})

--- a/tests/lib/editor/custom-preset-snapshot.test.ts
+++ b/tests/lib/editor/custom-preset-snapshot.test.ts
@@ -128,6 +128,33 @@ describe("custom preset snapshot", () => {
     expect(remapped.audio).toBeNull()
   })
 
+  it("preserves per-clip easing & speed through capture and apply", () => {
+    const source = canvasWithClips(["old-slot"])
+    source.animation = {
+      ...source.animation!,
+      clips: [{ ...source.animation!.clips[0], easing: "linear", speed: 2.5 }],
+    }
+    const geometry = captureCustomPresetGeometry(
+      source,
+      { id: "16-10", w: 16, h: 10 },
+      { includeAnimation: true }
+    )
+    const saved = geometry.animation!.clips[0] as {
+      easing?: string
+      speed?: number
+    }
+    expect(saved.easing).toBe("linear")
+    expect(saved.speed).toBe(2.5)
+
+    const remapped = remapAnimationForApply(
+      geometry.animation!,
+      ["new-slot"],
+      source.background
+    )
+    expect(remapped.clips[0]?.easing).toBe("linear")
+    expect(remapped.clips[0]?.speed).toBe(2.5)
+  })
+
   it("builds slot remap by index from sourceSlotIds", () => {
     const map = buildSlotIdRemap(["live-a", "live-b"], ["src-a", "src-b"], [])
     expect(map.get("src-a")).toBe("live-a")

--- a/tests/lib/editor/store/draft-persistence.test.ts
+++ b/tests/lib/editor/store/draft-persistence.test.ts
@@ -158,4 +158,61 @@ describe("draft persistence", () => {
     expect(applied.isAnimateMode).toBe(true)
     expect(applied.selectedAnimationClipId).toBe("clip-b")
   })
+
+  it("preserves per-clip transition easing & speed through hydration", () => {
+    const canvas = createCanvas("saved", { x: 0, y: 0 })
+    canvas.animation = {
+      durationMs: 4000,
+      clips: [
+        {
+          id: "clip-a",
+          startMs: 0,
+          durationMs: 1000,
+          effects: ["tilt"],
+          easing: "linear",
+          speed: 3,
+        },
+      ],
+      audio: null,
+    }
+
+    const draft: PersistedEditorDraft = {
+      id: EDITOR_DRAFT_KEY,
+      schemaVersion: EDITOR_DRAFT_SCHEMA_VERSION,
+      updatedAt: Date.now(),
+      present: {
+        activeTool: "pointer",
+        aspect: { id: "1-1", w: 1, h: 1 },
+        canvasZoom: 100,
+        annotation: {
+          mode: "pen",
+          color: "#111111",
+          strokeWidth: 4,
+          lineStyle: "solid",
+          blurEffect: "blur",
+          blurAmount: 0,
+        },
+        canvases: [canvas],
+        activeCanvasId: "saved",
+      },
+      ui: {
+        bulkEditMode: false,
+        bulkViewportZoom: 1,
+        bulkScale: 65,
+        presetTab: "custom",
+        activeLayoutPresetId: null,
+        activeCustomPresetId: null,
+        activeSinglePresetId: null,
+        previewAutoScrollDelay: 3000,
+        previewAnimation: "slide",
+        currentDraft: null,
+        isAnimateMode: true,
+      },
+    }
+
+    const applied = applyEditorDraft(draft)
+    const clip = applied.present?.canvases[0]?.animation?.clips[0]
+    expect(clip?.easing).toBe("linear")
+    expect(clip?.speed).toBe(3)
+  })
 })


### PR DESCRIPTION
## Summary

Adds a **per-clip transition system** to the Animate timeline. Each clip can now pick an easing curve (Linear / Cubic / In / Out / In Out / Out Circ) and an independent **speed** that finishes the motion early within the clip's window — *without* moving keyframe time (e.g. a 5s clip can complete its reveal in 1s, then hold). The same curve + speed drive live playback **and** GIF/WebM export, so the preview always matches the output.

This PR also bundles a few UX fixes surfaced while building the feature (Open-project dialog, image shimmer, public share player).

## Type of Change

- [x] fix
- [ ] refactor
- [ ] delete
- [x] optimised
- [ ] docs

_(Primarily a feature + fixes; no dedicated `feat` box in the template.)_

## Related Issues

<!-- none -->

## Changes Made

**Transition (easing + speed) — new capability**
- New `lib/editor/clip-easing.ts`: 6 easing curves, a `clipProgressEase(clip)` remap that composes curve + speed, and SVG-path / dot helpers shared by the popover thumbnails.
- `AnimationClip` gains optional `easing?` / `speed?`. Undefined `easing` resolves to the historic ease-out, so **existing drafts animate identically**.
- Threaded per-clip easing through the single playback path (`sampleKeyframes`, `sampleShadowLayers`, `clipsProgressAt`, `activeClipAt`) so it applies to **every** effect — position, zoom, tilt, shadow, background, lighting, border, etc. — on both the main screenshot and slots.
- New UI: `easing-curve.tsx` (curve thumbnail with a speed-aware hover dot) and `clip-transition-toolbar.tsx` (the Transition popover). Wired into `animate-controls.tsx` via a 3-column grid so the control sits far-right near the timeline **without shifting the centered play controls**. Stays visible-but-disabled during playback; the popover force-closes on play.
- Persists across **draft save/load**, **save-as-preset + apply**, and **export** (each path spreads the clip wholesale).

**Fixes**
- `shimmer-image.tsx`: the pulse now only appears after a short delay, so fast/cached thumbnails no longer flicker.
- `open-project-dialog.tsx`: the pagination bar no longer blinks out on page change (dropped `|| loading` from the hide gate), and **delete is now optimistic** with revert-on-failure — matching the shares gallery.
- `share-plyr-player.tsx`: Plyr keyboard set to `global: true` so Space / arrows / F work on the share page without clicking the player first.

## Screenshots / Recordings (if UI)

<!-- Transition popover (easing tiles + hover dot + speed slider) and the timeline control. -->

## Checklist

- [x] I ran `pnpm lint` (0 errors; 2 pre-existing warnings in unrelated files)
- [x] I ran `pnpm typecheck`
- [x] I ran `pnpm test` (622 passed)
- [x] I did not include secrets or sensitive data
- [ ] I updated docs when behavior changed
- [x] I kept this PR focused and reasonably small
