### PR TITLE
Fix WebKit video export: perspective, device-frame chrome, and layer order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ pnpm-debug.log*
 *.tsbuildinfo
 next-env.d.ts
 pack
+# local export debug dumps
+debug/

--- a/app/api/dev/export-debug/route.ts
+++ b/app/api/dev/export-debug/route.ts
@@ -1,0 +1,113 @@
+/**
+ * Dev-only endpoint: persist video/animation export debug payloads under
+ * `debug/video-export/` so Safari/WebKit filter failures can be inspected after
+ * a local export run.
+ *
+ * Disabled outside development (returns 403).
+ */
+
+import { mkdir, writeFile } from "node:fs/promises"
+import path from "node:path"
+
+import { NextResponse } from "next/server"
+
+export const runtime = "nodejs"
+
+// Dev-only, localhost: layer PNGs arrive base64-inlined and run several MB each.
+const MAX_BODY_BYTES = 64 * 1024 * 1024
+
+function isSafeSessionId(id: unknown): id is string {
+  return typeof id === "string" && /^[a-z0-9-]{6,64}$/i.test(id)
+}
+
+function isSafeKind(kind: unknown): kind is string {
+  return kind === "video-media" || kind === "animation"
+}
+
+export async function POST(request: Request) {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json(
+      { error: "export-debug is disabled in production" },
+      { status: 403 }
+    )
+  }
+
+  let body: unknown
+  try {
+    const text = await request.text()
+    if (text.length > MAX_BODY_BYTES) {
+      return NextResponse.json({ error: "payload too large" }, { status: 413 })
+    }
+    body = JSON.parse(text) as unknown
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 })
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "invalid body" }, { status: 400 })
+  }
+
+  const payload = body as {
+    sessionId?: unknown
+    kind?: unknown
+    status?: unknown
+    layers?: unknown
+  }
+
+  if (!isSafeSessionId(payload.sessionId) || !isSafeKind(payload.kind)) {
+    return NextResponse.json(
+      { error: "sessionId/kind missing or invalid" },
+      { status: 400 }
+    )
+  }
+
+  const status =
+    typeof payload.status === "string"
+      ? payload.status.replace(/[^a-z]/gi, "")
+      : "unknown"
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-")
+  const filename = `${stamp}_${payload.kind}_${payload.sessionId}_${status || "log"}.json`
+
+  const dir = path.join(process.cwd(), "debug", "video-export")
+  await mkdir(dir, { recursive: true })
+
+  // Layer PNGs go to disk as real images so they can be opened and compared;
+  // inlining megabytes of base64 into the JSON would only make it unreadable.
+  const writtenLayers: string[] = []
+  const layers = payload.layers
+  if (layers && typeof layers === "object") {
+    const base = `${stamp}_${payload.kind}_${payload.sessionId}`
+    for (const [name, value] of Object.entries(
+      layers as Record<string, unknown>
+    )) {
+      if (typeof value !== "string") continue
+      if (!/^[a-z0-9-]{1,32}$/i.test(name)) continue
+      const match = /^data:image\/png;base64,(.+)$/.exec(value)
+      if (!match) continue
+      const layerFile = `${base}_layer-${name}.png`
+      await writeFile(
+        path.join(dir, layerFile),
+        Buffer.from(match[1], "base64")
+      )
+      writtenLayers.push(layerFile)
+    }
+    delete (body as { layers?: unknown }).layers
+  }
+
+  const filePath = path.join(dir, filename)
+  await writeFile(filePath, JSON.stringify(body, null, 2), "utf8")
+
+  const rel = path.join("debug", "video-export", filename)
+  console.info(`[export-debug] wrote ${rel}`)
+  for (const layer of writtenLayers) {
+    console.info(
+      `[export-debug] wrote ${path.join("debug", "video-export", layer)}`
+    )
+  }
+
+  return NextResponse.json({
+    ok: true,
+    path: rel,
+    layers: writtenLayers,
+  })
+}

--- a/components/editor/annotation-shape/element.tsx
+++ b/components/editor/annotation-shape/element.tsx
@@ -493,6 +493,7 @@ export function AnnotationShapeElement({
         onPointerUp={endDrag}
         onPointerCancel={endDrag}
         data-annotation-shape-id={shape.id}
+        data-export-stack="foreground"
         style={{
           left: `var(--editor-position-x, ${shape.xPct}%)`,
           top: `var(--editor-position-y, ${shape.yPct}%)`,

--- a/components/editor/asset-element.tsx
+++ b/components/editor/asset-element.tsx
@@ -347,6 +347,7 @@ export function AssetElementView({
         onPointerCancel={endDrag}
         onClick={select}
         data-editor-asset-id={asset.id}
+        data-export-stack="foreground"
         className={cn(
           "nodrag nopan absolute touch-none select-none",
           isSelected ? "cursor-grabbing" : "cursor-grab"

--- a/components/editor/canvas/annotation-layer.tsx
+++ b/components/editor/canvas/annotation-layer.tsx
@@ -53,6 +53,7 @@ export function AnnotationLayer({
         <svg
           key={stroke.id}
           aria-hidden
+          data-export-stack="foreground"
           className="pointer-events-none absolute inset-0 h-full w-full touch-none"
           style={{
             zIndex: 60 + (stroke.zIndex ?? 0),

--- a/components/editor/canvas/canvas-backdrop.tsx
+++ b/components/editor/canvas/canvas-backdrop.tsx
@@ -307,7 +307,13 @@ function CanvasBackdropImpl({
   )
 
   return (
-    <>
+    // data-export-stack=underlay: video-media export composites the decoded
+    // frame between this backdrop and foreground overlays (text/lighting/…).
+    <div
+      data-export-stack="underlay"
+      className="pointer-events-none absolute inset-0"
+      aria-hidden
+    >
       {/*
         Background + patterns + noise form the blend group: the noise layer uses
         mix-blend-overlay and only ever needs to blend against these siblings.
@@ -572,7 +578,7 @@ function CanvasBackdropImpl({
           }}
         />
       ) : null}
-    </>
+    </div>
   )
 }
 

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -1436,6 +1436,7 @@ function CanvasViewInner({
                     return style ? (
                       <div
                         aria-hidden
+                        data-export-stack="foreground"
                         className="pointer-events-none absolute inset-0 bg-cover bg-center"
                         style={{ ...style, zIndex: 200 }}
                       />
@@ -1453,6 +1454,7 @@ function CanvasViewInner({
                   <div
                     key={layer.id}
                     aria-hidden
+                    data-export-stack="foreground"
                     className="pointer-events-none absolute inset-0 bg-cover bg-center"
                     style={{ ...style, zIndex: 200 }}
                   />
@@ -1462,6 +1464,7 @@ function CanvasViewInner({
           ) : overlay.id !== null && overlay.position === "overlay" ? (
             <div
               aria-hidden
+              data-export-stack="foreground"
               className="pointer-events-none absolute inset-0 bg-cover bg-center"
               style={{
                 backgroundImage: `url("${overlayUrl(overlay.id)}")`,

--- a/components/editor/canvas/helpers.ts
+++ b/components/editor/canvas/helpers.ts
@@ -525,7 +525,13 @@ export function framePositionedStyle({
     top: "50%",
     transform: framePositionTransform({ anchor, offset, transform, rotation }),
     transformOrigin: "center",
-    transformStyle: "preserve-3d",
+    // Deliberately no preserve-3d. Everything in this box is coplanar (the frame
+    // chrome and the lighting overlay above it), and a 3D rendering context makes
+    // WebKit sort children by depth rather than honor z-index — painting the
+    // z-10 lighting behind the opaque frame. It only appeared to work when a
+    // shadow or enhance filter was set, since a non-none `filter` is a grouping
+    // property that forces transform-style to compute to flat. `perspective()`
+    // in the transform tilts this element either way.
     filter,
     ...(layer
       ? {

--- a/components/editor/canvas/inner-lighting-overlay.tsx
+++ b/components/editor/canvas/inner-lighting-overlay.tsx
@@ -19,6 +19,7 @@ export function InnerLightingOverlay({
   return (
     <div
       aria-hidden
+      data-export-stack="foreground"
       className={cn("pointer-events-none absolute inset-0 z-10", className)}
       style={style}
     />

--- a/components/editor/canvas/screenshot-bare.tsx
+++ b/components/editor/canvas/screenshot-bare.tsx
@@ -455,6 +455,7 @@ export function ScreenshotBare({
           ref={setVideoShellRef}
           data-box-hover-target
           data-editor-shadow-box-target={shadowBoxTarget ? "" : undefined}
+          data-export-stack="media"
           style={videoShellStyle}
           className={cn(
             mediaClassName,
@@ -486,6 +487,7 @@ export function ScreenshotBare({
           shimmer
           data-box-hover-target
           data-editor-shadow-box-target={shadowBoxTarget ? "" : undefined}
+          data-export-stack="media"
           src={screenshot}
           alt="Screenshot"
           draggable={false}
@@ -503,6 +505,9 @@ export function ScreenshotBare({
       {innerLightingStyle && !screenshotLayer.hidden ? (
         <div
           aria-hidden
+          // Foreground stack: video-media export captures this above the
+          // decoded frame so lighting (and siblings) sit on top of the video.
+          data-export-stack="foreground"
           className={cn(
             "pointer-events-none absolute z-10",
             isScreenshotDragging ||

--- a/components/editor/canvas/screenshot-mockup.tsx
+++ b/components/editor/canvas/screenshot-mockup.tsx
@@ -275,6 +275,12 @@ export function ScreenshotMockup({
           alt=""
           draggable={false}
           data-editor-enhance-filter=""
+          // Frame chrome (bezel + notch) sits above the media at z-10. The
+          // video-media composite paints the decoded frame in 2D over the
+          // underlay, so it must re-draw this on top or an opaque cover-fit video
+          // would bury the bezel. It stays untagged (in the underlay too) so the
+          // frame's drop-shadow keeps following the PNG silhouette.
+          data-export-frame-chrome=""
           className="pointer-events-none absolute inset-0 z-10 h-full w-full object-contain select-none"
         />
 

--- a/components/editor/screenshot-slot-element.tsx
+++ b/components/editor/screenshot-slot-element.tsx
@@ -307,6 +307,7 @@ export function ScreenshotSlotRender({
       data-box-hover-target={previewMode ? undefined : ""}
       data-screenshot-slot-id={previewMode ? undefined : slot.id}
       data-editor-shadow-preview-scope={previewMode ? undefined : slot.id}
+      data-export-stack="foreground"
       onPointerDown={previewMode ? undefined : onPointerDown}
       onPointerMove={previewMode ? undefined : onPointerMove}
       onPointerUp={previewMode ? undefined : onPointerUp}

--- a/components/editor/text-element.tsx
+++ b/components/editor/text-element.tsx
@@ -104,6 +104,7 @@ export function TextElementView({
         onPointerUp={endDrag}
         onPointerCancel={endDrag}
         data-editor-text-id={text.id}
+        data-export-stack="foreground"
         onClick={(e) => {
           e.stopPropagation()
           selectTextElement()

--- a/lib/editor/animation-export/capture.ts
+++ b/lib/editor/animation-export/capture.ts
@@ -15,6 +15,11 @@ import {
 } from "../export"
 import type { AnimationClip, CanvasState } from "../state-types"
 import { blankFrame, isDrawImageSource, snapshotFrame } from "./draw-utils"
+import {
+  exportDebugLog,
+  getActiveExportDebug,
+  sampleFrameStats,
+} from "./export-debug"
 import type { AnimationCaptureMode } from "./types"
 import { waitForPaint } from "./utils"
 import type { CloneVideoLayer } from "./video-layer"
@@ -32,18 +37,58 @@ export async function acquireAnimationCapture(
   targetWidth: number,
   mode: AnimationCaptureMode
 ): Promise<AnimationCapture> {
-  if (mode === "legacy") return prepareAnimationCapture(canvasId, targetWidth)
-  if (mode === "fast") return prepareFastAnimationCapture(canvasId, targetWidth)
+  exportDebugLog("info", "capture.acquire", "resolving capture strategy", {
+    mode,
+    targetWidth,
+    canvasId,
+  })
+  if (mode === "legacy") {
+    const cap = await prepareAnimationCapture(canvasId, targetWidth)
+    exportDebugLog("info", "capture.acquire", "using legacy html-to-image", {
+      width: cap.width,
+      height: cap.height,
+      needsPaint: cap.needsPaint,
+    })
+    getActiveExportDebug()?.setMeta("captureStrategy", "legacy")
+    return cap
+  }
+  if (mode === "fast") {
+    const cap = await prepareFastAnimationCapture(canvasId, targetWidth)
+    exportDebugLog("info", "capture.acquire", "using fast path", {
+      width: cap.width,
+      height: cap.height,
+      needsPaint: cap.needsPaint,
+    })
+    getActiveExportDebug()?.setMeta("captureStrategy", "fast")
+    return cap
+  }
 
   // auto
   try {
-    return await prepareFastAnimationCapture(canvasId, targetWidth)
+    const cap = await prepareFastAnimationCapture(canvasId, targetWidth)
+    exportDebugLog("info", "capture.acquire", "auto → fast path", {
+      width: cap.width,
+      height: cap.height,
+      needsPaint: cap.needsPaint,
+    })
+    getActiveExportDebug()?.setMeta("captureStrategy", "auto-fast")
+    return cap
   } catch (err) {
     console.warn(
       "[export] fast capture setup failed, using html-to-image:",
       err
     )
-    return prepareAnimationCapture(canvasId, targetWidth)
+    exportDebugLog(
+      "warn",
+      "capture.acquire",
+      "fast setup failed, falling back to legacy html-to-image",
+      {
+        error: err instanceof Error ? err.message : String(err),
+      }
+    )
+    const cap = await prepareAnimationCapture(canvasId, targetWidth)
+    getActiveExportDebug()?.setMeta("captureStrategy", "auto-legacy-fallback")
+    return cap
   }
 }
 
@@ -89,8 +134,16 @@ const clamp01 = (n: number) => Math.max(0, Math.min(1, n))
  * `makeExportStyle`) and the effect is reconstructed here in 2D: blur the frame,
  * keep it only inside the masked band, and composite it back at the overlay's
  * (possibly animated) opacity. Reads the live clone so crossfades are respected.
+ *
+ * Must run on the *finished* frame: these overlays sit at z-index 200, above the
+ * media, so the blur is meant to catch the screenshot/video too — not just the
+ * backdrop. Only `blur`/`stage` are tagged; the gradient portrait modes render
+ * natively and are never neutralized.
  */
-function drawPortraitDepthOfField(frame: HTMLCanvasElement, node: HTMLElement) {
+export function drawPortraitDepthOfField(
+  frame: HTMLCanvasElement,
+  node: HTMLElement
+) {
   const els = node.querySelectorAll<HTMLElement>("[data-export-portrait-fx]")
   if (els.length === 0) return
   const ctx = frame.getContext("2d")
@@ -189,6 +242,7 @@ export async function captureStableFrame(
   timeMs: number,
   videoLayer?: CloneVideoLayer | null
 ): Promise<HTMLCanvasElement> {
+  const t0 = performance.now()
   // Non-null only for a video canvas: paints this frame's decoded pixels into
   // the clone, which otherwise rasterizes the video's box empty.
   await videoLayer?.paint(timeMs)
@@ -198,17 +252,40 @@ export async function captureStableFrame(
   // reads live computed styles and does.
   if (capture.needsPaint) await waitForPaint()
   let raw: unknown
+  let usedBlank = false
+  let retried = false
   try {
     raw = await capture.captureFrame()
-  } catch {
+  } catch (err) {
+    exportDebugLog(
+      "warn",
+      "capture.stable",
+      "captureFrame threw — returning blank frame",
+      {
+        timeMs,
+        error: err instanceof Error ? err.message : String(err),
+      }
+    )
+    usedBlank = true
     return blankFrame(capture.width, capture.height)
   }
   // html-to-image is flaky on some browsers — one retry after another paint.
   if (!isDrawImageSource(raw)) {
+    retried = true
     if (capture.needsPaint) await waitForPaint()
     try {
       raw = await capture.captureFrame()
-    } catch {
+    } catch (err) {
+      exportDebugLog(
+        "warn",
+        "capture.stable",
+        "captureFrame retry threw — returning blank frame",
+        {
+          timeMs,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      )
+      usedBlank = true
       return blankFrame(capture.width, capture.height)
     }
   }
@@ -216,5 +293,18 @@ export async function captureStableFrame(
   // Re-draw portrait blur/stage DoF (backdrop-filter can't rasterize) as content,
   // before any watermark. Reads the clone so animated crossfade opacity applies.
   drawPortraitDepthOfField(frame, capture.node)
+
+  const dbg = getActiveExportDebug()
+  if (dbg) {
+    // Approximate frame index from time for sampling throttle.
+    const approxIndex = Math.max(0, Math.round(timeMs / 33.33))
+    dbg.logFrameSample("capture.stable", approxIndex, 9999, frame, {
+      timeMs,
+      retried,
+      usedBlank,
+      durationMs: Math.round(performance.now() - t0),
+      stats: sampleFrameStats(frame),
+    })
+  }
   return frame
 }

--- a/lib/editor/animation-export/capture.ts
+++ b/lib/editor/animation-export/capture.ts
@@ -125,6 +125,141 @@ function applyExportFrame(
 const clamp01 = (n: number) => Math.max(0, Math.min(1, n))
 
 /**
+ * Whether `CanvasRenderingContext2D.filter` actually blurs. WebKit accepts the
+ * assignment but ignores it — `drawImage` comes back sharp — so a plain
+ * `ctx.filter = "blur()"` silently no-ops the portrait DoF on Safari. Probed once
+ * by blurring a 1px dark dot and checking the darkness bled to its neighbour.
+ */
+let canvasFilterBlurs: boolean | null = null
+function supportsCanvasFilterBlur(): boolean {
+  if (canvasFilterBlurs !== null) return canvasFilterBlurs
+  try {
+    const c = document.createElement("canvas")
+    c.width = 3
+    c.height = 1
+    const cx = c.getContext("2d", { willReadFrequently: true })
+    if (!cx) return (canvasFilterBlurs = false)
+    cx.fillStyle = "#fff"
+    cx.fillRect(0, 0, 3, 1)
+    cx.filter = "blur(1px)"
+    cx.fillStyle = "#000"
+    cx.fillRect(1, 0, 1, 1)
+    cx.filter = "none"
+    // If blur worked the black bled into pixel 0, dropping it below white.
+    canvasFilterBlurs = cx.getImageData(0, 0, 1, 1).data[0] < 250
+  } catch {
+    canvasFilterBlurs = false
+  }
+  return canvasFilterBlurs
+}
+
+function makeCanvas(w: number, h: number): HTMLCanvasElement {
+  const c = document.createElement("canvas")
+  c.width = Math.max(1, Math.round(w))
+  c.height = Math.max(1, Math.round(h))
+  return c
+}
+
+/**
+ * One separable box-blur pass, edge-clamped, reading `src` and writing `dst`
+ * (they must differ — a sliding window can't blur in place). `stride`/`count` and
+ * `lineStride`/`lines` let the same code run horizontally and vertically.
+ */
+function boxBlurPass(
+  src: Uint8ClampedArray,
+  dst: Uint8ClampedArray,
+  lines: number,
+  lineStart: number,
+  lineStride: number,
+  count: number,
+  stride: number,
+  radius: number
+): void {
+  const norm = 1 / (radius * 2 + 1)
+  for (let line = 0; line < lines; line++) {
+    const base = line * lineStride + lineStart
+    for (let c = 0; c < 4; c++) {
+      let sum = 0
+      for (let k = -radius; k <= radius; k++) {
+        const i = k < 0 ? 0 : k >= count ? count - 1 : k
+        sum += src[base + i * stride + c]
+      }
+      for (let x = 0; x < count; x++) {
+        dst[base + x * stride + c] = sum * norm
+        const addI = x + radius + 1
+        const subI = x - radius
+        const a = addI >= count ? count - 1 : addI
+        const s = subI < 0 ? 0 : subI
+        sum += src[base + a * stride + c] - src[base + s * stride + c]
+      }
+    }
+  }
+}
+
+/**
+ * Blur `src` into `dstCtx`. Native canvas `filter` where it works; on WebKit a
+ * real 3-pass separable box blur (a close, smooth Gaussian approximation —
+ * `ctx.filter` no-ops and a downscale/upscale trick prints visible blocks). Run
+ * at a capped working resolution: a heavy blur carries no fine detail, so
+ * shrinking first keeps 4K/8K fast without changing the look.
+ */
+function blurFrameInto(
+  dstCtx: CanvasRenderingContext2D,
+  src: HTMLCanvasElement,
+  blurPx: number
+): void {
+  const w = src.width
+  const h = src.height
+  if (blurPx < 0.5) {
+    dstCtx.drawImage(src, 0, 0)
+    return
+  }
+  if (supportsCanvasFilterBlur()) {
+    dstCtx.filter = `blur(${blurPx}px)`
+    dstCtx.drawImage(src, 0, 0)
+    dstCtx.filter = "none"
+    return
+  }
+
+  const MAX_WORK_W = 1280
+  const scale = Math.min(1, MAX_WORK_W / w)
+  const ww = Math.max(1, Math.round(w * scale))
+  const wh = Math.max(1, Math.round(h * scale))
+  const work = makeCanvas(ww, wh)
+  const wctx = work.getContext("2d", { willReadFrequently: true })
+  if (!wctx) {
+    dstCtx.drawImage(src, 0, 0)
+    return
+  }
+  wctx.imageSmoothingEnabled = true
+  wctx.imageSmoothingQuality = "high"
+  wctx.drawImage(src, 0, 0, w, h, 0, 0, ww, wh)
+
+  // CSS blur(σ) is a Gaussian of std-dev σ; three box passes of radius ≈ σ
+  // approximate it well. Clamp so a 1px working buffer can't underflow.
+  const radius = Math.max(
+    1,
+    Math.min(Math.round(blurPx * scale), (Math.min(ww, wh) >> 1) - 1)
+  )
+  if (radius >= 1) {
+    const img = wctx.getImageData(0, 0, ww, wh)
+    const a = img.data
+    const b = new Uint8ClampedArray(a.length)
+    for (let pass = 0; pass < 3; pass++) {
+      // Horizontal: each row, pixels stride 4, rows stride ww*4.
+      boxBlurPass(a, b, wh, 0, ww * 4, ww, 4, radius)
+      // Vertical: each column, pixels stride ww*4, columns stride 4.
+      boxBlurPass(b, a, ww, 0, 4, wh, ww * 4, radius)
+    }
+    wctx.putImageData(img, 0, 0)
+  }
+
+  dstCtx.imageSmoothingEnabled = true
+  dstCtx.imageSmoothingQuality = "high"
+  dstCtx.drawImage(work, 0, 0, ww, wh, 0, 0, w, h)
+}
+
+/**
  * Re-draw portrait `blur`/`stage` depth-of-field onto a captured frame.
  *
  * These modes fake DoF with `backdrop-filter: blur()` + a vertical gradient mask
@@ -140,16 +275,42 @@ const clamp01 = (n: number) => Math.max(0, Math.min(1, n))
  * backdrop. Only `blur`/`stage` are tagged; the gradient portrait modes render
  * natively and are never neutralized.
  */
+/** The debug session the portrait numbers were last logged for (once per export). */
+let portraitDbgSession: unknown = null
+
 export function drawPortraitDepthOfField(
   frame: HTMLCanvasElement,
   node: HTMLElement
 ) {
+  const dbgSession = getActiveExportDebug()
+  const portraitDbgLogged =
+    dbgSession != null && dbgSession === portraitDbgSession
   const els = node.querySelectorAll<HTMLElement>("[data-export-portrait-fx]")
   if (els.length === 0) return
   const ctx = frame.getContext("2d")
   const nodeRect = node.getBoundingClientRect()
   if (!ctx || !nodeRect.height) return
+  // Geometry (box position/height) maps the clone's own layout → frame px.
   const scaleY = frame.height / nodeRect.height
+
+  // Blur magnitude is different: the overlay's blur is `Xem` — a FIXED px size
+  // that doesn't scale with the canvas. The export clone lays out larger than the
+  // live editor canvas (it's sized to the export resolution), so that fixed blur
+  // renders proportionally weaker on the clone than the user sees on screen — and
+  // weaker still at 4K/8K. Reference the live canvas the effect was calibrated
+  // against so the blur keeps the same fraction of the frame it has in the editor.
+  // offsetHeight ignores the editor's zoom transform (display-only, must not leak
+  // into the export). Falls back to the clone when the live canvas isn't found.
+  const canvasId = node.getAttribute("data-canvas-id")
+  const liveCanvas = canvasId
+    ? document.querySelector<HTMLElement>(
+        `[data-canvas-id="${canvasId}"]:not([data-export-scope])`
+      )
+    : null
+  const blurScaleY =
+    liveCanvas && liveCanvas.offsetHeight > 0
+      ? frame.height / liveCanvas.offsetHeight
+      : scaleY
 
   for (const el of Array.from(els)) {
     const cs = window.getComputedStyle(el)
@@ -190,7 +351,43 @@ export function drawPortraitDepthOfField(
 
     const blurEm = (100 - clamp01(distance / 100) * 100) * 0.01
     const fontSize = parseFloat(cs.fontSize) || 16
-    const blurPx = blurEm * fontSize * scaleY
+    const blurPx = blurEm * fontSize * blurScaleY
+
+    // Dump the reconstruction as PNG layers (once per export) so the blur can be
+    // inspected directly instead of inferred from the numbers.
+    const doSnapshot = !!dbgSession && !portraitDbgLogged
+    if (dbgSession && !portraitDbgLogged) {
+      portraitDbgSession = dbgSession
+      getActiveExportDebug()?.addLayerSnapshot("portrait-before", frame)
+      exportDebugLog(
+        "info",
+        "renderer.portrait",
+        "depth-of-field reconstruct",
+        {
+          mode,
+          opacity,
+          position,
+          distance,
+          intensity,
+          fontSizePx: fontSize,
+          scaleY: Number(scaleY.toFixed(3)),
+          blurScaleY: Number(blurScaleY.toFixed(3)),
+          liveCanvasH: liveCanvas?.offsetHeight ?? null,
+          cloneH: Math.round(nodeRect.height),
+          blurEm: Number(blurEm.toFixed(3)),
+          blurPx: Number(blurPx.toFixed(2)),
+          maskStops: {
+            s0: Number(s0.toFixed(3)),
+            s1: Number(s1.toFixed(3)),
+            s2: Number(s2.toFixed(3)),
+          },
+          boxTop: Math.round(boxTop),
+          boxH: Math.round(boxH),
+          frame: { w: frame.width, h: frame.height },
+          willBlur: blurPx >= 0.5,
+        }
+      )
+    }
 
     if (blurPx >= 0.5) {
       const layer = document.createElement("canvas")
@@ -198,12 +395,14 @@ export function drawPortraitDepthOfField(
       layer.height = frame.height
       const lc = layer.getContext("2d")
       if (lc) {
-        lc.filter = `blur(${blurPx}px)`
-        lc.drawImage(frame, 0, 0)
-        lc.filter = "none"
+        // ctx.filter blur no-ops on WebKit — use the feature-tested blur instead.
+        blurFrameInto(lc, frame, blurPx)
         lc.globalCompositeOperation = "destination-in"
         lc.fillStyle = makeMask(lc)
         lc.fillRect(0, boxTop, frame.width, boxH)
+        if (doSnapshot) {
+          getActiveExportDebug()?.addLayerSnapshot("portrait-blur-layer", layer)
+        }
         ctx.save()
         ctx.globalAlpha = opacity
         ctx.drawImage(layer, 0, 0)
@@ -230,6 +429,10 @@ export function drawPortraitDepthOfField(
           ctx.restore()
         }
       }
+    }
+
+    if (doSnapshot) {
+      getActiveExportDebug()?.addLayerSnapshot("portrait-after", frame)
     }
   }
 }

--- a/lib/editor/animation-export/export-debug.ts
+++ b/lib/editor/animation-export/export-debug.ts
@@ -537,7 +537,7 @@ export class ExportDebugSession {
    */
   addLayerSnapshot(name: string, canvas: HTMLCanvasElement) {
     if (this.finished) return
-    if (Object.keys(this.layers).length >= 8) return
+    if (Object.keys(this.layers).length >= 20) return
     if (!canvas.width || !canvas.height) return
     try {
       this.layers[name] = canvas.toDataURL("image/png")

--- a/lib/editor/animation-export/export-debug.ts
+++ b/lib/editor/animation-export/export-debug.ts
@@ -1,0 +1,664 @@
+/**
+ * Video/animation export debug logger.
+ *
+ * Captures structured logs for a single export run, then persists them to
+ * `debug/video-export/` via `/api/dev/export-debug` (local `pnpm dev`), with
+ * a JSON download fallback when the API is unavailable.
+ *
+ * Enable:
+ *  - always in development (`NODE_ENV === "development"`)
+ *  - or `localStorage.setItem("tokokino:export-debug", "1")`
+ *  - or URL `?exportDebug=1`
+ */
+
+import type { CanvasState } from "../state-types"
+
+export type ExportDebugKind = "video-media" | "animation"
+
+export type ExportDebugLevel = "debug" | "info" | "warn" | "error"
+
+export type ExportDebugEntry = {
+  t: number
+  level: ExportDebugLevel
+  tag: string
+  message: string
+  data?: unknown
+}
+
+export type FrameSampleStats = {
+  width: number
+  height: number
+  sampleCount: number
+  meanR: number
+  meanG: number
+  meanB: number
+  meanA: number
+  nonBlackPct: number
+  fullyTransparentPct: number
+  likelyBlack: boolean
+  likelyBlank: boolean
+}
+
+export type ExportDebugPayload = {
+  sessionId: string
+  kind: ExportDebugKind
+  status: "success" | "error" | "aborted"
+  startedAt: string
+  finishedAt: string
+  durationMs: number
+  meta: Record<string, unknown>
+  entries: ExportDebugEntry[]
+  /**
+   * PNG data URLs of individual composite layers, written next to the JSON as
+   * files. Every geometry number in this log is measured on the export clone,
+   * so a clone that is itself wrong reads as perfectly self-consistent — the
+   * only way past that is to look at the actual pixels of each layer.
+   */
+  layers?: Record<string, string>
+  error?: { name: string; message: string; stack?: string }
+}
+
+const STORAGE_KEY = "tokokino:export-debug"
+const CONSOLE_PREFIX = "[export-debug]"
+
+let activeSession: ExportDebugSession | null = null
+
+function nowMs() {
+  return typeof performance !== "undefined" ? performance.now() : Date.now()
+}
+
+function safeJsonClone<T>(value: T): T | string {
+  try {
+    return JSON.parse(JSON.stringify(value)) as T
+  } catch {
+    return String(value)
+  }
+}
+
+function errPayload(err: unknown): {
+  name: string
+  message: string
+  stack?: string
+} {
+  if (err instanceof Error) {
+    return {
+      name: err.name,
+      message: err.message,
+      stack: err.stack,
+    }
+  }
+  return { name: "UnknownError", message: String(err) }
+}
+
+/** Collect browser/engine facts useful for Safari/WebKit filter bugs. */
+export function collectBrowserMeta(): Record<string, unknown> {
+  if (typeof navigator === "undefined") {
+    return { env: "non-browser" }
+  }
+  const ua = navigator.userAgent
+  const isSafari =
+    /Safari\//i.test(ua) && !/Chrome\//i.test(ua) && !/Chromium\//i.test(ua)
+  const isFirefox = /Firefox\//i.test(ua) || /FxiOS\//i.test(ua)
+  const isWebKit =
+    /AppleWebKit\//i.test(ua) &&
+    !/Chrome\//i.test(ua) &&
+    !/Chromium\//i.test(ua)
+  const isIos =
+    /iPad|iPhone|iPod/.test(ua) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+
+  let objectViewBox = false
+  try {
+    objectViewBox =
+      typeof CSS !== "undefined" &&
+      typeof CSS.supports === "function" &&
+      CSS.supports("object-view-box", "inset(0%)")
+  } catch {
+    objectViewBox = false
+  }
+
+  return {
+    userAgent: ua,
+    platform: navigator.platform,
+    vendor: navigator.vendor,
+    language: navigator.language,
+    isSafari,
+    isFirefox,
+    isWebKit,
+    isIos,
+    supportsObjectViewBox: objectViewBox,
+    videoEncoder: typeof VideoEncoder !== "undefined",
+    videoDecoder: typeof VideoDecoder !== "undefined",
+    mediaRecorder: typeof MediaRecorder !== "undefined",
+    devicePixelRatio:
+      typeof window !== "undefined" ? window.devicePixelRatio : null,
+    screen:
+      typeof screen !== "undefined"
+        ? { width: screen.width, height: screen.height }
+        : null,
+    viewport:
+      typeof window !== "undefined"
+        ? { width: window.innerWidth, height: window.innerHeight }
+        : null,
+  }
+}
+
+/** Snapshot of canvas style props that commonly break Safari export. */
+export function collectCanvasStyleSnapshot(
+  canvas: CanvasState
+): Record<string, unknown> {
+  return {
+    id: canvas.id,
+    hasScreenshot: !!canvas.screenshot,
+    screenshotKind: canvas.screenshot
+      ? canvas.screenshot.startsWith("blob:")
+        ? "blob"
+        : canvas.screenshot.startsWith("data:")
+          ? "data"
+          : "url"
+      : null,
+    background: canvas.background,
+    padding: canvas.padding,
+    borderRadius: canvas.borderRadius,
+    canvasBorderRadius: canvas.canvasBorderRadius,
+    border: canvas.border,
+    tilt: canvas.tilt,
+    scale: canvas.scale,
+    shadow: canvas.shadow,
+    overlay: canvas.overlay,
+    frame: canvas.frame,
+    portrait: canvas.portrait,
+    enhance: canvas.enhance,
+    objectFit: canvas.objectFit,
+    screenshotLayer: canvas.screenshotLayer,
+    backdrop: canvas.backdrop,
+    animationClipCount: canvas.animation?.clips?.length ?? 0,
+    videoClipCount: canvas.videoClips?.length ?? 0,
+    screenshotSlotCount: canvas.screenshotSlots?.length ?? 0,
+    textCount: canvas.texts?.length ?? 0,
+    assetCount: canvas.assets?.length ?? 0,
+  }
+}
+
+/**
+ * Sample sparse pixel stats from a canvas to detect black/blank/corrupt frames
+ * (the typical Safari filter/foreignObject failure mode).
+ */
+export function sampleFrameStats(
+  source: CanvasImageSource | HTMLCanvasElement | null | undefined,
+  label?: string
+): FrameSampleStats | null {
+  if (!source) return null
+  try {
+    const width =
+      "width" in source && typeof source.width === "number"
+        ? source.width
+        : "videoWidth" in source
+          ? Number((source as { videoWidth: number }).videoWidth)
+          : 0
+    const height =
+      "height" in source && typeof source.height === "number"
+        ? source.height
+        : "videoHeight" in source
+          ? Number((source as { videoHeight: number }).videoHeight)
+          : 0
+    if (!width || !height) {
+      return {
+        width: 0,
+        height: 0,
+        sampleCount: 0,
+        meanR: 0,
+        meanG: 0,
+        meanB: 0,
+        meanA: 0,
+        nonBlackPct: 0,
+        fullyTransparentPct: 100,
+        likelyBlack: true,
+        likelyBlank: true,
+      }
+    }
+
+    const probe = document.createElement("canvas")
+    // Downsample so sampling stays cheap even at 4K.
+    const maxEdge = 64
+    const scale = Math.min(1, maxEdge / Math.max(width, height))
+    probe.width = Math.max(1, Math.round(width * scale))
+    probe.height = Math.max(1, Math.round(height * scale))
+    const ctx = probe.getContext("2d", { willReadFrequently: true })
+    if (!ctx) return null
+    ctx.drawImage(source, 0, 0, probe.width, probe.height)
+    const { data } = ctx.getImageData(0, 0, probe.width, probe.height)
+
+    let r = 0
+    let g = 0
+    let b = 0
+    let a = 0
+    let nonBlack = 0
+    let transparent = 0
+    const pixels = data.length / 4
+    for (let i = 0; i < data.length; i += 4) {
+      const pr = data[i] ?? 0
+      const pg = data[i + 1] ?? 0
+      const pb = data[i + 2] ?? 0
+      const pa = data[i + 3] ?? 0
+      r += pr
+      g += pg
+      b += pb
+      a += pa
+      if (pa < 8) transparent++
+      else if (pr > 8 || pg > 8 || pb > 8) nonBlack++
+    }
+
+    const meanR = r / pixels
+    const meanG = g / pixels
+    const meanB = b / pixels
+    const meanA = a / pixels
+    const nonBlackPct = (nonBlack / pixels) * 100
+    const fullyTransparentPct = (transparent / pixels) * 100
+    const likelyBlank = fullyTransparentPct > 95 || pixels === 0
+    const likelyBlack =
+      !likelyBlank && nonBlackPct < 2 && meanR < 8 && meanG < 8 && meanB < 8
+
+    const stats: FrameSampleStats = {
+      width,
+      height,
+      sampleCount: pixels,
+      meanR: Math.round(meanR * 10) / 10,
+      meanG: Math.round(meanG * 10) / 10,
+      meanB: Math.round(meanB * 10) / 10,
+      meanA: Math.round(meanA * 10) / 10,
+      nonBlackPct: Math.round(nonBlackPct * 100) / 100,
+      fullyTransparentPct: Math.round(fullyTransparentPct * 100) / 100,
+      likelyBlack,
+      likelyBlank,
+    }
+    if (label) {
+      // label is only for call-site context; stats object stays pure
+      void label
+    }
+    return stats
+  } catch {
+    return null
+  }
+}
+
+type FilterHit = {
+  tag: string
+  id?: string | null
+  className?: string
+  dataAttrs: Record<string, string>
+  filter: string
+  webkitFilter: string
+  backdropFilter: string
+  webkitBackdropFilter: string
+  boxShadow: string
+  opacity: string
+  mixBlendMode: string
+  maskImage: string
+  webkitMaskImage: string
+  transform: string
+  inlineFilter?: string
+  inlineWebkitFilter?: string
+}
+
+/** Walk the clone for elements whose filter/backdrop-filter/shadow may break WebKit. */
+export function collectCloneFilterHits(
+  root: HTMLElement,
+  limit = 80
+): FilterHit[] {
+  const hits: FilterHit[] = []
+  const nodes = [root, ...Array.from(root.querySelectorAll<HTMLElement>("*"))]
+  for (const el of nodes) {
+    if (hits.length >= limit) break
+    let cs: CSSStyleDeclaration
+    try {
+      cs = getComputedStyle(el)
+    } catch {
+      continue
+    }
+    const filter = cs.filter || "none"
+    const webkitFilter =
+      (cs as CSSStyleDeclaration & { webkitFilter?: string }).webkitFilter ||
+      cs.getPropertyValue("-webkit-filter") ||
+      "none"
+    const backdropFilter = cs.backdropFilter || "none"
+    const webkitBackdropFilter =
+      cs.getPropertyValue("-webkit-backdrop-filter") || "none"
+    const boxShadow = cs.boxShadow || "none"
+    const maskImage = cs.maskImage || "none"
+    const webkitMaskImage = cs.getPropertyValue("-webkit-mask-image") || "none"
+    const transform = cs.transform || "none"
+    const opacity = cs.opacity || "1"
+    const mixBlendMode = cs.mixBlendMode || "normal"
+    const inlineFilter = el.style.filter || undefined
+    const inlineWebkitFilter =
+      el.style.getPropertyValue("-webkit-filter") || undefined
+
+    const interesting =
+      (filter && filter !== "none") ||
+      (webkitFilter && webkitFilter !== "none") ||
+      (backdropFilter && backdropFilter !== "none") ||
+      (webkitBackdropFilter && webkitBackdropFilter !== "none") ||
+      (boxShadow && boxShadow !== "none") ||
+      (maskImage && maskImage !== "none") ||
+      (webkitMaskImage && webkitMaskImage !== "none") ||
+      (transform && transform !== "none") ||
+      (mixBlendMode && mixBlendMode !== "normal") ||
+      !!inlineFilter ||
+      !!inlineWebkitFilter ||
+      el.hasAttribute("data-editor-shadow-filter-target") ||
+      el.hasAttribute("data-editor-shadow-box-target") ||
+      el.hasAttribute("data-export-portrait-fx") ||
+      el.tagName === "VIDEO" ||
+      el.tagName === "CANVAS" ||
+      el.tagName === "IMG"
+
+    if (!interesting) continue
+
+    const dataAttrs: Record<string, string> = {}
+    for (const attr of Array.from(el.attributes)) {
+      if (attr.name.startsWith("data-")) dataAttrs[attr.name] = attr.value
+    }
+
+    hits.push({
+      tag: el.tagName.toLowerCase(),
+      id: el.id || null,
+      className:
+        typeof el.className === "string"
+          ? el.className.slice(0, 200)
+          : undefined,
+      dataAttrs,
+      filter,
+      webkitFilter,
+      backdropFilter,
+      webkitBackdropFilter,
+      boxShadow: boxShadow.slice(0, 300),
+      opacity,
+      mixBlendMode,
+      maskImage: maskImage.slice(0, 200),
+      webkitMaskImage: webkitMaskImage.slice(0, 200),
+      transform: transform.slice(0, 200),
+      inlineFilter,
+      inlineWebkitFilter,
+    })
+  }
+  return hits
+}
+
+export function isExportDebugEnabled(): boolean {
+  if (typeof window === "undefined") return false
+  try {
+    if (localStorage.getItem(STORAGE_KEY) === "1") return true
+    if (localStorage.getItem(STORAGE_KEY) === "0") return false
+  } catch {
+    // private mode
+  }
+  try {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get("exportDebug") === "1") return true
+    if (params.get("exportDebug") === "0") return false
+  } catch {
+    // ignore
+  }
+  return process.env.NODE_ENV === "development"
+}
+
+export function getActiveExportDebug(): ExportDebugSession | null {
+  return activeSession
+}
+
+export class ExportDebugSession {
+  readonly sessionId: string
+  readonly kind: ExportDebugKind
+  readonly startedAt: string
+  private readonly t0: number
+  private readonly entries: ExportDebugEntry[] = []
+  private readonly meta: Record<string, unknown> = {}
+  private finished = false
+  private frameSampleBudget = 24
+  private slowFrameThresholdMs = 250
+  private readonly layers: Record<string, string> = {}
+
+  constructor(kind: ExportDebugKind, canvasId: string) {
+    this.sessionId = `${Date.now().toString(36)}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`
+    this.kind = kind
+    this.startedAt = new Date().toISOString()
+    this.t0 = nowMs()
+    this.meta.canvasId = canvasId
+    this.meta.browser = collectBrowserMeta()
+    this.info("session", "export debug session started", {
+      kind,
+      canvasId,
+      sessionId: this.sessionId,
+    })
+  }
+
+  setMeta(key: string, value: unknown) {
+    this.meta[key] = safeJsonClone(value)
+  }
+
+  mergeMeta(patch: Record<string, unknown>) {
+    for (const [k, v] of Object.entries(patch)) {
+      this.meta[k] = safeJsonClone(v)
+    }
+  }
+
+  log(level: ExportDebugLevel, tag: string, message: string, data?: unknown) {
+    if (this.finished) return
+    const entry: ExportDebugEntry = {
+      t: Math.round((nowMs() - this.t0) * 10) / 10,
+      level,
+      tag,
+      message,
+    }
+    if (data !== undefined) entry.data = safeJsonClone(data)
+    this.entries.push(entry)
+
+    const line = `${CONSOLE_PREFIX} [${this.kind}] ${tag}: ${message}`
+    if (level === "error") console.error(line, data ?? "")
+    else if (level === "warn") console.warn(line, data ?? "")
+    else if (level === "debug") console.debug(line, data ?? "")
+    else console.info(line, data ?? "")
+  }
+
+  debug(tag: string, message: string, data?: unknown) {
+    this.log("debug", tag, message, data)
+  }
+  info(tag: string, message: string, data?: unknown) {
+    this.log("info", tag, message, data)
+  }
+  warn(tag: string, message: string, data?: unknown) {
+    this.log("warn", tag, message, data)
+  }
+  error(tag: string, message: string, data?: unknown) {
+    this.log("error", tag, message, data)
+  }
+
+  /**
+   * Log frame sample stats. Throttled: first few, last, every Nth, black/blank,
+   * and frames that took too long.
+   */
+  logFrameSample(
+    tag: string,
+    frameIndex: number,
+    frameCount: number,
+    source: CanvasImageSource | HTMLCanvasElement | null | undefined,
+    extra?: Record<string, unknown>
+  ) {
+    const elapsed = typeof extra?.durationMs === "number" ? extra.durationMs : 0
+    const isBoundary =
+      frameIndex < 3 ||
+      frameIndex >= frameCount - 2 ||
+      frameIndex % 10 === 0 ||
+      elapsed >= this.slowFrameThresholdMs
+    if (!isBoundary && this.frameSampleBudget <= 0) {
+      if (extra && Object.keys(extra).length) {
+        this.debug(tag, `frame ${frameIndex}/${frameCount}`, extra)
+      }
+      return
+    }
+
+    const stats = sampleFrameStats(source)
+    if (stats?.likelyBlack || stats?.likelyBlank) {
+      this.warn(tag, `frame ${frameIndex} looks empty/black`, {
+        frameIndex,
+        frameCount,
+        stats,
+        ...extra,
+      })
+      this.frameSampleBudget--
+      return
+    }
+    if (isBoundary || this.frameSampleBudget > 0) {
+      this.info(tag, `frame ${frameIndex}/${frameCount}`, {
+        frameIndex,
+        frameCount,
+        stats,
+        ...extra,
+      })
+      if (isBoundary) this.frameSampleBudget--
+    }
+  }
+
+  logCloneFilters(root: HTMLElement, label = "clone-filters") {
+    const hits = collectCloneFilterHits(root)
+    this.info(label, `collected ${hits.length} filter/style hits on clone`, {
+      count: hits.length,
+      hits,
+    })
+  }
+
+  /**
+   * Store a PNG of one composite layer (underlay / foreground / first frame) so
+   * the layers can be inspected side by side after the run. Dev-only and capped
+   * — these are megabytes each.
+   */
+  addLayerSnapshot(name: string, canvas: HTMLCanvasElement) {
+    if (this.finished) return
+    if (Object.keys(this.layers).length >= 4) return
+    if (!canvas.width || !canvas.height) return
+    try {
+      this.layers[name] = canvas.toDataURL("image/png")
+      this.info("layer", `captured layer snapshot: ${name}`, {
+        width: canvas.width,
+        height: canvas.height,
+      })
+    } catch (err) {
+      this.warn("layer", `layer snapshot failed: ${name}`, {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  async flush(
+    status: "success" | "error" | "aborted",
+    err?: unknown
+  ): Promise<string | null> {
+    if (this.finished) return null
+    this.finished = true
+    const finishedAt = new Date().toISOString()
+    const durationMs = Math.round(nowMs() - this.t0)
+    this.info("session", "export debug session finishing", {
+      status,
+      durationMs,
+      entryCount: this.entries.length,
+    })
+
+    const payload: ExportDebugPayload = {
+      sessionId: this.sessionId,
+      kind: this.kind,
+      status,
+      startedAt: this.startedAt,
+      finishedAt,
+      durationMs,
+      meta: this.meta,
+      entries: this.entries,
+    }
+    if (Object.keys(this.layers).length > 0) payload.layers = this.layers
+    if (err !== undefined) payload.error = errPayload(err)
+
+    if (activeSession === this) activeSession = null
+
+    let savedPath: string | null = null
+    try {
+      const res = await fetch("/api/dev/export-debug", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+      if (res.ok) {
+        const json: unknown = await res.json()
+        if (
+          json &&
+          typeof json === "object" &&
+          "path" in json &&
+          typeof json.path === "string"
+        ) {
+          savedPath = json.path
+        }
+        console.info(
+          `${CONSOLE_PREFIX} saved export log → ${savedPath ?? "(unknown path)"}`
+        )
+      } else {
+        console.warn(
+          `${CONSOLE_PREFIX} API save failed (${res.status}), downloading log instead`
+        )
+        downloadPayload(payload)
+      }
+    } catch (fetchErr) {
+      console.warn(
+        `${CONSOLE_PREFIX} API save unavailable, downloading log instead`,
+        fetchErr
+      )
+      downloadPayload(payload)
+    }
+    return savedPath
+  }
+}
+
+function downloadPayload(payload: ExportDebugPayload) {
+  try {
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: "application/json",
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = `tokokino-export-debug-${payload.kind}-${payload.sessionId}.json`
+    a.rel = "noopener"
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    setTimeout(() => URL.revokeObjectURL(url), 5000)
+  } catch {
+    // last resort — already printed to console
+  }
+}
+
+export function startExportDebug(
+  kind: ExportDebugKind,
+  canvasId: string
+): ExportDebugSession | null {
+  if (!isExportDebugEnabled()) return null
+  // End any orphaned session so logs don't interleave.
+  if (activeSession) {
+    void activeSession.flush("aborted", new Error("superseded by new export"))
+  }
+  const session = new ExportDebugSession(kind, canvasId)
+  activeSession = session
+  return session
+}
+
+/** Convenience: log if a session is active. Safe no-op otherwise. */
+export function exportDebugLog(
+  level: ExportDebugLevel,
+  tag: string,
+  message: string,
+  data?: unknown
+) {
+  const s = activeSession
+  if (!s) return
+  s.log(level, tag, message, data)
+}

--- a/lib/editor/animation-export/export-debug.ts
+++ b/lib/editor/animation-export/export-debug.ts
@@ -537,7 +537,7 @@ export class ExportDebugSession {
    */
   addLayerSnapshot(name: string, canvas: HTMLCanvasElement) {
     if (this.finished) return
-    if (Object.keys(this.layers).length >= 4) return
+    if (Object.keys(this.layers).length >= 8) return
     if (!canvas.width || !canvas.height) return
     try {
       this.layers[name] = canvas.toDataURL("image/png")

--- a/lib/editor/animation-export/index.ts
+++ b/lib/editor/animation-export/index.ts
@@ -20,6 +20,11 @@ import { clearAnimationFrameVars } from "../apply-animation-frame"
 import { isVideoSrc } from "../media-type"
 import { captureClipPose, useEditorStore } from "../store"
 import { acquireAnimationCapture, suppressCloneTransitions } from "./capture"
+import {
+  collectCanvasStyleSnapshot,
+  startExportDebug,
+  type ExportDebugSession,
+} from "./export-debug"
 import { encodeGif } from "./gif"
 import { prepareCloneVideoLayer } from "./video-layer"
 import {
@@ -29,6 +34,7 @@ import {
   type CaptureCtx,
 } from "./types"
 import {
+  AnimationExportAbortedError,
   animationMimeAndExt,
   createProgressReporter,
   resolveAnimationDownloadFilename,
@@ -85,118 +91,203 @@ async function encodeAnimation(
 ): Promise<AnimationExportBlobResult> {
   const { onProgress, signal } = options
   const progress = createProgressReporter(onProgress)
-  throwIfAborted(signal)
-  progress.report("preparing", 0, 1)
-
-  const state = useEditorStore.getState()
-  const canvas = state.present.canvases.find((c) => c.id === canvasId)
-  const animation = canvas?.animation
-  if (!canvas || !animation) throw new Error("Nothing to export")
-
-  const { durationMs } = animation
-  const clips =
-    state.isAnimateMode && state.selectedAnimationClipId
-      ? animation.clips.map((clip) =>
-          clip.id === state.selectedAnimationClipId
-            ? { ...clip, pose: captureClipPose(canvas) }
-            : clip
-        )
-      : animation.clips
-  if (!clips.length) throw new Error("Add at least one keyframe before sharing")
-
-  const fps = Math.max(1, Math.min(60, options.fps ?? 30))
-  const frameCount = Math.min(
-    MAX_FRAMES,
-    Math.max(1, Math.round((durationMs / 1000) * fps))
-  )
-  const frameDurationMs = 1000 / fps
-  const targetWidth =
-    options.targetWidth ??
-    (options.format === "gif" ? 720 : options.format === "mp4" ? 1080 : 1080)
-
-  // Added unless explicitly disabled — mirrors the still-image export toggle.
-  // Preload the logo and the real Inter family together so every frame's canvas
-  // text rasterizes identically across OSes (no per-platform system-ui fallback).
-  const watermark =
-    options.watermark === false
-      ? null
-      : await (async () => {
-          const [logo, fontStack] = await Promise.all([
-            loadWatermarkLogo(),
-            resolveWatermarkFontStack(),
-          ])
-          return { logo, fontStack }
-        })()
-
-  throwIfAborted(signal)
-  const capture = await acquireAnimationCapture(
-    canvasId,
-    targetWidth,
-    options.capture ?? "auto"
-  )
-  suppressCloneTransitions(capture.node)
-
-  // A `<video>` renders nothing once the clone is serialized into an SVG, so a
-  // video canvas needs its frames decoded and painted in per capture.
-  const screenshot = canvas.screenshot
-  const videoLayer =
-    screenshot && isVideoSrc(screenshot)
-      ? await prepareCloneVideoLayer({
-          node: capture.node,
-          src: screenshot,
-          videoClips: canvas.videoClips ?? [],
-          signal,
-        })
-      : null
-
-  progress.report("preparing", 1, 1)
-
-  const ctx: CaptureCtx = {
-    capture,
-    canvas,
-    globalAspect: state.present.aspect,
-    clips,
-    frameCount,
-    frameDurationMs,
-    fps,
-    progress,
-    signal,
-    watermark,
-    videoLayer,
-  }
+  const dbg: ExportDebugSession | null = startExportDebug("animation", canvasId)
 
   try {
-    let blob: Blob
-    if (options.format === "gif") {
-      blob = await encodeGif(ctx)
-    } else {
-      const encoded = await tryEncodeWithMediabunny(ctx, options.format)
-      if (encoded) {
-        blob = encoded
-      } else {
-        if (options.format === "mp4") {
-          throw new Error(
-            "MP4 export needs WebCodecs (Chrome, Edge, or Safari 17+). Try WebM or update your browser."
+    throwIfAborted(signal)
+    progress.report("preparing", 0, 1)
+
+    const state = useEditorStore.getState()
+    const canvas = state.present.canvases.find((c) => c.id === canvasId)
+    const animation = canvas?.animation
+    if (!canvas || !animation) throw new Error("Nothing to export")
+
+    const { durationMs } = animation
+    const clips =
+      state.isAnimateMode && state.selectedAnimationClipId
+        ? animation.clips.map((clip) =>
+            clip.id === state.selectedAnimationClipId
+              ? { ...clip, pose: captureClipPose(canvas) }
+              : clip
           )
-        }
-        // WebM fallback — MediaRecorder (also fully local)
-        blob = await encodeWebmMediaRecorder({
-          ...ctx,
-          durationMs,
-        })
+        : animation.clips
+    if (!clips.length)
+      throw new Error("Add at least one keyframe before sharing")
+
+    const fps = Math.max(1, Math.min(60, options.fps ?? 30))
+    const frameCount = Math.min(
+      MAX_FRAMES,
+      Math.max(1, Math.round((durationMs / 1000) * fps))
+    )
+    const frameDurationMs = 1000 / fps
+    const targetWidth =
+      options.targetWidth ??
+      (options.format === "gif" ? 720 : options.format === "mp4" ? 1080 : 1080)
+
+    dbg?.mergeMeta({
+      options: {
+        format: options.format,
+        fps,
+        targetWidth,
+        capture: options.capture ?? "auto",
+        watermark: options.watermark !== false,
+        asBlob: !!options.asBlob,
+      },
+      canvasStyle: collectCanvasStyleSnapshot(canvas),
+      animation: {
+        durationMs,
+        clipCount: clips.length,
+        frameCount,
+        frameDurationMs,
+      },
+    })
+    dbg?.info("prepare", "starting animation encode", {
+      format: options.format,
+      fps,
+      frameCount,
+      targetWidth,
+      captureMode: options.capture ?? "auto",
+    })
+
+    // Added unless explicitly disabled — mirrors the still-image export toggle.
+    // Preload the logo and the real Inter family together so every frame's canvas
+    // text rasterizes identically across OSes (no per-platform system-ui fallback).
+    const watermark =
+      options.watermark === false
+        ? null
+        : await (async () => {
+            const [logo, fontStack] = await Promise.all([
+              loadWatermarkLogo(),
+              resolveWatermarkFontStack(),
+            ])
+            return { logo, fontStack }
+          })()
+
+    throwIfAborted(signal)
+    dbg?.info("capture", "acquireAnimationCapture begin", {
+      mode: options.capture ?? "auto",
+    })
+    const captureStarted = performance.now()
+    const capture = await acquireAnimationCapture(
+      canvasId,
+      targetWidth,
+      options.capture ?? "auto"
+    )
+    dbg?.info("capture", "acquireAnimationCapture done", {
+      durationMs: Math.round(performance.now() - captureStarted),
+      width: capture.width,
+      height: capture.height,
+      needsPaint: capture.needsPaint,
+    })
+    dbg?.setMeta("capture", {
+      width: capture.width,
+      height: capture.height,
+      needsPaint: capture.needsPaint,
+    })
+    suppressCloneTransitions(capture.node)
+    dbg?.logCloneFilters(capture.node)
+
+    // A `<video>` renders nothing once the clone is serialized into an SVG, so a
+    // video canvas needs its frames decoded and painted in per capture.
+    const screenshot = canvas.screenshot
+    const videoLayer =
+      screenshot && isVideoSrc(screenshot)
+        ? await prepareCloneVideoLayer({
+            node: capture.node,
+            src: screenshot,
+            videoClips: canvas.videoClips ?? [],
+            signal,
+          })
+        : null
+    dbg?.info(
+      "video-layer",
+      videoLayer ? "clone video layer ready" : "no video layer",
+      {
+        hasVideoLayer: !!videoLayer,
+        sourceDurationMs: videoLayer?.sourceDurationMs ?? null,
       }
+    )
+
+    progress.report("preparing", 1, 1)
+
+    const ctx: CaptureCtx = {
+      capture,
+      canvas,
+      globalAspect: state.present.aspect,
+      clips,
+      frameCount,
+      frameDurationMs,
+      fps,
+      progress,
+      signal,
+      watermark,
+      videoLayer,
     }
-    progress.report("finishing", 1, 1)
-    const { contentType, extension } = animationMimeAndExt(options.format)
-    // Prefer the blob's own type when the encoder set one.
-    return {
-      blob,
-      contentType: blob.type || contentType,
-      extension,
+
+    try {
+      let blob: Blob
+      let encoder: string
+      if (options.format === "gif") {
+        encoder = "gif"
+        blob = await encodeGif(ctx)
+      } else {
+        const encoded = await tryEncodeWithMediabunny(ctx, options.format)
+        if (encoded) {
+          encoder = "mediabunny"
+          blob = encoded
+        } else {
+          if (options.format === "mp4") {
+            throw new Error(
+              "MP4 export needs WebCodecs (Chrome, Edge, or Safari 17+). Try WebM or update your browser."
+            )
+          }
+          // WebM fallback — MediaRecorder (also fully local)
+          encoder = "mediarecorder-webm"
+          dbg?.warn("encode", "falling back to MediaRecorder WebM")
+          blob = await encodeWebmMediaRecorder({
+            ...ctx,
+            durationMs,
+          })
+        }
+      }
+      progress.report("finishing", 1, 1)
+      const { contentType, extension } = animationMimeAndExt(options.format)
+      dbg?.mergeMeta({
+        encoder,
+        result: {
+          contentType: blob.type || contentType,
+          extension,
+          blobSize: blob.size,
+          blobType: blob.type,
+        },
+      })
+      dbg?.info("result", "animation encode complete", {
+        encoder,
+        blobSize: blob.size,
+        extension,
+      })
+      await dbg?.flush("success")
+      // Prefer the blob's own type when the encoder set one.
+      return {
+        blob,
+        contentType: blob.type || contentType,
+        extension,
+      }
+    } finally {
+      videoLayer?.cleanup()
+      clearAnimationFrameVars(capture.node, clips)
+      capture.cleanup()
+      dbg?.info("capture", "capture cleaned up")
     }
-  } finally {
-    videoLayer?.cleanup()
-    clearAnimationFrameVars(capture.node, clips)
-    capture.cleanup()
+  } catch (err) {
+    const aborted = err instanceof AnimationExportAbortedError
+    dbg?.error("export", aborted ? "export aborted" : "export failed", {
+      error:
+        err instanceof Error
+          ? { name: err.name, message: err.message, stack: err.stack }
+          : String(err),
+    })
+    await dbg?.flush(aborted ? "aborted" : "error", err)
+    throw err
   }
 }

--- a/lib/editor/animation-export/video-layer.ts
+++ b/lib/editor/animation-export/video-layer.ts
@@ -18,6 +18,7 @@
  */
 
 import type { VideoTimelineClip } from "../state-types"
+import { exportDebugLog } from "./export-debug"
 import { createDecodedFrameSource } from "./video-media/decoded-frames"
 import { waitForVideoReady } from "./video-media/dom-video"
 
@@ -146,6 +147,26 @@ export async function prepareCloneVideoLayer({
     return null
   }
 
+  // The <video> is swapped for an <img>, so every box the layout hangs off the
+  // media (frame screen area, contain shells, crop) is re-resolved against a
+  // different replaced element. Measure across the swap: the framing check runs
+  // earlier and queries "video", so it cannot see this.
+  const boxOf = (el: Element | null) => {
+    const root = node.getBoundingClientRect()
+    const r = el?.getBoundingClientRect()
+    if (!r || !root.width || !root.height) return null
+    return {
+      leftPct: Number(((r.left - root.left) / root.width).toFixed(4)),
+      topPct: Number(((r.top - root.top) / root.height).toFixed(4)),
+      widthPct: Number((r.width / root.width).toFixed(4)),
+      heightPct: Number((r.height / root.height).toFixed(4)),
+      w: Number(r.width.toFixed(1)),
+      h: Number(r.height.toFixed(1)),
+    }
+  }
+  const beforeBox = boxOf(video)
+  const beforeParent = boxOf(video.parentElement)
+
   const img = document.createElement("img")
   for (const attribute of Array.from(video.attributes)) {
     if (DROPPED_VIDEO_ATTRIBUTES.has(attribute.name)) continue
@@ -195,6 +216,31 @@ export async function prepareCloneVideoLayer({
   const firstClip = videoClips.length > 0 ? videoClips : [DEFAULT_VIDEO_CLIP]
   await paintSourceMs(
     Math.max(0, Math.min(...firstClip.map((clip) => clip.startMs)))
+  )
+
+  const afterBox = boxOf(img)
+  const drifted =
+    !!beforeBox &&
+    !!afterBox &&
+    (Math.abs(beforeBox.leftPct - afterBox.leftPct) > 0.002 ||
+      Math.abs(beforeBox.topPct - afterBox.topPct) > 0.002 ||
+      Math.abs(beforeBox.widthPct - afterBox.widthPct) > 0.002 ||
+      Math.abs(beforeBox.heightPct - afterBox.heightPct) > 0.002)
+  exportDebugLog(
+    drifted ? "warn" : "info",
+    "video-layer",
+    drifted
+      ? "clone media box MOVED across the <video>→<img> swap"
+      : "clone media box stable across the <video>→<img> swap",
+    {
+      before: beforeBox,
+      after: afterBox,
+      parentBefore: beforeParent,
+      parentAfter: boxOf(img.parentElement),
+      imgClass: img.className || null,
+      imgNatural: { w: img.naturalWidth, h: img.naturalHeight },
+      drifted,
+    }
   )
 
   return {

--- a/lib/editor/animation-export/video-media/decoded-frames.ts
+++ b/lib/editor/animation-export/video-media/decoded-frames.ts
@@ -11,6 +11,7 @@ import {
   type WrappedCanvas,
 } from "mediabunny"
 
+import { exportDebugLog } from "../export-debug"
 import { throwIfAborted } from "../utils"
 
 export type DecodedFrameSource = {
@@ -37,19 +38,55 @@ export async function createDecodedFrameSource(
   src: string,
   signal?: AbortSignal
 ): Promise<DecodedFrameSource | null> {
-  if (typeof VideoDecoder === "undefined") return null
+  if (typeof VideoDecoder === "undefined") {
+    exportDebugLog(
+      "warn",
+      "decode",
+      "VideoDecoder undefined — no WebCodecs decode"
+    )
+    return null
+  }
   let input: Input | null = null
   try {
     throwIfAborted(signal)
+    const t0 = performance.now()
+    exportDebugLog("info", "decode", "fetching source for WebCodecs decode", {
+      srcKind: src.startsWith("blob:")
+        ? "blob"
+        : src.startsWith("data:")
+          ? "data"
+          : "url",
+    })
     const res = await fetch(src)
-    if (!res.ok) return null
+    if (!res.ok) {
+      exportDebugLog("warn", "decode", "source fetch failed", {
+        status: res.status,
+      })
+      return null
+    }
     const blob = await res.blob()
+    exportDebugLog("info", "decode", "source fetched", {
+      byteLength: blob.size,
+      type: blob.type,
+      durationMs: Math.round(performance.now() - t0),
+    })
     input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) })
     const track = await input.getPrimaryVideoTrack()
     if (!track || !(await track.canDecode())) {
+      exportDebugLog(
+        "warn",
+        "decode",
+        "primary track missing or not decodable",
+        {
+          hasTrack: !!track,
+        }
+      )
       input.dispose()
       return null
     }
+    exportDebugLog("info", "decode", "WebCodecs track ready", {
+      durationMs: Math.round(performance.now() - t0),
+    })
     const boundInput = input
     // poolSize 0 → each yielded frame is its own canvas, so holding a reference
     // to the last one across calls is safe (a pooled canvas would be overwritten).
@@ -95,7 +132,10 @@ export async function createDecodedFrameSource(
         boundInput.dispose()
       },
     }
-  } catch {
+  } catch (err) {
+    exportDebugLog("warn", "decode", "createDecodedFrameSource failed", {
+      error: err instanceof Error ? err.message : String(err),
+    })
     input?.dispose()
     return null
   }

--- a/lib/editor/animation-export/video-media/decoded-frames.ts
+++ b/lib/editor/animation-export/video-media/decoded-frames.ts
@@ -72,13 +72,51 @@ export async function createDecodedFrameSource(
     })
     input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) })
     const track = await input.getPrimaryVideoTrack()
-    if (!track || !(await track.canDecode())) {
+    const canDecode = track ? await track.canDecode() : false
+    if (!track || !canDecode) {
+      // Report exactly why this clip won't decode: the codec, its full parameter
+      // string, whether mediabunny could build a decoder config at all, and what
+      // the browser's own VideoDecoder.isConfigSupported says about it. This is
+      // the difference between "unknown codec" and "WebKit refuses this profile",
+      // and it decides whether the flickery DOM-seek fallback was avoidable.
+      let codec: string | null = null
+      let codecString: string | null = null
+      let decoderConfig: VideoDecoderConfig | null = null
+      let isConfigSupported: boolean | null = null
+      try {
+        codec = track ? await track.getCodec() : null
+        codecString = track ? await track.getCodecParameterString() : null
+        decoderConfig = track ? await track.getDecoderConfig() : null
+        if (decoderConfig && typeof VideoDecoder !== "undefined") {
+          isConfigSupported =
+            (await VideoDecoder.isConfigSupported(decoderConfig)).supported ??
+            null
+        }
+      } catch (probeErr) {
+        exportDebugLog("warn", "decode", "decodability probe threw", {
+          error:
+            probeErr instanceof Error ? probeErr.message : String(probeErr),
+        })
+      }
       exportDebugLog(
         "warn",
         "decode",
         "primary track missing or not decodable",
         {
           hasTrack: !!track,
+          canDecode,
+          codec,
+          codecString,
+          hasDecoderConfig: !!decoderConfig,
+          decoderConfig: decoderConfig
+            ? {
+                codec: decoderConfig.codec,
+                codedWidth: decoderConfig.codedWidth,
+                codedHeight: decoderConfig.codedHeight,
+                hasDescription: !!decoderConfig.description,
+              }
+            : null,
+          isConfigSupported,
         }
       )
       input.dispose()

--- a/lib/editor/animation-export/video-media/encode-video.ts
+++ b/lib/editor/animation-export/video-media/encode-video.ts
@@ -14,6 +14,7 @@ import {
   type VideoCodec,
 } from "mediabunny"
 
+import { exportDebugLog, getActiveExportDebug } from "../export-debug"
 import type { WatermarkAssets } from "../types"
 import {
   AnimationExportAbortedError,
@@ -36,18 +37,32 @@ export async function encodeMp4OrWebm(
   signal?: AbortSignal
 ): Promise<Blob> {
   if (typeof VideoEncoder === "undefined") {
+    exportDebugLog("error", "encode", "VideoEncoder undefined")
     throw new Error("Video encoding is not supported in this browser")
   }
   const preferred: VideoCodec[] =
     format === "mp4"
       ? (["avc", "hevc", "av1"] as VideoCodec[])
       : (["vp9", "vp8", "av1"] as VideoCodec[])
+  exportDebugLog("info", "encode", "probing video codec", {
+    format,
+    preferred,
+    width: encodeCanvas.width,
+    height: encodeCanvas.height,
+  })
   const codec = await getFirstEncodableVideoCodec(preferred, {
     width: encodeCanvas.width,
     height: encodeCanvas.height,
     bitrate: QUALITY_HIGH,
   })
-  if (!codec) throw new Error("No supported video codec for this format")
+  if (!codec) {
+    exportDebugLog("error", "encode", "no encodable video codec", {
+      preferred,
+    })
+    throw new Error("No supported video codec for this format")
+  }
+  exportDebugLog("info", "encode", "selected video codec", { codec })
+  getActiveExportDebug()?.setMeta("videoCodec", codec)
 
   const outputFormat =
     format === "mp4" ? new Mp4OutputFormat() : new WebMOutputFormat()
@@ -59,6 +74,11 @@ export async function encodeMp4OrWebm(
     durationSec,
     signal
   )
+  exportDebugLog("info", "encode", "source audio prepared", {
+    hasAudio: !!sourceAudio,
+    durationSec,
+  })
+  getActiveExportDebug()?.setMeta("hasSourceAudio", !!sourceAudio)
 
   const target = new BufferTarget()
   const output = new Output({
@@ -89,25 +109,53 @@ export async function encodeMp4OrWebm(
     // buffer every video packet waiting for the first audio packet.
     if (sourceAudio) {
       progress.report("encoding", 0, 1)
+      const audioStarted = performance.now()
       await sourceAudio.feed()
+      exportDebugLog("info", "encode", "audio feed complete", {
+        durationMs: Math.round(performance.now() - audioStarted),
+      })
     }
     progress.report("capturing", 0, plan.frameCount)
+    exportDebugLog("info", "encode", "frame loop begin", {
+      frameCount: plan.frameCount,
+    })
+    const loopStarted = performance.now()
     for (let f = 0; f < plan.frameCount; f++) {
       if (cancelled || signal?.aborted) throw new AnimationExportAbortedError()
       const frame = await renderFrame(f)
       blitFrame(ctx, frame, encodeCanvas.width, encodeCanvas.height, watermark)
       await videoSource.add(plan.timeForFrame(f), plan.frameDurationSec)
       progress.report("capturing", f + 1, plan.frameCount)
+      if (f === 0 || f === plan.frameCount - 1 || (f + 1) % 30 === 0) {
+        exportDebugLog(
+          "debug",
+          "encode",
+          `encoded frame ${f + 1}/${plan.frameCount}`,
+          {
+            frameIndex: f,
+            elapsedMs: Math.round(performance.now() - loopStarted),
+          }
+        )
+      }
     }
     throwIfAborted(signal)
     progress.report("encoding", 0, 1)
+    exportDebugLog("info", "encode", "finalizing mux", {
+      frameLoopMs: Math.round(performance.now() - loopStarted),
+    })
     await output.finalize()
     progress.report("encoding", 1, 1)
     const buffer = target.buffer
     if (!buffer || buffer.byteLength === 0) {
+      exportDebugLog("error", "encode", "empty output buffer")
       throw new Error("Video encode produced an empty file")
     }
     const mime = format === "mp4" ? "video/mp4" : "video/webm"
+    exportDebugLog("info", "encode", "mux complete", {
+      byteLength: buffer.byteLength,
+      mime,
+    })
+    getActiveExportDebug()?.setMeta("encodedBytes", buffer.byteLength)
     return new Blob([buffer], { type: mime })
   } finally {
     signal?.removeEventListener("abort", onAbort)

--- a/lib/editor/animation-export/video-media/export-stack.ts
+++ b/lib/editor/animation-export/video-media/export-stack.ts
@@ -1,0 +1,100 @@
+/**
+ * Layered video-media export stacking.
+ *
+ * The composite path cannot re-raster the live `<video>` through html-to-image
+ * on Safari (flicker). It draws decoded frames in 2D onto a scene template.
+ * That breaks anything that should sit *above* the video unless we split the
+ * scene into independent passes:
+ *
+ *   underlay  → backdrop, patterns, outer lighting, underlay overlays, and the
+ *               media shell itself (shadow / frame chrome / black plate) — the
+ *               video's own pixels are painted by the decoder, not this pass
+ *   foreground → inner lighting, overlay textures, text, assets, annotations,
+ *                screenshot slots — anything data-export-stack="foreground"
+ *
+ * Markup: components set `data-export-stack` (see EXPORT_STACK). This module
+ * only toggles visibility for the two capture passes.
+ */
+
+export const EXPORT_STACK_ATTR = "data-export-stack"
+
+export type ExportStackLayer = "underlay" | "media" | "foreground"
+
+export const EXPORT_STACK = {
+  underlay: "underlay",
+  media: "media",
+  foreground: "foreground",
+} as const satisfies Record<ExportStackLayer, ExportStackLayer>
+
+type VisibilityRestore = () => void
+
+function queryStack(root: HTMLElement, layer: ExportStackLayer): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(`[${EXPORT_STACK_ATTR}="${layer}"]`)
+  )
+}
+
+export function queryForeground(root: HTMLElement): HTMLElement[] {
+  return queryStack(root, "foreground")
+}
+
+/**
+ * Hide/show layers for one capture pass. Returns a restore function that puts
+ * every touched inline style back.
+ *
+ * - `underlay`: hide videos + foreground, plus any `alsoHide` layers; keep the
+ *   backdrop and the media shell, so the shell's shadow, radius and letterbox
+ *   plate stay baked in behind the video.
+ * - `foreground`: hide the whole tree, then re-show only foreground nodes.
+ *   `visibility` inherits and a descendant can override it, so this leaves an
+ *   otherwise transparent raster. Hiding by *exclusion* matters: anything
+ *   untagged would otherwise paint in both passes and be drawn twice.
+ *
+ * `alsoHide` exists because WebKit rasterizes a 3D transform inside an SVG
+ * foreignObject *without* the perspective divide — it bakes the flat affine
+ * projection, while `getBoundingClientRect` (and the editor) use the real
+ * perspective one. Any element whose box the transform bends therefore lands in
+ * the raster at the wrong shape; those are kept out of the flat passes and
+ * projected individually instead.
+ */
+export function applyExportStackVisibility(
+  root: HTMLElement,
+  pass: "underlay" | "foreground",
+  options: { alsoHide?: HTMLElement[]; only?: HTMLElement[] } = {}
+): VisibilityRestore {
+  const prev = new Map<HTMLElement, string>()
+  const set = (el: HTMLElement, value: string) => {
+    if (!prev.has(el)) prev.set(el, el.style.visibility)
+    el.style.visibility = value
+  }
+
+  const foreground = queryStack(root, "foreground")
+  // Main + slot videos — never leave a live <video> for foreignObject to sample.
+  const videos = Array.from(root.querySelectorAll<HTMLElement>("video"))
+
+  if (pass === "underlay") {
+    for (const el of foreground) set(el, "hidden")
+    for (const el of videos) set(el, "hidden")
+    for (const el of options.alsoHide ?? []) set(el, "hidden")
+  } else {
+    set(root, "hidden")
+    // `only` narrows the pass to specific elements, so a layer that must be
+    // projected by hand can be isolated and captured on its own.
+    for (const el of options.only ?? foreground) set(el, "visible")
+    // A <video> nested inside a foreground node would come back visible with it.
+    for (const el of videos) set(el, "hidden")
+  }
+
+  return () => {
+    for (const [el, value] of prev) el.style.visibility = value
+  }
+}
+
+export function countExportStack(root: HTMLElement) {
+  return {
+    underlay: queryStack(root, "underlay").length,
+    media: queryStack(root, "media").length,
+    foreground: queryStack(root, "foreground").length,
+    videos: root.querySelectorAll("video").length,
+  }
+}

--- a/lib/editor/animation-export/video-media/frame-renderer.ts
+++ b/lib/editor/animation-export/video-media/frame-renderer.ts
@@ -122,6 +122,19 @@ function resolveTransformCarrier(
   return null
 }
 
+/**
+ * Neutralize a transform without removing it.
+ *
+ * A computed `transform` other than `none` makes an element the containing block
+ * for its absolutely-positioned descendants, so `transform: none` silently
+ * re-parents every abs-positioned child to a different ancestor and their
+ * percentage sizes resolve against the wrong box. A device frame renders its
+ * chrome that way: clearing the tilt on the carrier collapsed the frame to ~46%
+ * inside a carrier whose own box never moved — a correctly placed, half-size
+ * frame. Identity leaves layout alone and still paints untransformed.
+ */
+const IDENTITY_TRANSFORM = "matrix(1, 0, 0, 1, 0, 0)"
+
 /** A planar box projected into capture-root CSS px, perspective included. */
 type QuadProjection = {
   corners: [Point, Point, Point, Point]
@@ -157,10 +170,10 @@ function projectElementQuad(
   const style = getComputedStyle(carrier)
   const cssTransform = style.transform
 
-  // Untransformed layout — the transform MUST be cleared on the carrier (the
+  // Untransformed layout — the transform MUST be neutralized on the carrier (the
   // element that actually has it), not on a child reporting transform:none.
   const prevInline = carrier.style.transform
-  carrier.style.transform = "none"
+  carrier.style.transform = IDENTITY_TRANSFORM
   void carrier.offsetWidth
   const rootRect = root.getBoundingClientRect()
   const carrierBox = carrier.getBoundingClientRect()
@@ -809,6 +822,9 @@ function overlayVideoFrameImage(
  * gives the raster nothing to flatten; the projection is then ours to do, with
  * the same maths the video goes through.
  */
+/** Distinguishes snapshots when several layers share a stack tag (or none). */
+let projectedSeq = 0
+
 async function captureProjectedElement(
   capture: AnimationCapture,
   layer: ProjectedLayer,
@@ -819,6 +835,8 @@ async function captureProjectedElement(
   excludeForeground: HTMLElement[] = []
 ): Promise<HTMLCanvasElement | null> {
   const { el, carrier, quad } = layer
+  const seq = projectedSeq++
+  const tag = `${seq}-${el.getAttribute("data-export-stack") ?? "untagged"}`
 
   // box-shadow / drop-shadow paint outside the border box and are transformed
   // with the element, so the texture has to include them or a tilted shadow gets
@@ -840,10 +858,26 @@ async function captureProjectedElement(
         f.style.visibility = prev
       }
     })
-  // Clear the transform on the *carrier*: `el` may merely inherit it, and
+  // Neutralize the transform on the *carrier*: `el` may merely inherit it, and
   // clearing a child that reports transform:none would change nothing.
   const prevTransform = carrier.style.transform
-  carrier.style.transform = "none"
+
+  // The carrier's transform is not only the tilt — it also carries the layout's
+  // own translate(-50%, -50%) centering. Neutralizing it outright drops the
+  // centering, dumping the element's top-left on its 50%/50% anchor where it
+  // hangs off the capture canvas and rasterizes clipped: a full-size layer that
+  // survives only as its top-left corner. So place the box at a known spot and
+  // crop where it actually lands, rather than trusting it to stay put.
+  carrier.style.transform = IDENTITY_TRANSFORM
+  const rootRect = capture.node.getBoundingClientRect()
+  const loose = el.getBoundingClientRect()
+  const dx = -(loose.left - rootRect.left) + pad
+  const dy = -(loose.top - rootRect.top) + pad
+  carrier.style.transform = `matrix(1, 0, 0, 1, ${dx}, ${dy})`
+  const placed = el.getBoundingClientRect()
+  const cropX = Math.round((placed.left - rootRect.left - pad) * scale)
+  const cropY = Math.round((placed.top - rootRect.top - pad) * scale)
+
   let raster: HTMLCanvasElement | null = null
   try {
     raster = await captureForegroundLayer(capture)
@@ -853,29 +887,39 @@ async function captureProjectedElement(
     restoreVisibility()
   }
   if (!raster) return null
+  getActiveExportDebug()?.addLayerSnapshot(`raster-${tag}`, raster)
 
-  // With the transform cleared the element rasterizes into its untransformed
-  // layout box; lift that box (plus the shadow margin) out as the quad texture.
+  // Lift the placed box (plus the shadow margin) out as the quad texture.
   const boxW = quad.localW + pad * 2
   const boxH = quad.localH + pad * 2
   const cropW = Math.max(1, Math.round(boxW * scale))
   const cropH = Math.max(1, Math.round(boxH * scale))
+  if (
+    cropX < 0 ||
+    cropY < 0 ||
+    cropX + cropW > raster.width + 1 ||
+    cropY + cropH > raster.height + 1
+  ) {
+    exportDebugLog(
+      "warn",
+      "renderer.composite",
+      "layer texture is clipped by the capture canvas — it will warp in undersized",
+      {
+        tag: el.tagName,
+        stack: el.getAttribute("data-export-stack"),
+        crop: { x: cropX, y: cropY, w: cropW, h: cropH },
+        raster: { w: raster.width, h: raster.height },
+      }
+    )
+  }
   const local = document.createElement("canvas")
   local.width = cropW
   local.height = cropH
   const lctx = local.getContext("2d")
   if (!lctx) return null
-  lctx.drawImage(
-    raster,
-    (quad.origin.x - pad) * scale,
-    (quad.origin.y - pad) * scale,
-    cropW,
-    cropH,
-    0,
-    0,
-    cropW,
-    cropH
-  )
+  lctx.drawImage(raster, cropX, cropY, cropW, cropH, 0, 0, cropW, cropH)
+
+  getActiveExportDebug()?.addLayerSnapshot(`tex-${tag}`, local)
 
   const out = document.createElement("canvas")
   out.width = width

--- a/lib/editor/animation-export/video-media/frame-renderer.ts
+++ b/lib/editor/animation-export/video-media/frame-renderer.ts
@@ -123,6 +123,32 @@ function resolveTransformCarrier(
 }
 
 /**
+ * The corner radius (in `localW`-box px) that clips the video's box.
+ *
+ * The rounding lives on whichever ancestor actually clips the media — for a
+ * device frame the square-cornered outer shell has none and the rounded screen
+ * glass carries it a couple levels down. Walk from the video up to the shell,
+ * take the first rounded ancestor and rescale its authored radius from that
+ * element's own layout width to the projected box, so the rounded corners land
+ * exactly where the bezel expects them.
+ */
+function resolveVideoClipRadius(
+  video: HTMLElement,
+  shell: HTMLElement,
+  localW: number
+): number {
+  let node: HTMLElement | null = video
+  while (node) {
+    const r = parseFloat(getComputedStyle(node).borderTopLeftRadius) || 0
+    const w = node.offsetWidth
+    if (r > 0 && w > 0) return r * (localW / w)
+    if (node === shell) break
+    node = node.parentElement
+  }
+  return 0
+}
+
+/**
  * Neutralize a transform without removing it.
  *
  * A computed `transform` other than `none` makes an element the containing block
@@ -979,20 +1005,70 @@ function shadowExtentPx(el: HTMLElement): number {
 }
 
 /**
- * Build the single foreground raster drawn over every composited frame.
+ * Whether `el` paints above `video` in the live DOM's stacking order.
  *
- * Perspective-carrying layers are projected individually (the raster would
- * flatten them); everything else comes from one flat capture. The projected ones
- * are painted first: they are locked to the media box and sit at the bottom of
- * the foreground (inner lighting is z-10, below text/overlays/annotations).
+ * The two-pass split must honor this: a foreground-tagged layer (annotation,
+ * asset, text) shares the screenshot's `z-index: 60 + n` scale and can be ordered
+ * *behind* the screenshot, where it belongs under the video, not over it. CSS
+ * stacks the two at their nearest common ancestor — the child on each branch is
+ * what actually competes — by z-index, then document order.
+ */
+function paintsAboveVideo(
+  el: HTMLElement,
+  video: HTMLElement,
+  root: HTMLElement
+): boolean {
+  const chainOf = (node: HTMLElement): HTMLElement[] => {
+    const chain: HTMLElement[] = []
+    let n: HTMLElement | null = node
+    while (n) {
+      chain.push(n)
+      if (n === root) break
+      n = n.parentElement
+    }
+    return chain
+  }
+  const elChain = chainOf(el)
+  const vChain = chainOf(video)
+  const vIndex = new Map(vChain.map((n, i) => [n, i]))
+  const commonAt = elChain.findIndex((n) => vIndex.has(n))
+  if (commonAt < 0) return true // disjoint trees — keep on top
+  const common = elChain[commonAt]
+  const elBranch = elChain[commonAt - 1]
+  const vBranch = vChain[(vIndex.get(common) ?? 0) - 1]
+  // One is an ancestor of the other: a descendant always paints over its box.
+  if (!elBranch) return false
+  if (!vBranch) return true
+  const z = (n: HTMLElement) => {
+    const v = parseInt(getComputedStyle(n).zIndex, 10)
+    return Number.isNaN(v) ? 0 : v
+  }
+  const ze = z(elBranch)
+  const zv = z(vBranch)
+  if (ze !== zv) return ze > zv
+  return Boolean(
+    vBranch.compareDocumentPosition(elBranch) & Node.DOCUMENT_POSITION_FOLLOWING
+  )
+}
+
+/**
+ * Build a raster layer from a set of nodes, projecting each perspective-carrying
+ * one individually (the flat raster would flatten it) and capturing the rest in
+ * one pass. Projected ones are painted first: they are locked to the media box
+ * and sit at the bottom (inner lighting is z-10, below text/overlays).
+ *
+ * `els` is passed explicitly so the caller can split the foreground by z-order —
+ * layers ordered behind the screenshot are composited under the video instead.
  */
 async function buildForegroundLayer(
   capture: AnimationCapture,
+  els: HTMLElement[],
   scale: number,
   width: number,
-  height: number
+  height: number,
+  label = "foreground groups"
 ): Promise<HTMLCanvasElement | null> {
-  const all = queryForeground(capture.node)
+  const all = els
   if (all.length === 0) return null
   // Each foreground node is projected on its own if anything bends it — whether
   // it carries the transform or inherits one from a tilted wrapper.
@@ -1004,7 +1080,7 @@ async function buildForegroundLayer(
     else flat.push(el)
   }
 
-  exportDebugLog("info", "renderer.composite", "foreground groups", {
+  exportDebugLog("info", "renderer.composite", label, {
     total: all.length,
     perspective: perspective.length,
     flat: flat.length,
@@ -1048,6 +1124,78 @@ async function buildForegroundLayer(
       }
     } finally {
       restore()
+    }
+  }
+
+  return painted ? out : null
+}
+
+/**
+ * Re-project a device frame's chrome (bezel + notch) so it composites *over* the
+ * decoded video, matching its real z-10 order in the DOM.
+ *
+ * The chrome is left untagged so it stays baked into the underlay shell, where it
+ * casts the frame's drop-shadow. That copy is buried by an opaque cover/fill
+ * video, so this pass paints the bezel back on top. The shadow filter lives on an
+ * ancestor (`data-editor-shadow-filter-target`); it is neutralized here so the
+ * on-top copy carries only the bezel, not a second phone-shaped shadow.
+ */
+async function buildFrameChromeLayer(
+  capture: AnimationCapture,
+  shell: HTMLElement,
+  scale: number,
+  width: number,
+  height: number
+): Promise<HTMLCanvasElement | null> {
+  const chromes = Array.from(
+    shell.querySelectorAll<HTMLElement>("[data-export-frame-chrome]")
+  )
+  if (chromes.length === 0) return null
+
+  const out = document.createElement("canvas")
+  out.width = width
+  out.height = height
+  const ctx = out.getContext("2d")
+  if (!ctx) return null
+  let painted = false
+
+  for (const chrome of chromes) {
+    const shadowHost = chrome.closest<HTMLElement>(
+      "[data-editor-shadow-filter-target]"
+    )
+    const prevFilter = shadowHost?.style.filter
+    if (shadowHost) shadowHost.style.filter = "none"
+    try {
+      const layer = projectionFor(capture.node, chrome)
+      if (layer) {
+        const canvas = await captureProjectedElement(
+          capture,
+          layer,
+          scale,
+          width,
+          height
+        )
+        if (canvas) {
+          ctx.drawImage(canvas, 0, 0)
+          painted = true
+        }
+      } else {
+        // Untilted frame: no perspective to undo — capture it in place.
+        const restore = applyExportStackVisibility(capture.node, "foreground", {
+          only: [chrome],
+        })
+        try {
+          const raster = await captureForegroundLayer(capture)
+          if (raster) {
+            ctx.drawImage(raster, 0, 0)
+            painted = true
+          }
+        } finally {
+          restore()
+        }
+      }
+    } finally {
+      if (shadowHost) shadowHost.style.filter = prevFilter ?? ""
     }
   }
 
@@ -1122,7 +1270,6 @@ async function createCompositeRenderer(
   })
 
   const stackCounts = countExportStack(capture.node)
-  const hasForeground = queryForeground(capture.node).length > 0
   exportDebugLog("info", "renderer.composite", "export stack", {
     ...stackCounts,
     enhance: mediaFx?.enhance ?? "off",
@@ -1188,7 +1335,48 @@ async function createCompositeRenderer(
   const underlayProjected = projected.filter(
     ({ el }) => !foregroundEls.some((f) => f === el || f.contains(el))
   )
+
+  // Split the foreground by real stacking order: layers the user sent behind the
+  // screenshot must composite under the video, not over it. Only meaningful when
+  // the shell is projected (drawn separately, below) — otherwise it is baked into
+  // the backdrop template and there is no seam to slip a layer beneath.
+  const canOrderBelow = underlayProjected.length > 0
+  const aboveEls: HTMLElement[] = []
+  const belowEls: HTMLElement[] = []
+  for (const el of foregroundEls) {
+    if (canOrderBelow && !paintsAboveVideo(el, video, capture.node)) {
+      belowEls.push(el)
+    } else {
+      aboveEls.push(el)
+    }
+  }
+  exportDebugLog("info", "renderer.composite", "foreground z-split", {
+    above: aboveEls.length,
+    below: belowEls.length,
+    canOrderBelow,
+  })
+
   const tctx = templateCopy.getContext("2d")
+
+  // Behind-the-screenshot layers first, so the projected shell paints over them.
+  if (belowEls.length > 0) {
+    const belowLayer = await buildForegroundLayer(
+      capture,
+      belowEls,
+      scale,
+      templateCopy.width,
+      templateCopy.height,
+      "underlay foreground groups"
+    )
+    if (belowLayer && tctx) {
+      tctx.drawImage(belowLayer, 0, 0)
+      getActiveExportDebug()?.addLayerSnapshot(
+        "underlay-foreground",
+        belowLayer
+      )
+    }
+  }
+
   for (const layer of underlayProjected) {
     const canvas = await captureProjectedElement(
       capture,
@@ -1207,9 +1395,10 @@ async function createCompositeRenderer(
   // This is what makes the stacking general: the editor decides what's above the
   // media via data-export-stack, not this renderer.
   let foregroundLayer: HTMLCanvasElement | null = null
-  if (hasForeground) {
+  if (aboveEls.length > 0) {
     foregroundLayer = await buildForegroundLayer(
       capture,
+      aboveEls,
       scale,
       templateCopy.width,
       templateCopy.height
@@ -1217,6 +1406,19 @@ async function createCompositeRenderer(
     if (foregroundLayer) {
       getActiveExportDebug()?.addLayerSnapshot("foreground", foregroundLayer)
     }
+  }
+
+  // Device-frame chrome (bezel + notch), re-drawn over the video since its
+  // underlay copy is buried by an opaque cover/fill fit.
+  const frameChromeLayer = await buildFrameChromeLayer(
+    capture,
+    shell,
+    scale,
+    templateCopy.width,
+    templateCopy.height
+  )
+  if (frameChromeLayer) {
+    getActiveExportDebug()?.addLayerSnapshot("frame-chrome", frameChromeLayer)
   }
 
   const templateStats = sampleFrameStats(templateCopy)
@@ -1288,8 +1490,11 @@ async function createCompositeRenderer(
     corners: quad?.corners ?? null,
   })
 
-  // Border-radius lives on the shell; pass a synthetic style source for local paint.
-  const shellRadius = parseFloat(getComputedStyle(shell).borderRadius) || 0
+  // Corner rounding that clips the video's own box. It is NOT on the tilt shell:
+  // for a device frame that outer div is square-cornered and the rounded screen
+  // glass sits a couple levels down. Without it the video keeps sharp corners
+  // that poke out past the bezel's rounded silhouette (cover/fill especially).
+  const shellRadius = resolveVideoClipRadius(video, shell, localW)
   let warpUsed: "gl" | "grid" | null = null
 
   return async (i: number) => {
@@ -1381,6 +1586,10 @@ async function createCompositeRenderer(
         }
       }
     }
+
+    // The device bezel/notch masks the video edges before the editor's own
+    // foreground (text, annotations) is stacked above the whole device.
+    if (frameChromeLayer) sctx.drawImage(frameChromeLayer, 0, 0)
 
     // Everything the editor stacks above the media, back on top of the video.
     if (foregroundLayer) sctx.drawImage(foregroundLayer, 0, 0)

--- a/lib/editor/animation-export/video-media/frame-renderer.ts
+++ b/lib/editor/animation-export/video-media/frame-renderer.ts
@@ -3,168 +3,1370 @@
  * WebCodecs frame source, returns a function that produces the fully styled
  * canvas for output frame `i`.
  *
- * Three strategies, in preference order:
+ * Preference order:
  * 1. Composite — rasterize the scene ONCE with the video hidden and draw each
- *    decoded frame onto that template with 2D drawImage. Needs an untilted
- *    video whose box maps linearly to the frame (`measureVideoRegion`).
- * 2. Overlay — paint decoded frames into a `<canvas>` layered over the clone's
- *    `<video>` and rasterize per frame (3D-tilted videos).
+ *    decoded frame onto that template with 2D drawImage. Handles tilt by
+ *    projecting the video's CSS transform quad (Safari cannot reliably re-raster
+ *    a changing `<img>`/`<canvas>` inside html-to-image's foreignObject — most
+ *    frames come back background-only, which looks like intense flicker).
+ *
+ *    Because the video is painted *over* that raster, anything the editor
+ *    stacks above the media would end up behind it. So the scene is captured as
+ *    two layers — underlay and foreground — and each frame is sandwiched
+ *    between them. Components declare which side they belong to via
+ *    data-export-stack; see `export-stack.ts`.
+ * 2. Overlay — paint decoded frames into an `<img>` layered over the clone's
+ *    hidden `<video>` and rasterize per frame (fallback when composite can't
+ *    measure geometry). Includes WebKit settle/retries.
  * 3. DOM seek + rVFC wait — no WebCodecs decode available; best-effort quality.
  */
 
-import type { AnimationCapture } from "../../export"
 import { supportsObjectViewBox } from "../../crop-utils"
+import { enhanceFilterCss } from "../../css-utils"
+import type { AnimationCapture } from "../../export"
+import type { EnhancePreset } from "../../state-types"
+import { drawPortraitDepthOfField } from "../capture"
+import {
+  exportDebugLog,
+  getActiveExportDebug,
+  sampleFrameStats,
+} from "../export-debug"
 import { waitForPaint } from "../utils"
 import type { DecodedFrameSource } from "./decoded-frames"
 import { seekTo, waitForVideoFrame } from "./dom-video"
+import {
+  applyExportStackVisibility,
+  countExportStack,
+  queryForeground,
+} from "./export-stack"
 import type { FramePlan, RenderFrame } from "./frames"
 import { measureVideoRegion } from "./region"
+import { drawImageToQuadGL, type QuadCornerH } from "./warp-gl"
+
+type Point = { x: number; y: number }
 
 /**
- * Overlay a canvas we paint ourselves on top of the clone's `<video>` so the
- * pixels html-to-image rasterizes come from a static `<canvas>` (reliable in
- * every engine) instead of a live `<video>` — which Safari/Firefox render
- * blank/black inside a serialized `<foreignObject>`.
- *
- * The `<video>` stays in the clone only for its box + crop/radius/object-fit
- * styling and natural size; the overlay copies those and sits one layer above,
- * showing the frame we paint (from the WebCodecs decoder). Returns a `paint()`
- * that draws a decoded frame into the overlay, or null when it can't be created.
+ * Effects that apply to the video's own pixels, so they cannot come from the
+ * foreground pass — we draw the decoded frame ourselves and must re-apply them.
+ * Everything that merely sits *above* the media (lighting, overlays, text,
+ * annotations) is captured by the foreground pass instead — see export-stack.
  */
-function overlayVideoFrameCanvas(
-  video: HTMLVideoElement
-): ((frame: CanvasImageSource) => void) | null {
-  const parent = video.parentElement
-  const canvas = document.createElement("canvas")
-  // willReadFrequently forces a CPU-backed canvas. On Safari a GPU-backed 2D
-  // context can return a *black* draw of decoded video (WebKit GPU-process bug
-  // #237424 / Apple dev thread 708348); the CPU path draws the real pixels.
-  const ctx = canvas.getContext("2d", { willReadFrequently: true })
-  if (!parent || !ctx) return null
+export type VideoMediaFx = {
+  enhance?: EnhancePreset | null
+}
 
-  // Reuse the video's own box + crop/radius/object-fit styling so the overlay
-  // lands exactly where the video renders. A cropped video is absolutely
-  // positioned (overflow polyfill); an uncropped one fills its parent in flow,
-  // so force absolute inset-0 in that case to actually overlay rather than stack.
-  canvas.className = video.className
-  canvas.setAttribute("style", video.getAttribute("style") ?? "")
+/** Wait for an `<img>` to finish decoding a new `src` (or fail open). */
+function setImageSource(img: HTMLImageElement, url: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    img.onload = () => resolve()
+    img.onerror = () => resolve()
+    img.src = url
+  })
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Parse CSS `transform-origin` into px relative to the element's border box.
+ */
+function parseTransformOrigin(
+  origin: string,
+  width: number,
+  height: number
+): Point {
+  const parts = origin.trim().split(/\s+/)
+  const parsePart = (
+    raw: string | undefined,
+    size: number,
+    fallback: number
+  ) => {
+    if (!raw) return fallback
+    if (raw.endsWith("%")) {
+      const n = parseFloat(raw)
+      return Number.isFinite(n) ? (n / 100) * size : fallback
+    }
+    if (raw === "left" || raw === "top") return 0
+    if (raw === "right" || raw === "bottom") return size
+    if (raw === "center") return size / 2
+    const n = parseFloat(raw)
+    return Number.isFinite(n) ? n : fallback
+  }
+  return {
+    x: parsePart(parts[0], width, width / 2),
+    y: parsePart(parts[1], height, height / 2),
+  }
+}
+
+/**
+ * The nearest ancestor-or-self carrying the 3D transform, or null.
+ *
+ * The tilt lives on some wrapper around the `<video>`, never on the video
+ * itself, but *which* wrapper depends on the render path (bare / framed / row
+ * item). Identify it by the property that actually matters — carrying a 3D
+ * matrix — rather than guessing from a marker attribute: attribute guesses put
+ * the video in an untransformed 1026×614 wrapper while the real tilt sat on a
+ * 982×616 div inside it, and it exported flat.
+ */
+function resolveTransformCarrier(
+  el: HTMLElement,
+  root: HTMLElement
+): HTMLElement | null {
+  let node: HTMLElement | null = el
+  while (node) {
+    if (getComputedStyle(node).transform.startsWith("matrix3d(")) return node
+    if (node === root) break
+    node = node.parentElement
+  }
+  return null
+}
+
+/** A planar box projected into capture-root CSS px, perspective included. */
+type QuadProjection = {
+  corners: [Point, Point, Point, Point]
+  localW: number
+  localH: number
+  /** Border-box px within the element → capture-root CSS px. */
+  project: (x: number, y: number) => Point
+  /** Same, but keeping the homogeneous w the GPU warp needs to interpolate. */
+  projectH: (x: number, y: number) => QuadCornerH
+  /** True when the CSS matrix carries a perspective component (w varies). */
+  hasPerspective: boolean
+  /** Untransformed top-left of the box, in capture-root CSS px. */
+  origin: Point
+}
+
+/**
+ * Project `target`'s border box into the capture root's CSS-px space, through
+ * the 3D transform carried by `carrier` (an ancestor-or-self of target).
+ *
+ * Splitting carrier from target matters: the element holding the tilt is often a
+ * wrapper, while the box we need to paint into is the `<video>` (or an overlay)
+ * nested inside it. Projecting the carrier's own box instead would paint the
+ * video into the wrapper's rectangle.
+ *
+ * Clears the carrier's transform to read untransformed layout, then re-applies
+ * the computed matrix around its transform-origin.
+ */
+function projectElementQuad(
+  root: HTMLElement,
+  carrier: HTMLElement,
+  target: HTMLElement = carrier
+): QuadProjection | null {
+  const style = getComputedStyle(carrier)
+  const cssTransform = style.transform
+
+  // Untransformed layout — the transform MUST be cleared on the carrier (the
+  // element that actually has it), not on a child reporting transform:none.
+  const prevInline = carrier.style.transform
+  carrier.style.transform = "none"
+  void carrier.offsetWidth
+  const rootRect = root.getBoundingClientRect()
+  const carrierBox = carrier.getBoundingClientRect()
+  const box = target === carrier ? carrierBox : target.getBoundingClientRect()
+  carrier.style.transform = prevInline
+  void carrier.offsetWidth
+
+  // Prefer getBoundingClientRect size (after transform:none) over offsetWidth —
+  // offset* can disagree under subpixel layout / export clones.
+  const localW = box.width
+  const localH = box.height
+  if (!rootRect.width || !localW || !localH) return null
+
+  const ox = box.left - rootRect.left
+  const oy = box.top - rootRect.top
+
+  const untransformed = (): QuadProjection => {
+    const project = (x: number, y: number) => ({ x: ox + x, y: oy + y })
+    return {
+      projectH: (x, y) => ({ ...project(x, y), w: 1 }),
+      corners: [
+        { x: ox, y: oy },
+        { x: ox + localW, y: oy },
+        { x: ox + localW, y: oy + localH },
+        { x: ox, y: oy + localH },
+      ],
+      localW,
+      localH,
+      project,
+      hasPerspective: false,
+      origin: { x: ox, y: oy },
+    }
+  }
+
+  if (!cssTransform || cssTransform === "none") return untransformed()
+
+  let matrix: DOMMatrix
+  try {
+    matrix = new DOMMatrix(cssTransform)
+  } catch {
+    return untransformed()
+  }
+
+  // The matrix acts around the carrier's transform-origin, in the carrier's
+  // local space — so target coordinates are offset into that space first.
+  const origin = parseTransformOrigin(
+    style.transformOrigin,
+    carrierBox.width,
+    carrierBox.height
+  )
+  const localMatrix = new DOMMatrix()
+    .translate(origin.x, origin.y)
+    .multiply(matrix)
+    .translate(-origin.x, -origin.y)
+
+  const targetX = box.left - carrierBox.left
+  const targetY = box.top - carrierBox.top
+  const carrierOx = carrierBox.left - rootRect.left
+  const carrierOy = carrierBox.top - rootRect.top
+
+  /**
+   * CSS flattens a 3D transform to 2D with a perspective divide. DOMPoint's
+   * matrixTransform returns the raw homogeneous point and does NOT divide by w,
+   * so reading `p.x`/`p.y` silently mis-sizes any perspective-tilted box (the
+   * editor's tilt bakes perspective() into the matrix, giving w ≈ 0.82–1.18).
+   */
+  const projectH = (x: number, y: number): QuadCornerH => {
+    const p = new DOMPoint(targetX + x, targetY + y, 0, 1).matrixTransform(
+      localMatrix
+    )
+    // w <= 0 is behind the camera — no sane 2D image; fall back to no divide.
+    const w = p.w > 1e-6 ? p.w : 1
+    return { x: carrierOx + p.x / w, y: carrierOy + p.y / w, w }
+  }
+  const project = (x: number, y: number): Point => {
+    const { x: px, y: py } = projectH(x, y)
+    return { x: px, y: py }
+  }
+
+  const cornerPoints = (
+    [
+      [0, 0],
+      [localW, 0],
+      [localW, localH],
+      [0, localH],
+    ] as const
+  ).map(([x, y]) => projectH(x, y))
+
+  return {
+    corners: cornerPoints.map(({ x, y }) => ({ x, y })) as [
+      Point,
+      Point,
+      Point,
+      Point,
+    ],
+    localW,
+    localH,
+    project,
+    projectH,
+    hasPerspective: cornerPoints.some((c) => Math.abs(c.w - 1) > 1e-4),
+    origin: { x: ox, y: oy },
+  }
+}
+
+/**
+ * An element whose rasterized shape WebKit gets wrong: `el` is what we paint,
+ * `carrier` is the ancestor-or-self holding the 3D matrix that bends it.
+ */
+type ProjectedLayer = {
+  el: HTMLElement
+  carrier: HTMLElement
+  quad: QuadProjection
+}
+
+/**
+ * The projection for one element, via whichever ancestor carries the tilt, or
+ * null when nothing bends its box. Works for elements that inherit a transform
+ * from a wrapper rather than carrying one themselves — inner lighting nested in
+ * a tilted shell has no matrix3d of its own, but is bent all the same.
+ */
+function projectionFor(
+  root: HTMLElement,
+  el: HTMLElement
+): ProjectedLayer | null {
+  const carrier = resolveTransformCarrier(el, root)
+  if (!carrier) return null
+  const quad = projectElementQuad(root, carrier, el)
+  return quad?.hasPerspective ? { el, carrier, quad } : null
+}
+
+/**
+ * Every element whose box the raster will flatten, outermost first.
+ *
+ * `perspective()` alone is not enough to matter: the editor always emits
+ * `perspective(1400px) rotateX(0) …`, and with no rotation every corner sits at
+ * z=0, so w stays 1 and the flat and perspective projections are identical. The
+ * test is whether w actually varies across the corners — `hasPerspective` —
+ * which is what makes a box bend. `matrix3d` is a cheap pre-filter (2D
+ * transforms serialize as `matrix`).
+ *
+ * Nested hits are dropped: projecting an ancestor already carries its subtree,
+ * and projecting both would apply the transform twice.
+ */
+function collectProjectedLayers(root: HTMLElement): ProjectedLayer[] {
+  const candidates = Array.from(root.querySelectorAll<HTMLElement>("*")).filter(
+    (el) => getComputedStyle(el).transform.startsWith("matrix3d(")
+  )
+  const outermost = candidates.filter(
+    (el) => !candidates.some((other) => other !== el && other.contains(el))
+  )
+  const layers: ProjectedLayer[] = []
+  for (const el of outermost) {
+    const quad = projectElementQuad(root, el)
+    if (quad?.hasPerspective) layers.push({ el, carrier: el, quad })
+  }
+  return layers
+}
+
+/**
+ * Draw `image` (source rect → full image if omitted) into a destination
+ * triangle using an affine map. Used to approximate a projected quad.
+ */
+function drawTexturedTriangle(
+  ctx: CanvasRenderingContext2D,
+  image: CanvasImageSource,
+  s0: Point,
+  s1: Point,
+  s2: Point,
+  d0: Point,
+  d1: Point,
+  d2: Point
+) {
+  // Cells share exact edges and must not overlap: drawing a translucent texture
+  // twice composites it twice (2a - a²), which prints the grid straight onto any
+  // semi-transparent layer like inner lighting.
+  ctx.save()
+  ctx.beginPath()
+  ctx.moveTo(d0.x, d0.y)
+  ctx.lineTo(d1.x, d1.y)
+  ctx.lineTo(d2.x, d2.y)
+  ctx.closePath()
+  ctx.clip()
+
+  // Solve the affine transform that maps source triangle → dest triangle.
+  // | a c e |   | x |   | x' |
+  // | b d f | * | y | = | y' |
+  // | 0 0 1 |   | 1 |   | 1  |
+  const denom =
+    s0.x * (s1.y - s2.y) + s1.x * (s2.y - s0.y) + s2.x * (s0.y - s1.y)
+  if (Math.abs(denom) < 1e-6) {
+    ctx.restore()
+    return
+  }
+
+  const a =
+    (d0.x * (s1.y - s2.y) + d1.x * (s2.y - s0.y) + d2.x * (s0.y - s1.y)) / denom
+  const b =
+    (d0.y * (s1.y - s2.y) + d1.y * (s2.y - s0.y) + d2.y * (s0.y - s1.y)) / denom
+  const c =
+    (d0.x * (s2.x - s1.x) + d1.x * (s0.x - s2.x) + d2.x * (s1.x - s0.x)) / denom
+  const d =
+    (d0.y * (s2.x - s1.x) + d1.y * (s0.x - s2.x) + d2.y * (s1.x - s0.x)) / denom
+  const e =
+    (d0.x * (s1.x * s2.y - s2.x * s1.y) +
+      d1.x * (s2.x * s0.y - s0.x * s2.y) +
+      d2.x * (s0.x * s1.y - s1.x * s0.y)) /
+    denom
+  const f =
+    (d0.y * (s1.x * s2.y - s2.x * s1.y) +
+      d1.y * (s2.x * s0.y - s0.x * s2.y) +
+      d2.y * (s0.x * s1.y - s1.x * s0.y)) /
+    denom
+
+  ctx.setTransform(a, b, c, d, e, f)
+  ctx.drawImage(image, 0, 0)
+  ctx.restore()
+}
+
+/** Maps normalized (u, v) in [0,1]² across the media box → destination px. */
+export type UvProjector = (u: number, v: number) => Point
+
+/** Same, carrying the homogeneous w so the GPU can do the divide exactly. */
+export type UvProjectorH = (u: number, v: number) => QuadCornerH
+
+/**
+ * A canvas 2D transform is affine, so it cannot reproduce a perspective divide:
+ * mapping the whole quad with two triangles bows the image badly (measured >100px
+ * of interior error at the editor's default tilt). Subdividing into a grid keeps
+ * each cell's affine error sub-pixel, since the error shrinks with cell size.
+ *
+ * Returns the coarsest grid whose worst probe stays under `tolerancePx`. Pure
+ * rotateZ/scale/translate has no perspective and is exact at 1×1.
+ */
+export function chooseQuadSubdivision(
+  project: UvProjector,
+  tolerancePx = 0.5
+): number {
+  for (const n of [1, 2, 4, 8, 16, 24, 32]) {
+    if (quadAffineError(project, n) <= tolerancePx) return n
+  }
+  return 32
+}
+
+/** Worst affine-vs-true deviation over a grid, probed per triangle. */
+export function quadAffineError(project: UvProjector, n: number): number {
+  let worst = 0
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      const u0 = i / n
+      const u1 = (i + 1) / n
+      const v0 = j / n
+      const v1 = (j + 1) / n
+      const tris: [Point, Point, Point][] = [
+        [
+          { x: u0, y: v0 },
+          { x: u1, y: v0 },
+          { x: u0, y: v1 },
+        ],
+        [
+          { x: u1, y: v0 },
+          { x: u1, y: v1 },
+          { x: u0, y: v1 },
+        ],
+      ]
+      for (const [a, b, c] of tris) {
+        const da = project(a.x, a.y)
+        const db = project(b.x, b.y)
+        const dc = project(c.x, c.y)
+        // Affine is exact at the vertices, so probe the interior + edges.
+        const probes: [number, number, number][] = [
+          [1 / 3, 1 / 3, 1 / 3],
+          [0.5, 0.5, 0],
+          [0, 0.5, 0.5],
+          [0.5, 0, 0.5],
+        ]
+        for (const [wa, wb, wc] of probes) {
+          const u = a.x * wa + b.x * wb + c.x * wc
+          const v = a.y * wa + b.y * wb + c.y * wc
+          const truePt = project(u, v)
+          const approx = {
+            x: da.x * wa + db.x * wb + dc.x * wc,
+            y: da.y * wa + db.y * wb + dc.y * wc,
+          }
+          worst = Math.max(
+            worst,
+            Math.hypot(truePt.x - approx.x, truePt.y - approx.y)
+          )
+          if (worst > 1e4) return worst
+        }
+      }
+    }
+  }
+  return worst
+}
+
+/**
+ * Map a full image onto a projected quad, preferring the GPU.
+ *
+ * The subdivided 2D path is a fallback: its cells cannot share an edge cleanly
+ * (see warp-gl.ts), so it trades a seam lattice for the perspective it can't
+ * otherwise express. Returns which path ran, for the debug log.
+ */
+function drawImageToQuadWarp(
+  ctx: CanvasRenderingContext2D,
+  image: HTMLCanvasElement,
+  srcW: number,
+  srcH: number,
+  project: UvProjectorH,
+  subdivisions: number
+): "gl" | "grid" {
+  const corners: [QuadCornerH, QuadCornerH, QuadCornerH, QuadCornerH] = [
+    project(0, 0),
+    project(1, 0),
+    project(1, 1),
+    project(0, 1),
+  ]
+  if (drawImageToQuadGL(ctx, image, srcW, srcH, corners)) return "gl"
+  drawImageToQuad(ctx, image, srcW, srcH, project, subdivisions)
+  return "grid"
+}
+
+/**
+ * Map a full image onto a projected quad via an `n × n` grid of affine cells.
+ */
+function drawImageToQuad(
+  ctx: CanvasRenderingContext2D,
+  image: CanvasImageSource,
+  srcW: number,
+  srcH: number,
+  project: UvProjector,
+  n: number
+) {
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      const u0 = i / n
+      const u1 = (i + 1) / n
+      const v0 = j / n
+      const v1 = (j + 1) / n
+
+      const s00 = { x: u0 * srcW, y: v0 * srcH }
+      const s10 = { x: u1 * srcW, y: v0 * srcH }
+      const s11 = { x: u1 * srcW, y: v1 * srcH }
+      const s01 = { x: u0 * srcW, y: v1 * srcH }
+
+      const d00 = project(u0, v0)
+      const d10 = project(u1, v0)
+      const d11 = project(u1, v1)
+      const d01 = project(u0, v1)
+
+      drawTexturedTriangle(ctx, image, s00, s10, s01, d00, d10, d01)
+      drawTexturedTriangle(ctx, image, s10, s11, s01, d10, d11, d01)
+    }
+  }
+}
+
+/**
+ * Paint a decoded frame into a local buffer the size of the shell's layout box,
+ * honoring object-fit/object-position and the media's own enhance filter.
+ * Overlays that sit above the media come from the foreground pass, not here.
+ */
+function paintFrameToLocalBox(
+  frame: CanvasImageSource,
+  localW: number,
+  localH: number,
+  video: HTMLVideoElement,
+  fw: number,
+  fh: number,
+  borderRadius = 0,
+  mediaFx?: VideoMediaFx | null
+): HTMLCanvasElement | null {
+  const buf = document.createElement("canvas")
+  buf.width = Math.max(1, Math.round(localW))
+  buf.height = Math.max(1, Math.round(localH))
+  const ctx = buf.getContext("2d", { willReadFrequently: true })
+  if (!ctx) return null
+
+  const style = getComputedStyle(video)
+  const fit = style.objectFit || "contain"
+  const radius =
+    borderRadius > 0
+      ? borderRadius
+      : Math.max(0, parseFloat(style.borderRadius) || 0)
+  if (radius > 0 && typeof ctx.roundRect === "function") {
+    ctx.beginPath()
+    ctx.roundRect(0, 0, buf.width, buf.height, radius)
+    ctx.clip()
+  }
+
+  let dw = buf.width
+  let dh = buf.height
+  let dx = 0
+  let dy = 0
+  if (fit === "contain" || fit === "cover") {
+    const s =
+      fit === "contain"
+        ? Math.min(buf.width / fw, buf.height / fh)
+        : Math.max(buf.width / fw, buf.height / fh)
+    dw = fw * s
+    dh = fh * s
+    const pos = style.objectPosition.split(" ")
+    const parsePos = (raw: string | undefined, slack: number) => {
+      if (!raw) return slack / 2
+      const n = parseFloat(raw)
+      if (!Number.isFinite(n)) return slack / 2
+      return raw.trim().endsWith("%") ? (n / 100) * slack : n
+    }
+    dx = parsePos(pos[0], buf.width - dw)
+    dy = parsePos(pos[1], buf.height - dh)
+  }
+
+  try {
+    const enhance = mediaFx?.enhance
+      ? enhanceFilterCss(mediaFx.enhance)
+      : undefined
+    if (enhance) ctx.filter = enhance
+    ctx.drawImage(frame, 0, 0, fw, fh, dx, dy, dw, dh)
+    ctx.filter = "none"
+  } catch {
+    return null
+  }
+
+  return buf
+}
+
+/**
+ * Capture a scene template, retrying on Safari when html-to-image returns an
+ * empty/near-empty raster (common on the first few foreignObject paints).
+ */
+async function captureSceneTemplate(
+  capture: AnimationCapture,
+  label: string
+): Promise<HTMLCanvasElement> {
+  const isWebKit = !supportsObjectViewBox()
+  const maxAttempts = isWebKit ? 8 : 2
+  let best: HTMLCanvasElement | null = null
+  let bestScore = -1
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (attempt > 0) await sleep(20 + attempt * 15)
+    else if (capture.needsPaint) await waitForPaint()
+
+    let frame: HTMLCanvasElement
+    try {
+      frame = await capture.captureFrame()
+    } catch (err) {
+      exportDebugLog(
+        "warn",
+        label,
+        `template capture attempt ${attempt + 1} threw`,
+        {
+          error: err instanceof Error ? err.message : String(err),
+        }
+      )
+      continue
+    }
+    const stats = sampleFrameStats(frame)
+    const score = stats?.nonBlackPct ?? 0
+    if (score > bestScore) {
+      bestScore = score
+      best = frame
+    }
+    // Background-only scenes can legitimately be dark; accept anything that
+    // produced a non-zero canvas. For video-hidden templates, mesh backgrounds
+    // typically land around 10–20% non-black.
+    if (frame.width > 0 && frame.height > 0 && score >= 1) {
+      if (attempt > 0) {
+        exportDebugLog("info", label, `template ok on attempt ${attempt + 1}`, {
+          score,
+        })
+      }
+      return frame
+    }
+  }
+  if (best) return best
+  return capture.captureFrame()
+}
+
+/** Detached copy so a later capture can't alias the same canvas buffer. */
+function copyCanvas(src: HTMLCanvasElement): HTMLCanvasElement {
+  const out = document.createElement("canvas")
+  out.width = src.width
+  out.height = src.height
+  const ctx = out.getContext("2d")
+  if (!ctx) throw new Error("Could not get 2d context for canvas copy")
+  ctx.drawImage(src, 0, 0)
+  return out
+}
+
+/** Fraction of sampled pixels with meaningful alpha (0–100). */
+function opaquePct(canvas: HTMLCanvasElement): number {
+  const ctx = canvas.getContext("2d", { willReadFrequently: true })
+  if (!ctx || !canvas.width || !canvas.height) return 0
+  let data: Uint8ClampedArray
+  try {
+    data = ctx.getImageData(0, 0, canvas.width, canvas.height).data
+  } catch {
+    return 0
+  }
+  // Stride the buffer — full scans of an 8K frame are needlessly slow here.
+  const step = Math.max(1, Math.floor(data.length / 4 / 20000)) * 4
+  let seen = 0
+  let opaque = 0
+  for (let i = 3; i < data.length; i += step) {
+    seen++
+    if (data[i] > 8) opaque++
+  }
+  return seen ? (opaque / seen) * 100 : 0
+}
+
+/**
+ * Capture the foreground pass: everything above the media on a transparent
+ * field. Unlike the scene template this is legitimately empty when the canvas
+ * has no foreground layers, so emptiness is judged on alpha, not luminance —
+ * and WebKit only gets retries when we know something *should* be there.
+ */
+async function captureForegroundLayer(
+  capture: AnimationCapture
+): Promise<HTMLCanvasElement | null> {
+  const isWebKit = !supportsObjectViewBox()
+  const maxAttempts = isWebKit ? 6 : 1
+  let best: HTMLCanvasElement | null = null
+  let bestScore = -1
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (attempt > 0) await sleep(20 + attempt * 15)
+    else if (capture.needsPaint) await waitForPaint()
+
+    let frame: HTMLCanvasElement
+    try {
+      frame = await capture.captureFrame()
+    } catch (err) {
+      exportDebugLog(
+        "warn",
+        "renderer.composite",
+        `foreground capture attempt ${attempt + 1} threw`,
+        { error: err instanceof Error ? err.message : String(err) }
+      )
+      continue
+    }
+    if (!frame.width || !frame.height) continue
+    const score = opaquePct(frame)
+    if (score > bestScore) {
+      bestScore = score
+      best = copyCanvas(frame)
+    }
+    if (score > 0.05) {
+      exportDebugLog(
+        "info",
+        "renderer.composite",
+        "foreground layer captured",
+        {
+          attempt: attempt + 1,
+          opaquePct: Number(score.toFixed(2)),
+          width: frame.width,
+          height: frame.height,
+        }
+      )
+      return best
+    }
+  }
+
+  exportDebugLog(
+    "warn",
+    "renderer.composite",
+    "foreground layer came back empty — overlays may be missing",
+    { opaquePct: Number(Math.max(0, bestScore).toFixed(2)) }
+  )
+  return best
+}
+
+/**
+ * Overlay an `<img>` we repaint from decoded frames (fallback path only).
+ * Prefer composite — Safari foreignObject drops changing images most frames.
+ */
+function overlayVideoFrameImage(
+  video: HTMLVideoElement
+): ((frame: CanvasImageSource) => Promise<void>) | null {
+  const parent = video.parentElement
+  if (!parent) return null
+
+  const scratch = document.createElement("canvas")
+  const ctx = scratch.getContext("2d", { willReadFrequently: true })
+  if (!ctx) return null
+
+  const img = document.createElement("img")
+  img.className = video.className
+  img.setAttribute("style", video.getAttribute("style") ?? "")
   const position = getComputedStyle(video).position
   if (position === "static" || position === "relative") {
-    canvas.style.position = "absolute"
-    canvas.style.inset = "0"
+    img.style.position = "absolute"
+    img.style.inset = "0"
   }
-  canvas.style.pointerEvents = "none"
-  parent.insertBefore(canvas, video.nextSibling)
+  img.style.pointerEvents = "none"
+  parent.insertBefore(img, video.nextSibling)
+  video.style.visibility = "hidden"
 
-  return (frame: CanvasImageSource) => {
-    // Size the overlay to the decoded frame's own intrinsic dimensions so the
-    // copied object-fit maps it to the display box exactly as it does for the
-    // video (and so we don't depend on the DOM <video>.videoWidth, which is
-    // unreliable on Safari for an unplayed clone).
+  let lastFrame: CanvasImageSource | null = null
+  let lastBlobUrl: string | null = null
+
+  return async (frame: CanvasImageSource) => {
+    if (frame === lastFrame) return
+
     const w = "width" in frame ? Number(frame.width) : video.videoWidth
     const h = "height" in frame ? Number(frame.height) : video.videoHeight
     if (!w || !h) return
-    // Setting width/height also clears the canvas; only clear explicitly when
-    // the size is unchanged.
-    if (canvas.width !== w || canvas.height !== h) {
-      canvas.width = w
-      canvas.height = h
+    if (scratch.width !== w || scratch.height !== h) {
+      scratch.width = w
+      scratch.height = h
     } else {
       ctx.clearRect(0, 0, w, h)
     }
     try {
       ctx.drawImage(frame, 0, 0, w, h)
     } catch {
-      // Frame not drawable — keep the previous paint rather than blanking.
+      return
     }
+
+    // Blob URLs (not data URLs): html-to-image re-embeds them fresh each capture
+    // instead of trusting a giant inline data URI that Safari often skips.
+    const blob = await new Promise<Blob | null>((resolve) =>
+      scratch.toBlob((b) => resolve(b), "image/jpeg", 0.92)
+    )
+    if (!blob) return
+    if (lastBlobUrl) URL.revokeObjectURL(lastBlobUrl)
+    const url = URL.createObjectURL(blob)
+    lastBlobUrl = url
+    await setImageSource(img, url)
+    if (typeof img.decode === "function") {
+      try {
+        await img.decode()
+      } catch {
+        // decode() can reject on transient state — onload already fired.
+      }
+    }
+    lastFrame = frame
   }
 }
 
 /**
- * Composite path: one scene raster reused for every frame, with the decoded
- * frame drawn into the measured video region. Returns null when the video's
- * rect can't be measured (non-linear map), so the caller can fall back.
+ * Rasterize one foreground element with its transform removed, then project it
+ * ourselves onto its own quad.
+ *
+ * WebKit bakes a perspective transform flat inside foreignObject, so an overlay
+ * that carries the media's tilt (inner lighting) comes back the wrong shape and
+ * sits misaligned over the correctly-projected video. Capturing it untransformed
+ * gives the raster nothing to flatten; the projection is then ours to do, with
+ * the same maths the video goes through.
+ */
+async function captureProjectedElement(
+  capture: AnimationCapture,
+  layer: ProjectedLayer,
+  scale: number,
+  width: number,
+  height: number,
+  /** Foreground nodes inside `el` — they composite above the video, not here. */
+  excludeForeground: HTMLElement[] = []
+): Promise<HTMLCanvasElement | null> {
+  const { el, carrier, quad } = layer
+
+  // box-shadow / drop-shadow paint outside the border box and are transformed
+  // with the element, so the texture has to include them or a tilted shadow gets
+  // sheared off at the box edge.
+  const pad = shadowExtentPx(el)
+
+  const restoreVisibility = applyExportStackVisibility(
+    capture.node,
+    "foreground",
+    { only: [el] }
+  )
+  // Nested foreground nodes inherit `el`'s visibility, so re-hide them.
+  const restoreHidden = excludeForeground
+    .filter((f) => f !== el && el.contains(f))
+    .map((f) => {
+      const prev = f.style.visibility
+      f.style.visibility = "hidden"
+      return () => {
+        f.style.visibility = prev
+      }
+    })
+  // Clear the transform on the *carrier*: `el` may merely inherit it, and
+  // clearing a child that reports transform:none would change nothing.
+  const prevTransform = carrier.style.transform
+  carrier.style.transform = "none"
+  let raster: HTMLCanvasElement | null = null
+  try {
+    raster = await captureForegroundLayer(capture)
+  } finally {
+    carrier.style.transform = prevTransform
+    for (const restore of restoreHidden) restore()
+    restoreVisibility()
+  }
+  if (!raster) return null
+
+  // With the transform cleared the element rasterizes into its untransformed
+  // layout box; lift that box (plus the shadow margin) out as the quad texture.
+  const boxW = quad.localW + pad * 2
+  const boxH = quad.localH + pad * 2
+  const cropW = Math.max(1, Math.round(boxW * scale))
+  const cropH = Math.max(1, Math.round(boxH * scale))
+  const local = document.createElement("canvas")
+  local.width = cropW
+  local.height = cropH
+  const lctx = local.getContext("2d")
+  if (!lctx) return null
+  lctx.drawImage(
+    raster,
+    (quad.origin.x - pad) * scale,
+    (quad.origin.y - pad) * scale,
+    cropW,
+    cropH,
+    0,
+    0,
+    cropW,
+    cropH
+  )
+
+  const out = document.createElement("canvas")
+  out.width = width
+  out.height = height
+  const octx = out.getContext("2d")
+  if (!octx) return null
+  // The padded box maps through the same matrix — it is linear, so points
+  // outside the border box project just as correctly as the corners.
+  const projectUV: UvProjectorH = (u, v) => {
+    const p = quad.projectH(u * boxW - pad, v * boxH - pad)
+    return { x: p.x * scale, y: p.y * scale, w: p.w }
+  }
+  const subdivisions = chooseQuadSubdivision(projectUV)
+  const warp = drawImageToQuadWarp(
+    octx,
+    local,
+    local.width,
+    local.height,
+    projectUV,
+    subdivisions
+  )
+  exportDebugLog("info", "renderer.composite", "projected layer", {
+    tag: el.tagName,
+    stack: el.getAttribute("data-export-stack"),
+    warp,
+    subdivisions,
+    localW: quad.localW,
+    localH: quad.localH,
+    shadowPadPx: pad,
+  })
+  return out
+}
+
+/**
+ * How far this element's shadows reach beyond its border box, in CSS px.
+ *
+ * Colour functions are stripped first so their commas don't break the
+ * per-shadow split and their numbers aren't mistaken for lengths.
+ */
+function shadowExtentPx(el: HTMLElement): number {
+  const cs = getComputedStyle(el)
+  let max = 0
+  for (const source of [cs.boxShadow, cs.filter]) {
+    if (!source || source === "none") continue
+    const cleaned = source.replace(/(rgba?|hsla?|color)\([^)]*\)/g, " ")
+    for (const part of cleaned.split(",")) {
+      const nums = (part.match(/-?\d+(?:\.\d+)?(?=px)/g) ?? []).map(Number)
+      if (nums.length === 0) continue
+      const [dx = 0, dy = 0, blur = 0, spread = 0] = nums
+      max = Math.max(
+        max,
+        Math.abs(dx) + Math.abs(dy) + Math.abs(blur) + Math.abs(spread)
+      )
+    }
+  }
+  return Math.ceil(max)
+}
+
+/**
+ * Build the single foreground raster drawn over every composited frame.
+ *
+ * Perspective-carrying layers are projected individually (the raster would
+ * flatten them); everything else comes from one flat capture. The projected ones
+ * are painted first: they are locked to the media box and sit at the bottom of
+ * the foreground (inner lighting is z-10, below text/overlays/annotations).
+ */
+async function buildForegroundLayer(
+  capture: AnimationCapture,
+  scale: number,
+  width: number,
+  height: number
+): Promise<HTMLCanvasElement | null> {
+  const all = queryForeground(capture.node)
+  if (all.length === 0) return null
+  // Each foreground node is projected on its own if anything bends it — whether
+  // it carries the transform or inherits one from a tilted wrapper.
+  const perspective: ProjectedLayer[] = []
+  const flat: HTMLElement[] = []
+  for (const el of all) {
+    const layer = projectionFor(capture.node, el)
+    if (layer) perspective.push(layer)
+    else flat.push(el)
+  }
+
+  exportDebugLog("info", "renderer.composite", "foreground groups", {
+    total: all.length,
+    perspective: perspective.length,
+    flat: flat.length,
+  })
+  getActiveExportDebug()?.setMeta("foregroundGroups", {
+    total: all.length,
+    perspective: perspective.length,
+    flat: flat.length,
+  })
+
+  const out = document.createElement("canvas")
+  out.width = width
+  out.height = height
+  const ctx = out.getContext("2d")
+  if (!ctx) return null
+  let painted = false
+
+  for (const layer of perspective) {
+    const canvas = await captureProjectedElement(
+      capture,
+      layer,
+      scale,
+      width,
+      height
+    )
+    if (canvas) {
+      ctx.drawImage(canvas, 0, 0)
+      painted = true
+    }
+  }
+
+  if (flat.length > 0) {
+    const restore = applyExportStackVisibility(capture.node, "foreground", {
+      only: flat,
+    })
+    try {
+      const layer = await captureForegroundLayer(capture)
+      if (layer) {
+        ctx.drawImage(layer, 0, 0)
+        painted = true
+      }
+    } finally {
+      restore()
+    }
+  }
+
+  return painted ? out : null
+}
+
+/**
+ * Composite path: one scene raster reused for every frame, with each decoded
+ * frame drawn into the shell's projected quad (includes CSS 3D tilt).
  */
 async function createCompositeRenderer(
   capture: AnimationCapture,
   video: HTMLVideoElement,
   decoded: DecodedFrameSource,
-  plan: FramePlan
+  plan: FramePlan,
+  mediaFx?: VideoMediaFx | null
 ): Promise<RenderFrame | null> {
-  const region = measureVideoRegion(capture.node, video)
-  if (!region) return null
-
-  // Hide the <video> so the one-off scene raster has no baked-in frame to
-  // bleed through; we paint every frame's video ourselves.
-  video.style.visibility = "hidden"
-  if (capture.needsPaint) await waitForPaint()
-  // This single scene raster is reused for every frame, so make sure it
-  // lands — html-to-image's first call can be flaky (fonts/images not yet
-  // embedded in the clone).
-  let template: HTMLCanvasElement
-  try {
-    template = await capture.captureFrame()
-  } catch {
-    template = await capture.captureFrame()
+  // Seed natural size from the DOM video; fall back to the first decoded frame
+  // when Safari reports 0×0 on an unplayed clone.
+  let naturalW = video.videoWidth
+  let naturalH = video.videoHeight
+  if (!naturalW || !naturalH) {
+    const seed = await decoded.getFrameAt(0)
+    naturalW = seed ? Number((seed as { width?: unknown }).width) || 0 : 0
+    naturalH = seed ? Number((seed as { height?: unknown }).height) || 0 : 0
   }
-  const scale = template.width / region.rootW
-  const dx = region.destX * scale
-  const dy = region.destY * scale
-  const dw = region.destW * scale
-  const dh = region.destH * scale
+  if (!naturalW || !naturalH) {
+    exportDebugLog(
+      "warn",
+      "renderer.composite",
+      "no natural video size — cannot composite"
+    )
+    return null
+  }
+
+  // Tilt/scale/position live on some wrapper around the <video>. Find the one
+  // that actually carries the 3D matrix and project the *video's own box*
+  // through it — the carrier's box is often a larger, untilted wrapper.
+  const carrier = resolveTransformCarrier(video, capture.node)
+  const shell = carrier ?? video
+
+  // Measure geometry while everything is still laid out and visible.
+  const quad = carrier
+    ? projectElementQuad(capture.node, carrier, video)
+    : projectElementQuad(capture.node, video)
+  const region = measureVideoRegion(capture.node, video)
+
+  if (!quad && !region) {
+    exportDebugLog(
+      "warn",
+      "renderer.composite",
+      "no video geometry — cannot composite"
+    )
+    return null
+  }
+
+  exportDebugLog("info", "renderer.composite", "geometry measured", {
+    hasQuad: !!quad,
+    hasRegion: !!region,
+    naturalW,
+    naturalH,
+    carrierTag: carrier?.tagName ?? null,
+    carrierIsVideoParent: carrier === video.parentElement,
+    carrierHasTransform: !!carrier,
+    videoHasTransform:
+      getComputedStyle(video).transform !== "none" &&
+      !!getComputedStyle(video).transform,
+    quad: quad
+      ? { corners: quad.corners, localW: quad.localW, localH: quad.localH }
+      : null,
+    region,
+  })
+
+  const stackCounts = countExportStack(capture.node)
+  const hasForeground = queryForeground(capture.node).length > 0
+  exportDebugLog("info", "renderer.composite", "export stack", {
+    ...stackCounts,
+    enhance: mediaFx?.enhance ?? "off",
+  })
+
+  // Reference: the untouched scene as the browser itself composites it, before
+  // any layer is hidden. The video usually won't rasterize here (that's the
+  // whole reason for this pipeline), but the backdrop, shell and foreground do —
+  // so this is the ground truth for *framing*, independent of our own maths.
+  // Only when a debug session is listening: it costs a full extra capture.
+  const dbgSession = getActiveExportDebug()
+  if (dbgSession) {
+    try {
+      dbgSession.addLayerSnapshot("reference", await capture.captureFrame())
+    } catch {
+      // Diagnostic only — never fail an export over it.
+    }
+  }
+
+  // Every element whose box the raster would flatten — the media shell (with its
+  // plate, radius, border, frame chrome and shadow) and any tilted overlay. These
+  // are kept out of the flat passes and projected individually below, so nothing
+  // depends on WebKit getting perspective right.
+  const projected = collectProjectedLayers(capture.node)
+  exportDebugLog("info", "renderer.composite", "perspective audit", {
+    projectedLayers: projected.map(({ el, quad: q }) => ({
+      tag: el.tagName,
+      stack: el.getAttribute("data-export-stack"),
+      shadowPadPx: shadowExtentPx(el),
+      localW: Math.round(q.localW),
+      localH: Math.round(q.localH),
+    })),
+  })
+  getActiveExportDebug()?.setMeta(
+    "projectedLayers",
+    projected.map(({ el }) => ({
+      tag: el.tagName,
+      stack: el.getAttribute("data-export-stack"),
+    }))
+  )
+
+  // Pass 1 — underlay: backdrop only. Anything bent by perspective is excluded
+  // and re-projected; without perspective the raster is faithful and stays put.
+  const restoreUnderlay = applyExportStackVisibility(capture.node, "underlay", {
+    alsoHide: projected.map(({ el }) => el),
+  })
+  if (capture.needsPaint) await waitForPaint()
+
+  const templateStarted = performance.now()
+  const template = await captureSceneTemplate(capture, "renderer.composite")
+  const templateCopy = copyCanvas(template)
+  restoreUnderlay()
+
+  // Capture-root CSS px → template px. Every quad is measured in root CSS px,
+  // so the video and each projected layer share this scale.
+  const rootW = region?.rootW ?? capture.node.getBoundingClientRect().width
+  const scale = rootW > 0 ? templateCopy.width / rootW : 1
+
+  // Project the non-foreground bent layers (the media shell) straight onto the
+  // underlay: this is what puts the plate, border, radius, frame chrome and
+  // shadow back — in the right shape — under the video drawn into the same quad.
+  const foregroundEls = queryForeground(capture.node)
+  const underlayProjected = projected.filter(
+    ({ el }) => !foregroundEls.some((f) => f === el || f.contains(el))
+  )
+  const tctx = templateCopy.getContext("2d")
+  for (const layer of underlayProjected) {
+    const canvas = await captureProjectedElement(
+      capture,
+      layer,
+      scale,
+      templateCopy.width,
+      templateCopy.height,
+      foregroundEls
+    )
+    if (canvas && tctx) tctx.drawImage(canvas, 0, 0)
+  }
+  getActiveExportDebug()?.addLayerSnapshot("underlay", templateCopy)
+
+  // Pass 2 — foreground: inner lighting, overlay textures, text, assets,
+  // annotations and slots, built once and drawn over every composited frame.
+  // This is what makes the stacking general: the editor decides what's above the
+  // media via data-export-stack, not this renderer.
+  let foregroundLayer: HTMLCanvasElement | null = null
+  if (hasForeground) {
+    foregroundLayer = await buildForegroundLayer(
+      capture,
+      scale,
+      templateCopy.width,
+      templateCopy.height
+    )
+    if (foregroundLayer) {
+      getActiveExportDebug()?.addLayerSnapshot("foreground", foregroundLayer)
+    }
+  }
+
+  const templateStats = sampleFrameStats(templateCopy)
+  exportDebugLog("info", "renderer.composite", "scene template captured", {
+    durationMs: Math.round(performance.now() - templateStarted),
+    width: templateCopy.width,
+    height: templateCopy.height,
+    stats: templateStats,
+  })
+  getActiveExportDebug()?.setMeta("compositeTemplate", {
+    width: templateCopy.width,
+    height: templateCopy.height,
+    stats: templateStats,
+    region,
+    quad: quad
+      ? { corners: quad.corners, localW: quad.localW, localH: quad.localH }
+      : null,
+    shell: {
+      tag: shell.tagName,
+      localW: quad?.localW ?? null,
+      localH: quad?.localH ?? null,
+    },
+    stack: {
+      ...stackCounts,
+      hasForegroundLayer: !!foregroundLayer,
+      foregroundOpaquePct: foregroundLayer
+        ? Number(opaquePct(foregroundLayer).toFixed(2))
+        : 0,
+    },
+  })
+
   const scratch = document.createElement("canvas")
-  scratch.width = template.width
-  scratch.height = template.height
+  scratch.width = templateCopy.width
+  scratch.height = templateCopy.height
   const sctx = scratch.getContext("2d", { willReadFrequently: true })
   if (!sctx) throw new Error("Could not get 2d context for compositing")
-  const clip = region.clip
+
+  const localW = quad?.localW ?? region?.destW ?? naturalW
+  const localH = quad?.localH ?? region?.destH ?? naturalH
+
+  // Normalized media box → template px, perspective-correct.
+  const projectUV: UvProjectorH | null = quad
+    ? (u, v) => {
+        const p = quad.projectH(u * quad.localW, v * quad.localH)
+        return { x: p.x * scale, y: p.y * scale, w: p.w }
+      }
+    : null
+
+  const useQuad = !!projectUV
+  const subdivisions = projectUV ? chooseQuadSubdivision(projectUV) : 1
+  exportDebugLog(
+    "info",
+    "renderer.composite",
+    useQuad ? "using projected-quad composite" : "using AABB region composite",
+    {
+      scale,
+      localW,
+      localH,
+      hasPerspective: quad?.hasPerspective ?? false,
+      subdivisions,
+      affineErrorPx: projectUV
+        ? Number(quadAffineError(projectUV, subdivisions).toFixed(3))
+        : null,
+    }
+  )
+  getActiveExportDebug()?.setMeta("compositeQuad", {
+    hasPerspective: quad?.hasPerspective ?? false,
+    subdivisions,
+    corners: quad?.corners ?? null,
+  })
+
+  // Border-radius lives on the shell; pass a synthetic style source for local paint.
+  const shellRadius = parseFloat(getComputedStyle(shell).borderRadius) || 0
+  let warpUsed: "gl" | "grid" | null = null
 
   return async (i: number) => {
-    const frame = await decoded.getFrameAt(plan.timeForFrame(i))
+    const t0 = performance.now()
+    const t = plan.timeForFrame(i)
+    const frame = await decoded.getFrameAt(t)
     sctx.clearRect(0, 0, scratch.width, scratch.height)
-    sctx.drawImage(template, 0, 0)
+    sctx.drawImage(templateCopy, 0, 0)
+
+    let drewVideo = false
+    let frameW = 0
+    let frameH = 0
     if (frame) {
-      // Source rect in the decoded frame's own pixel space — sized off the
-      // frame, not <video>.videoWidth, which can disagree (e.g. rotation
-      // metadata) and is unreliable on Safari for an unplayed clone.
-      const fw = Number((frame as { width?: unknown }).width) || 0
-      const fh = Number((frame as { height?: unknown }).height) || 0
+      const fw = Number((frame as { width?: unknown }).width) || naturalW
+      const fh = Number((frame as { height?: unknown }).height) || naturalH
+      frameW = fw
+      frameH = fh
       if (fw > 0 && fh > 0) {
-        sctx.save()
-        // Re-apply the shell's rounded corners: the raw frame rect would
-        // otherwise paint square corners over the template's rounding.
-        if (clip && typeof sctx.roundRect === "function") {
-          sctx.beginPath()
-          sctx.roundRect(
-            clip.x * scale,
-            clip.y * scale,
-            clip.w * scale,
-            clip.h * scale,
-            clip.radii.map((r) => r * scale)
+        if (useQuad && projectUV) {
+          // Paint object-fit into the shell's local box, using the <video>'s
+          // object-fit but the shell's border-radius.
+          const local = paintFrameToLocalBox(
+            frame,
+            localW,
+            localH,
+            video,
+            fw,
+            fh,
+            shellRadius,
+            mediaFx
           )
-          sctx.clip()
+          if (local) {
+            warpUsed = drawImageToQuadWarp(
+              sctx,
+              local,
+              local.width,
+              local.height,
+              projectUV,
+              subdivisions
+            )
+            drewVideo = true
+          }
+        } else if (region) {
+          // AABB path: paint into a local box (with fx) then drawImage that.
+          const local = paintFrameToLocalBox(
+            frame,
+            region.destW,
+            region.destH,
+            video,
+            fw,
+            fh,
+            shellRadius,
+            mediaFx
+          )
+          const dx = region.destX * scale
+          const dy = region.destY * scale
+          const dw = region.destW * scale
+          const dh = region.destH * scale
+          const clip = region.clip
+          sctx.save()
+          if (clip && typeof sctx.roundRect === "function") {
+            sctx.beginPath()
+            sctx.roundRect(
+              clip.x * scale,
+              clip.y * scale,
+              clip.w * scale,
+              clip.h * scale,
+              clip.radii.map((r) => r * scale)
+            )
+            sctx.clip()
+          }
+          if (local) {
+            sctx.drawImage(local, dx, dy, dw, dh)
+          } else {
+            sctx.drawImage(
+              frame,
+              region.srcXFrac * fw,
+              region.srcYFrac * fh,
+              region.srcWFrac * fw,
+              region.srcHFrac * fh,
+              dx,
+              dy,
+              dw,
+              dh
+            )
+          }
+          sctx.restore()
+          drewVideo = true
         }
-        sctx.drawImage(
-          frame,
-          region.srcXFrac * fw,
-          region.srcYFrac * fh,
-          region.srcWFrac * fw,
-          region.srcHFrac * fh,
-          dx,
-          dy,
-          dw,
-          dh
-        )
-        sctx.restore()
       }
     }
+
+    // Everything the editor stacks above the media, back on top of the video.
+    if (foregroundLayer) sctx.drawImage(foregroundLayer, 0, 0)
+
+    // One fully composited frame, to compare against the layers that built it.
+    if (i === 0) getActiveExportDebug()?.addLayerSnapshot("frame0", scratch)
+
+    getActiveExportDebug()?.logFrameSample(
+      "renderer.composite",
+      i,
+      plan.frameCount,
+      scratch,
+      {
+        strategy: useQuad ? "composite-quad" : "composite-aabb",
+        timeSec: t,
+        drewVideo,
+        warp: warpUsed,
+        drewForeground: !!foregroundLayer,
+        decodedFrameSize: { w: frameW, h: frameH },
+        durationMs: Math.round(performance.now() - t0),
+      }
+    )
     return scratch
   }
 }
 
 /**
- * Per-frame rasterization of the clone: decoded frames go through an overlay
- * canvas when available, otherwise the DOM `<video>` is seeked.
+ * Per-frame rasterization of the clone — fallback when composite can't run.
+ * On WebKit, retries captures that come back background-only (foreignObject
+ * nested-image race).
  */
 function createRasterRenderer(
   capture: AnimationCapture,
@@ -173,27 +1375,123 @@ function createRasterRenderer(
   plan: FramePlan,
   signal?: AbortSignal
 ): RenderFrame {
-  const paintOverlay = decoded ? overlayVideoFrameCanvas(video) : null
+  const paintOverlay = decoded ? overlayVideoFrameImage(video) : null
+  const strategy =
+    decoded && paintOverlay
+      ? "raster-overlay-img"
+      : decoded
+        ? "raster-decoded-no-overlay"
+        : "raster-dom-seek"
+  const isWebKit = !supportsObjectViewBox()
+  exportDebugLog("info", "renderer.raster", "using raster path", {
+    strategy,
+    hasDecoded: !!decoded,
+    hasOverlay: !!paintOverlay,
+    supportsObjectViewBox: supportsObjectViewBox(),
+  })
+  getActiveExportDebug()?.setMeta("rendererStrategy", strategy)
+
+  // Background-only captures sit ~13% non-black; with video ~70%.
+  const minNonBlack = 25
+
   return async (i: number) => {
+    const t0 = performance.now()
     const t = plan.timeForFrame(i)
+    let drewDecoded = false
     if (decoded && paintOverlay) {
       const frame = await decoded.getFrameAt(t)
-      if (frame) paintOverlay(frame)
+      if (frame) {
+        await paintOverlay(frame)
+        drewDecoded = true
+      }
     } else {
       await seekTo(video, t, signal)
-      // Only Safari/Firefox need the extra decode wait (and only reach here
-      // when WebCodecs decode was unavailable); Chromium stays as before.
       if (!supportsObjectViewBox()) await waitForVideoFrame(video)
     }
     if (capture.needsPaint) await waitForPaint()
-    return capture.captureFrame()
+
+    let out: HTMLCanvasElement
+    let attempts = 1
+    try {
+      out = await capture.captureFrame()
+      if (isWebKit && drewDecoded) {
+        // Nested images inside SVG foreignObject load async on WebKit — most
+        // first paints miss the video (background-only). Retry until the video
+        // area shows up or we exhaust attempts.
+        for (let attempt = 0; attempt < 10; attempt++) {
+          const stats = sampleFrameStats(out)
+          if ((stats?.nonBlackPct ?? 0) >= minNonBlack) break
+          await sleep(16 + attempt * 12)
+          out = await capture.captureFrame()
+          attempts++
+        }
+      }
+    } catch (err) {
+      exportDebugLog(
+        "error",
+        "renderer.raster",
+        `captureFrame failed at ${i}`,
+        {
+          frameIndex: i,
+          timeSec: t,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      )
+      throw err
+    }
+    getActiveExportDebug()?.logFrameSample(
+      "renderer.raster",
+      i,
+      plan.frameCount,
+      out,
+      {
+        strategy,
+        timeSec: t,
+        drewDecoded,
+        attempts,
+        durationMs: Math.round(performance.now() - t0),
+        videoReadyState: video.readyState,
+        videoCurrentTime: video.currentTime,
+      }
+    )
+    return out
   }
 }
 
 /**
- * Pick and build the frame renderer for this export. `tilted` forces the
- * per-frame raster path: the composite maps the video with a plain rect, which
- * a 3D rotation invalidates.
+ * Portrait blur/stage fake depth-of-field with `backdrop-filter`, which cannot
+ * rasterize inside a foreignObject — the overlay is neutralized during capture
+ * and reconstructed in 2D instead. The Animate paths get this via
+ * `captureStableFrame`; video-media builds its frames here, so without this wrap
+ * the effect is silently dropped from every video export.
+ *
+ * Runs last, on the finished frame, because the overlay sits above the media and
+ * is meant to blur the video too. No-ops when no portrait overlay is tagged.
+ */
+function withPortraitDepthOfField(
+  render: RenderFrame,
+  node: HTMLElement
+): RenderFrame {
+  const count = node.querySelectorAll("[data-export-portrait-fx]").length
+  exportDebugLog("info", "renderer.portrait", "portrait depth-of-field", {
+    overlays: count,
+    applied: count > 0,
+  })
+  getActiveExportDebug()?.setMeta("portraitFx", { overlays: count })
+  if (count === 0) return render
+  return async (i: number) => {
+    const frame = await render(i)
+    drawPortraitDepthOfField(frame, node)
+    return frame
+  }
+}
+
+/**
+ * Pick and build the frame renderer for this export.
+ *
+ * Always prefers composite when WebCodecs frames are available — including
+ * tilted videos (projected quad). Per-frame foreignObject raster of a changing
+ * video overlay flickers hard on Safari (debug logs: ~80% frames background-only).
  */
 export async function createFrameRenderer({
   capture,
@@ -202,6 +1500,7 @@ export async function createFrameRenderer({
   tilted,
   plan,
   signal,
+  mediaFx,
 }: {
   capture: AnimationCapture
   video: HTMLVideoElement
@@ -209,15 +1508,40 @@ export async function createFrameRenderer({
   tilted: boolean
   plan: FramePlan
   signal?: AbortSignal
+  /** Media-pixel effects (enhance) re-applied to the decoded frame. */
+  mediaFx?: VideoMediaFx | null
 }): Promise<RenderFrame> {
-  if (decoded && !tilted) {
+  exportDebugLog("info", "renderer", "selecting strategy", {
+    hasDecoded: !!decoded,
+    tilted,
+    videoWidth: video.videoWidth,
+    videoHeight: video.videoHeight,
+    frameCount: plan.frameCount,
+    mediaFx: { enhance: mediaFx?.enhance ?? null },
+  })
+  if (decoded) {
     const composite = await createCompositeRenderer(
       capture,
       video,
       decoded,
-      plan
+      plan,
+      mediaFx
     )
-    if (composite) return composite
+    if (composite) {
+      exportDebugLog("info", "renderer", "selected composite strategy", {
+        tilted,
+      })
+      getActiveExportDebug()?.setMeta("rendererStrategy", "composite")
+      return withPortraitDepthOfField(composite, capture.node)
+    }
+    exportDebugLog(
+      "warn",
+      "renderer",
+      "composite unavailable, falling back to raster"
+    )
   }
-  return createRasterRenderer(capture, video, decoded, plan, signal)
+  return withPortraitDepthOfField(
+    createRasterRenderer(capture, video, decoded, plan, signal),
+    capture.node
+  )
 }

--- a/lib/editor/animation-export/video-media/index.ts
+++ b/lib/editor/animation-export/video-media/index.ts
@@ -3,11 +3,10 @@
  * downloadable video (MP4/WebM) or GIF, with all styling applied.
  *
  * The styled scene (background, shadow, frame, border, tilt, crop…) always
- * comes from an offscreen clone rasterized with html-to-image; how the moving
- * video pixels get in depends on the engine — see `frame-renderer.ts`, which
- * picks between compositing WebCodecs-decoded frames onto a one-off scene
- * raster (Safari/Firefox) and per-frame rasterization of a seeked `<video>`
- * (Chromium).
+ * comes from an offscreen clone rasterized once with html-to-image; decoded
+ * video frames are then composited in 2D (including CSS 3D tilt via projected
+ * quads). Per-frame foreignObject re-raster of a changing video overlay
+ * flickers on Safari — see `frame-renderer.ts`.
  *
  * This module wires those pieces together: plan the frames (`frames.ts`), build
  * the renderer, and hand it to the GIF (`encode-gif.ts`) or MP4/WebM
@@ -18,6 +17,12 @@ import { supportsObjectViewBox } from "../../crop-utils"
 import { prepareAnimationCapture } from "../../export"
 import { isVideoSrc } from "../../media-type"
 import { useEditorStore } from "../../store"
+import {
+  collectCanvasStyleSnapshot,
+  getActiveExportDebug,
+  startExportDebug,
+  type ExportDebugSession,
+} from "../export-debug"
 import type {
   AnimationExportBlobResult,
   AnimationExportFormat,
@@ -25,6 +30,7 @@ import type {
   WatermarkAssets,
 } from "../types"
 import {
+  AnimationExportAbortedError,
   animationMimeAndExt,
   createProgressReporter,
   even,
@@ -61,116 +67,309 @@ export function canvasIsVideoMedia(canvasId: string): boolean {
   return !!canvas && isVideoSrc(canvas.screenshot)
 }
 
+/**
+ * The export rasterizes an offscreen *clone*, so the exported framing can only
+ * match the editor if the clone lays out identically. Everything downstream
+ * (scene template, projected quad) is measured on the clone and is therefore
+ * self-consistent even when the clone itself is framed wrong — which makes that
+ * class of bug invisible in the rest of the log. Compare the live canvas and the
+ * clone directly, as fractions of their own canvas box, so a mismatch is obvious.
+ */
+function logLiveVsCloneFraming(canvasId: string, cloneNode: HTMLElement) {
+  const dbg = getActiveExportDebug()
+  if (!dbg) return
+
+  const frame = (root: HTMLElement | null) => {
+    const media = root?.querySelector("video")
+    if (!root || !media) return null
+    const rootRect = root.getBoundingClientRect()
+    const box = media.getBoundingClientRect()
+    if (!rootRect.width || !rootRect.height) return null
+    return {
+      canvasW: Number(rootRect.width.toFixed(2)),
+      canvasH: Number(rootRect.height.toFixed(2)),
+      aspect: Number((rootRect.width / rootRect.height).toFixed(4)),
+      // Transformed media box as a fraction of the canvas — resolution-independent,
+      // so the live canvas and the (differently scaled) clone are comparable.
+      mediaPct: {
+        left: Number(((box.left - rootRect.left) / rootRect.width).toFixed(4)),
+        top: Number(((box.top - rootRect.top) / rootRect.height).toFixed(4)),
+        width: Number((box.width / rootRect.width).toFixed(4)),
+        height: Number((box.height / rootRect.height).toFixed(4)),
+      },
+    }
+  }
+
+  const live = frame(
+    document.querySelector<HTMLElement>(`[data-canvas-id="${canvasId}"]`)
+  )
+  const clone = frame(cloneNode)
+  if (!live || !clone) {
+    dbg.info("framing", "live/clone framing unavailable", {
+      hasLive: !!live,
+      hasClone: !!clone,
+    })
+    return
+  }
+
+  const drift = {
+    left: Number((clone.mediaPct.left - live.mediaPct.left).toFixed(4)),
+    top: Number((clone.mediaPct.top - live.mediaPct.top).toFixed(4)),
+    width: Number((clone.mediaPct.width - live.mediaPct.width).toFixed(4)),
+    height: Number((clone.mediaPct.height - live.mediaPct.height).toFixed(4)),
+    aspect: Number((clone.aspect - live.aspect).toFixed(4)),
+  }
+  // 0.5% of the canvas — past rounding, under "you'd never notice".
+  const matches = Math.max(...Object.values(drift).map(Math.abs)) <= 0.005
+
+  dbg.setMeta("framing", { live, clone, drift, matches })
+  dbg.log(
+    matches ? "info" : "warn",
+    "framing",
+    matches
+      ? "clone framing matches the editor"
+      : "clone framing DIFFERS from the editor — export will not match the canvas",
+    { live, clone, drift }
+  )
+}
+
 async function encodeVideoMedia(
   canvasId: string,
   options: VideoMediaExportOptions
 ): Promise<AnimationExportBlobResult> {
   const { onProgress, signal } = options
   const progress = createProgressReporter(onProgress)
+  const dbg: ExportDebugSession | null = startExportDebug(
+    "video-media",
+    canvasId
+  )
 
-  throwIfAborted(signal)
-  progress.report("preparing", 0, 1)
-
-  const state = useEditorStore.getState()
-  const canvas = state.present.canvases.find((c) => c.id === canvasId)
-  if (!canvas || !canvas.screenshot || !isVideoSrc(canvas.screenshot)) {
-    throw new Error("Canvas has no video to export")
-  }
-
-  const format = options.format
-  const fps = Math.max(1, Math.min(60, options.fps ?? 30))
-  const targetWidth = even(options.targetWidth ?? 1080)
-
-  const watermark: WatermarkAssets | null =
-    options.watermark === false
-      ? null
-      : await (async () => {
-          const [logo, fontStack] = await Promise.all([
-            loadWatermarkLogo(),
-            resolveWatermarkFontStack(),
-          ])
-          return { logo, fontStack }
-        })()
-
-  // Offscreen clone of the styled canvas, rasterized per frame (handles tilt,
-  // crop, frames, shadow — everything the DOM renders).
-  const capture = await prepareAnimationCapture(canvasId, targetWidth)
   try {
-    const cloneVideo = capture.node.querySelector("video")
-    if (!cloneVideo) throw new Error("Video element not found in export clone")
-    cloneVideo.muted = true
-    cloneVideo.preload = "auto"
-    await waitForVideoReady(cloneVideo)
+    throwIfAborted(signal)
+    progress.report("preparing", 0, 1)
 
-    const durationSec = cloneVideo.duration
-    if (!Number.isFinite(durationSec) || durationSec <= 0) {
-      throw new Error("Video has no readable duration")
+    const state = useEditorStore.getState()
+    const canvas = state.present.canvases.find((c) => c.id === canvasId)
+    if (!canvas || !canvas.screenshot || !isVideoSrc(canvas.screenshot)) {
+      throw new Error("Canvas has no video to export")
     }
-    const plan = planFrames(durationSec, fps)
 
-    const width = even(capture.width)
-    const height = even(capture.height)
-    const encodeCanvas = document.createElement("canvas")
-    encodeCanvas.width = width
-    encodeCanvas.height = height
-    const ctx = encodeCanvas.getContext("2d")
-    if (!ctx) throw new Error("Could not get 2d context")
+    const format = options.format
+    const fps = Math.max(1, Math.min(60, options.fps ?? 30))
+    const targetWidth = even(options.targetWidth ?? 1080)
 
-    // Safari/Firefox render a live <video> unreliably inside html-to-image's
-    // serialized SVG (foreignObject), and rasterizing it per frame flickers.
-    // There we decode frames with WebCodecs (mediabunny). Chromium rasterizes the
-    // <video> in SVG fine, so it keeps the DOM-seek path. If decode isn't possible
-    // (codec not WebCodecs-decodable), fall back to the DOM path too.
-    const decoded = supportsObjectViewBox()
-      ? null
-      : await createDecodedFrameSource(canvas.screenshot, signal)
-
-    const tilt = canvas.tilt
-    const tilted = !!tilt && (tilt.rx !== 0 || tilt.ry !== 0 || tilt.rz !== 0)
-    const renderFrame = await createFrameRenderer({
-      capture,
-      video: cloneVideo,
-      decoded,
-      tilted,
-      plan,
-      signal,
+    dbg?.mergeMeta({
+      options: {
+        format,
+        fps,
+        targetWidth,
+        scale: options.scale ?? null,
+        watermark: options.watermark !== false,
+        asBlob: !!options.asBlob,
+      },
+      canvasStyle: collectCanvasStyleSnapshot(canvas),
+      supportsObjectViewBox: supportsObjectViewBox(),
+    })
+    dbg?.info("prepare", "starting video-media encode", {
+      format,
+      fps,
+      targetWidth,
     })
 
-    try {
-      const blob =
-        format === "gif"
-          ? await encodeGif(
-              ctx,
-              encodeCanvas,
-              renderFrame,
-              watermark,
-              plan,
-              progress,
-              signal
-            )
-          : await encodeMp4OrWebm(
-              format,
-              ctx,
-              encodeCanvas,
-              renderFrame,
-              watermark,
-              plan,
-              progress,
-              // Exact export length (frameCount / fps), not the raw clip
-              // duration — keeps audio aligned with the styled video track.
-              exportAudioDurationSec(plan),
-              canvas.screenshot,
-              signal
-            )
+    const watermark: WatermarkAssets | null =
+      options.watermark === false
+        ? null
+        : await (async () => {
+            const [logo, fontStack] = await Promise.all([
+              loadWatermarkLogo(),
+              resolveWatermarkFontStack(),
+            ])
+            return { logo, fontStack }
+          })()
+    dbg?.info("prepare", "watermark assets ready", {
+      hasLogo: !!watermark?.logo,
+      fontStack: watermark?.fontStack ?? null,
+    })
 
-      progress.report("finishing", 1, 1)
-      const { contentType, extension } = animationMimeAndExt(format)
-      return { blob, contentType, extension }
+    // Offscreen clone of the styled canvas, rasterized per frame (handles tilt,
+    // crop, frames, shadow — everything the DOM renders).
+    dbg?.info("capture", "prepareAnimationCapture begin")
+    const captureStarted = performance.now()
+    const capture = await prepareAnimationCapture(canvasId, targetWidth)
+    dbg?.info("capture", "prepareAnimationCapture done", {
+      durationMs: Math.round(performance.now() - captureStarted),
+      width: capture.width,
+      height: capture.height,
+      needsPaint: capture.needsPaint,
+    })
+    dbg?.setMeta("capture", {
+      width: capture.width,
+      height: capture.height,
+      needsPaint: capture.needsPaint,
+    })
+    dbg?.logCloneFilters(capture.node)
+    logLiveVsCloneFraming(canvasId, capture.node)
+
+    try {
+      const cloneVideo = capture.node.querySelector("video")
+      if (!cloneVideo)
+        throw new Error("Video element not found in export clone")
+      cloneVideo.muted = true
+      cloneVideo.preload = "auto"
+      dbg?.info("video", "waiting for clone <video> ready", {
+        readyState: cloneVideo.readyState,
+        networkState: cloneVideo.networkState,
+        videoWidth: cloneVideo.videoWidth,
+        videoHeight: cloneVideo.videoHeight,
+        currentSrcKind: cloneVideo.currentSrc
+          ? cloneVideo.currentSrc.startsWith("blob:")
+            ? "blob"
+            : cloneVideo.currentSrc.startsWith("data:")
+              ? "data"
+              : "url"
+          : null,
+      })
+      await waitForVideoReady(cloneVideo)
+      dbg?.info("video", "clone <video> ready", {
+        readyState: cloneVideo.readyState,
+        duration: cloneVideo.duration,
+        videoWidth: cloneVideo.videoWidth,
+        videoHeight: cloneVideo.videoHeight,
+      })
+
+      const durationSec = cloneVideo.duration
+      if (!Number.isFinite(durationSec) || durationSec <= 0) {
+        throw new Error("Video has no readable duration")
+      }
+      const plan = planFrames(durationSec, fps)
+      dbg?.setMeta("plan", {
+        durationSec,
+        fps,
+        frameCount: plan.frameCount,
+        frameDurationSec: plan.frameDurationSec,
+      })
+      dbg?.info("plan", "frame plan", {
+        durationSec,
+        frameCount: plan.frameCount,
+        fps,
+      })
+
+      const width = even(capture.width)
+      const height = even(capture.height)
+      const encodeCanvas = document.createElement("canvas")
+      encodeCanvas.width = width
+      encodeCanvas.height = height
+      const ctx = encodeCanvas.getContext("2d")
+      if (!ctx) throw new Error("Could not get 2d context")
+      dbg?.setMeta("encodeCanvas", { width, height })
+
+      // Safari/Firefox render a live <video> unreliably inside html-to-image's
+      // serialized SVG (foreignObject), and rasterizing it per frame flickers.
+      // There we decode frames with WebCodecs (mediabunny). Chromium rasterizes the
+      // <video> in SVG fine, so it keeps the DOM-seek path. If decode isn't possible
+      // (codec not WebCodecs-decodable), fall back to the DOM path too.
+      const useDomPath = supportsObjectViewBox()
+      dbg?.info("decode", "selecting frame source", {
+        supportsObjectViewBox: useDomPath,
+        preferDecoded: !useDomPath,
+      })
+      const decoded = useDomPath
+        ? null
+        : await createDecodedFrameSource(canvas.screenshot, signal)
+      dbg?.info(
+        "decode",
+        decoded
+          ? "WebCodecs decode source ready"
+          : "no decoded source (DOM path)",
+        {
+          hasDecoded: !!decoded,
+        }
+      )
+      dbg?.setMeta("decodedFrameSource", { hasDecoded: !!decoded })
+
+      const tilt = canvas.tilt
+      const tilted = !!tilt && (tilt.rx !== 0 || tilt.ry !== 0 || tilt.rz !== 0)
+      // Enhance filters the media's own pixels, and the composite path draws
+      // those pixels itself — so it has to re-apply it. Layers that merely sit
+      // above the media are handled by the foreground pass (see export-stack).
+      const mediaFx = { enhance: canvas.enhance }
+      dbg?.info("renderer", "createFrameRenderer begin", {
+        tilted,
+        tilt,
+        mediaFx,
+      })
+      const renderFrame = await createFrameRenderer({
+        capture,
+        video: cloneVideo,
+        decoded,
+        tilted,
+        plan,
+        signal,
+        mediaFx,
+      })
+      dbg?.info("renderer", "createFrameRenderer done")
+
+      try {
+        const blob =
+          format === "gif"
+            ? await encodeGif(
+                ctx,
+                encodeCanvas,
+                renderFrame,
+                watermark,
+                plan,
+                progress,
+                signal
+              )
+            : await encodeMp4OrWebm(
+                format,
+                ctx,
+                encodeCanvas,
+                renderFrame,
+                watermark,
+                plan,
+                progress,
+                // Exact export length (frameCount / fps), not the raw clip
+                // duration — keeps audio aligned with the styled video track.
+                exportAudioDurationSec(plan),
+                canvas.screenshot,
+                signal
+              )
+
+        progress.report("finishing", 1, 1)
+        const { contentType, extension } = animationMimeAndExt(format)
+        dbg?.mergeMeta({
+          result: {
+            contentType,
+            extension,
+            blobSize: blob.size,
+            blobType: blob.type,
+          },
+        })
+        dbg?.info("result", "encode complete", {
+          contentType,
+          extension,
+          blobSize: blob.size,
+        })
+        await dbg?.flush("success")
+        return { blob, contentType, extension }
+      } finally {
+        decoded?.cleanup()
+      }
     } finally {
-      decoded?.cleanup()
+      capture.cleanup()
+      dbg?.info("capture", "capture cleaned up")
     }
-  } finally {
-    capture.cleanup()
+  } catch (err) {
+    const aborted = err instanceof AnimationExportAbortedError
+    dbg?.error("export", aborted ? "export aborted" : "export failed", {
+      error:
+        err instanceof Error
+          ? { name: err.name, message: err.message, stack: err.stack }
+          : String(err),
+    })
+    await dbg?.flush(aborted ? "aborted" : "error", err)
+    throw err
   }
 }
 

--- a/lib/editor/animation-export/video-media/warp-gl.ts
+++ b/lib/editor/animation-export/video-media/warp-gl.ts
@@ -1,0 +1,255 @@
+/**
+ * Perspective-correct quad warp on the GPU.
+ *
+ * The 2D fallback approximates the perspective divide with a grid of affine
+ * cells, and both ways of stitching those cells are visibly wrong:
+ *
+ *   - cells drawn edge-to-edge antialias their clip boundary to ~50% alpha, and
+ *     two touching 50% edges over transparency composite to 75% — a dark lattice
+ *   - overlapping the cells to cover the gap composites translucent layers twice
+ *     (2a − a² ≠ a) — a bright lattice
+ *
+ * There is no inflate that satisfies both, because Canvas2D cannot rasterize a
+ * shared edge watertight. A GL rasterizer can: the quad is two triangles sharing
+ * an exact edge, drawn once, with no interior seams to show.
+ *
+ * The perspective itself is exact rather than approximated. Each corner's
+ * homogeneous w is fed to `gl_Position.w`, so the rasterizer's own
+ * perspective-correct interpolation reproduces the CSS divide — the same thing
+ * the subdivision was spending 24×24 cells to approximate.
+ */
+
+/** A destination corner: already-divided position plus its homogeneous w. */
+export type QuadCornerH = { x: number; y: number; w: number }
+
+const VERT = `
+attribute vec2 a_pos;
+attribute vec2 a_uv;
+attribute float a_q;
+uniform vec2 u_res;
+varying vec2 v_uv;
+void main() {
+  vec2 clip = (a_pos / u_res) * 2.0 - 1.0;
+  // Scaling xy by q with w=q leaves x/w,y/w at the projected point, while
+  // giving the rasterizer the w it needs to interpolate v_uv correctly.
+  gl_Position = vec4(clip.x * a_q, -clip.y * a_q, 0.0, a_q);
+  v_uv = a_uv;
+}
+`
+
+const FRAG = `
+precision highp float;
+varying vec2 v_uv;
+uniform sampler2D u_tex;
+void main() {
+  gl_FragColor = texture2D(u_tex, v_uv);
+}
+`
+
+type GLWarper = {
+  canvas: HTMLCanvasElement
+  gl: WebGLRenderingContext
+  program: WebGLProgram
+  buffer: WebGLBuffer
+  texture: WebGLTexture
+  loc: {
+    pos: number
+    uv: number
+    q: number
+    res: WebGLUniformLocation | null
+    tex: WebGLUniformLocation | null
+  }
+}
+
+/**
+ * One context for the whole export: browsers cap live WebGL contexts (~16) and
+ * silently kill the oldest, so a per-call context would break long exports.
+ */
+let warper: GLWarper | null = null
+let unavailable = false
+
+function compile(
+  gl: WebGLRenderingContext,
+  type: number,
+  src: string
+): WebGLShader | null {
+  const shader = gl.createShader(type)
+  if (!shader) return null
+  gl.shaderSource(shader, src)
+  gl.compileShader(shader)
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    gl.deleteShader(shader)
+    return null
+  }
+  return shader
+}
+
+function createWarper(): GLWarper | null {
+  if (typeof document === "undefined") return null
+  const canvas = document.createElement("canvas")
+  const attrs: WebGLContextAttributes = {
+    alpha: true,
+    // MSAA on the quad's outer edge; the interior shared edge is watertight
+    // regardless, which is the reason for coming to GL at all.
+    antialias: true,
+    depth: false,
+    stencil: false,
+    premultipliedAlpha: true,
+    preserveDrawingBuffer: true,
+  }
+  const gl = (canvas.getContext("webgl", attrs) ??
+    canvas.getContext(
+      "experimental-webgl",
+      attrs
+    )) as WebGLRenderingContext | null
+  if (!gl) return null
+
+  const vs = compile(gl, gl.VERTEX_SHADER, VERT)
+  const fs = compile(gl, gl.FRAGMENT_SHADER, FRAG)
+  const program = gl.createProgram()
+  if (!vs || !fs || !program) return null
+  gl.attachShader(program, vs)
+  gl.attachShader(program, fs)
+  gl.linkProgram(program)
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) return null
+
+  const buffer = gl.createBuffer()
+  const texture = gl.createTexture()
+  if (!buffer || !texture) return null
+
+  gl.bindTexture(gl.TEXTURE_2D, texture)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+
+  canvas.addEventListener("webglcontextlost", (e) => {
+    e.preventDefault()
+    warper = null
+  })
+
+  return {
+    canvas,
+    gl,
+    program,
+    buffer,
+    texture,
+    loc: {
+      pos: gl.getAttribLocation(program, "a_pos"),
+      uv: gl.getAttribLocation(program, "a_uv"),
+      q: gl.getAttribLocation(program, "a_q"),
+      res: gl.getUniformLocation(program, "u_res"),
+      tex: gl.getUniformLocation(program, "u_tex"),
+    },
+  }
+}
+
+function getWarper(): GLWarper | null {
+  if (unavailable) return null
+  if (warper) return warper
+  warper = createWarper()
+  if (!warper) unavailable = true
+  return warper
+}
+
+/** Test seam: reset the module singleton. */
+export function resetQuadWarperForTest() {
+  warper = null
+  unavailable = false
+}
+
+/**
+ * Warp `image` onto the quad `corners` (TL, TR, BR, BL, in `ctx` pixels) and
+ * composite the result into `ctx`. Returns false when GL can't do it and the
+ * caller should fall back to the subdivided 2D path.
+ */
+export function drawImageToQuadGL(
+  ctx: CanvasRenderingContext2D,
+  image: TexImageSource,
+  srcW: number,
+  srcH: number,
+  corners: [QuadCornerH, QuadCornerH, QuadCornerH, QuadCornerH]
+): boolean {
+  // A non-positive w is a corner at or behind the eye plane; the divide has no
+  // finite image and GL would rasterize garbage.
+  if (
+    corners.some(
+      (c) => !(c.w > 1e-6) || !Number.isFinite(c.x) || !Number.isFinite(c.y)
+    )
+  ) {
+    return false
+  }
+
+  const w = ctx.canvas.width
+  const h = ctx.canvas.height
+  if (!w || !h) return false
+
+  const warp = getWarper()
+  if (!warp) return false
+  const { gl, program, buffer, texture, loc } = warp
+
+  const maxTex = gl.getParameter(gl.MAX_TEXTURE_SIZE) as number
+  if (srcW > maxTex || srcH > maxTex) return false
+  const maxRb = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE) as number
+  if (w > maxRb || h > maxRb) return false
+
+  if (warp.canvas.width !== w || warp.canvas.height !== h) {
+    warp.canvas.width = w
+    warp.canvas.height = h
+  }
+
+  gl.viewport(0, 0, w, h)
+  gl.disable(gl.BLEND)
+  gl.clearColor(0, 0, 0, 0)
+  gl.clear(gl.COLOR_BUFFER_BIT)
+  gl.useProgram(program)
+
+  gl.bindTexture(gl.TEXTURE_2D, texture)
+  // NOT flipped: texImage2D already puts the image's top row at t=0, and our uv
+  // comes from top-down CSS layout space, so t and v already agree. UNPACK_FLIP_Y
+  // is for the y-up uv convention and would upload the video upside down. (The
+  // shader's -clip.y is unrelated — that flips y-down px into y-up NDC.)
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false)
+  // Premultiplied on upload + a premultiplied drawing buffer means the sampled
+  // texel can go straight out, and drawImage into the 2D canvas composites right.
+  gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true)
+  try {
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image)
+  } catch {
+    return false
+  }
+  if (gl.getError() !== gl.NO_ERROR) return false
+
+  const [tl, tr, br, bl] = corners
+  // pos.xy, uv.xy, q — two triangles sharing the TL→BR diagonal.
+  const v = (c: QuadCornerH, u: number, t: number) => [c.x, c.y, u, t, c.w]
+  const data = new Float32Array([
+    ...v(tl, 0, 0),
+    ...v(tr, 1, 0),
+    ...v(br, 1, 1),
+    ...v(tl, 0, 0),
+    ...v(br, 1, 1),
+    ...v(bl, 0, 1),
+  ])
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, buffer)
+  gl.bufferData(gl.ARRAY_BUFFER, data, gl.DYNAMIC_DRAW)
+  const stride = 5 * 4
+  gl.enableVertexAttribArray(loc.pos)
+  gl.vertexAttribPointer(loc.pos, 2, gl.FLOAT, false, stride, 0)
+  gl.enableVertexAttribArray(loc.uv)
+  gl.vertexAttribPointer(loc.uv, 2, gl.FLOAT, false, stride, 2 * 4)
+  gl.enableVertexAttribArray(loc.q)
+  gl.vertexAttribPointer(loc.q, 1, gl.FLOAT, false, stride, 4 * 4)
+
+  if (loc.res) gl.uniform2f(loc.res, w, h)
+  if (loc.tex) gl.uniform1i(loc.tex, 0)
+  gl.activeTexture(gl.TEXTURE0)
+  gl.bindTexture(gl.TEXTURE_2D, texture)
+
+  gl.drawArrays(gl.TRIANGLES, 0, 6)
+  if (gl.getError() !== gl.NO_ERROR) return false
+
+  ctx.drawImage(warp.canvas, 0, 0)
+  return true
+}

--- a/lib/editor/animation-export/video.ts
+++ b/lib/editor/animation-export/video.ts
@@ -23,6 +23,7 @@ import { isVideoSrc } from "../media-type"
 import { prepareAnimationAudio } from "./animation-audio"
 import { captureStableFrame } from "./capture"
 import { safeDrawImage } from "./draw-utils"
+import { exportDebugLog } from "./export-debug"
 import type { CaptureCtx } from "./types"
 import { resolveVideoSegments } from "./video-layer"
 import {
@@ -197,6 +198,14 @@ export async function tryEncodeWithMediabunny(
     }
     // Fall through to MediaRecorder for WebM only.
     console.warn("[export] WebCodecs encode failed, trying fallback:", err)
+    exportDebugLog(
+      "warn",
+      "encode.mediabunny",
+      "WebCodecs encode failed, trying MediaRecorder fallback",
+      {
+        error: err instanceof Error ? err.message : String(err),
+      }
+    )
     return null
   } finally {
     signal?.removeEventListener("abort", onAbort)

--- a/lib/editor/export.ts
+++ b/lib/editor/export.ts
@@ -1,6 +1,10 @@
 import { toJpeg, toBlob, toCanvas, getFontEmbedCSS } from "html-to-image"
 
 import { triggerAnchorDownload } from "@/lib/download"
+import {
+  exportDebugLog,
+  getActiveExportDebug,
+} from "./animation-export/export-debug"
 import { supportsObjectViewBox } from "./crop-utils"
 import { shouldProxyAssetUrl } from "./export-assets"
 import { replaceCloneVideosWithFrames } from "./export-video-frames"
@@ -713,12 +717,33 @@ export type AnimationCapture = {
  * No-op on Chromium.
  */
 async function warmUpWebKitCapture(captureFrame: () => Promise<unknown>) {
-  if (supportsObjectViewBox()) return
+  if (supportsObjectViewBox()) {
+    exportDebugLog(
+      "debug",
+      "capture.warmup",
+      "skipped (Chromium object-view-box supported)"
+    )
+    return
+  }
+  exportDebugLog("info", "capture.warmup", "WebKit warm-up begin (2 attempts)")
   for (let attempt = 0; attempt < 2; attempt++) {
+    const t0 = performance.now()
     try {
       await captureFrame()
-    } catch {
+      exportDebugLog("info", "capture.warmup", `attempt ${attempt + 1} ok`, {
+        durationMs: Math.round(performance.now() - t0),
+      })
+    } catch (err) {
       // Warm-up only — the real capture surfaces its own errors.
+      exportDebugLog(
+        "warn",
+        "capture.warmup",
+        `attempt ${attempt + 1} failed`,
+        {
+          durationMs: Math.round(performance.now() - t0),
+          error: err instanceof Error ? err.message : String(err),
+        }
+      )
     }
     await new Promise((resolve) => setTimeout(resolve, 60))
   }
@@ -728,6 +753,10 @@ export async function prepareAnimationCapture(
   canvasId: string,
   targetWidth = 1280
 ): Promise<AnimationCapture> {
+  exportDebugLog("info", "capture.legacy", "prepareAnimationCapture begin", {
+    canvasId,
+    targetWidth,
+  })
   const node = findCanvasElement(canvasId)
   if (!node) throw new Error("Canvas not found")
 
@@ -738,6 +767,13 @@ export async function prepareAnimationCapture(
   const pixelRatio = targetWidth / renderedWidth
   const outputWidth = Math.round(renderedWidth * pixelRatio)
   const outputHeight = Math.round(renderedHeight * pixelRatio)
+  exportDebugLog("info", "capture.legacy", "layout dims", {
+    renderedWidth,
+    renderedHeight,
+    pixelRatio,
+    outputWidth,
+    outputHeight,
+  })
 
   const exportTarget = prepareExportNode(
     node,
@@ -747,6 +783,10 @@ export async function prepareAnimationCapture(
     true // neutralize portrait blur/stage — redrawn onto the frame canvas
   )
   const { rewrites, preloadUrls } = rewriteExportAssets(exportTarget.node)
+  exportDebugLog("debug", "capture.legacy", "assets rewritten", {
+    rewriteCount: rewrites.length,
+    preloadUrlCount: preloadUrls.length,
+  })
 
   await waitForExportAssets(preloadUrls)
   await embedCloneImages(exportTarget.node)
@@ -755,6 +795,7 @@ export async function prepareAnimationCapture(
   // data URIs or html-to-image caches them and freezes the animated background
   // on one frame — see embedCloneBackgroundImages.
   await embedCloneBackgroundImages(exportTarget.node)
+  exportDebugLog("info", "capture.legacy", "clone assets embedded")
 
   const captureOptions = {
     pixelRatio,
@@ -762,21 +803,65 @@ export async function prepareAnimationCapture(
     filter: filterExportHidden,
   } as const
 
+  let captureCallCount = 0
   const captureFrame = async () => {
     // html-to-image can return a non-canvas / zero-size value on Safari &
     // Firefox. Validate before handing it to drawImage callers.
-    const canvas = await toCanvas(exportTarget.node, captureOptions)
+    const call = ++captureCallCount
+    const t0 = performance.now()
+    let canvas: HTMLCanvasElement
+    try {
+      canvas = await toCanvas(exportTarget.node, captureOptions)
+    } catch (err) {
+      exportDebugLog("error", "capture.legacy", `toCanvas threw (#${call})`, {
+        call,
+        durationMs: Math.round(performance.now() - t0),
+        error: err instanceof Error ? err.message : String(err),
+      })
+      throw err
+    }
     if (
       !(canvas instanceof HTMLCanvasElement) ||
       canvas.width <= 0 ||
       canvas.height <= 0
     ) {
+      exportDebugLog(
+        "error",
+        "capture.legacy",
+        `toCanvas returned invalid canvas (#${call})`,
+        {
+          call,
+          type: canvas == null ? "null" : typeof canvas,
+          width:
+            canvas && typeof canvas === "object" && "width" in canvas
+              ? (canvas as { width: unknown }).width
+              : null,
+          height:
+            canvas && typeof canvas === "object" && "height" in canvas
+              ? (canvas as { height: unknown }).height
+              : null,
+          durationMs: Math.round(performance.now() - t0),
+        }
+      )
       throw new Error("Frame capture returned an invalid canvas")
+    }
+    // Log only first few + occasional later calls to avoid drowning the log.
+    if (call <= 4 || call % 30 === 0) {
+      exportDebugLog("debug", "capture.legacy", `toCanvas ok (#${call})`, {
+        call,
+        width: canvas.width,
+        height: canvas.height,
+        durationMs: Math.round(performance.now() - t0),
+      })
     }
     return canvas
   }
 
   await warmUpWebKitCapture(captureFrame)
+  getActiveExportDebug()?.setMeta(
+    "legacyCaptureCallsAfterWarmup",
+    captureCallCount
+  )
 
   return {
     node: exportTarget.node,
@@ -914,6 +999,10 @@ export async function prepareFastAnimationCapture(
   canvasId: string,
   targetWidth = 1280
 ): Promise<AnimationCapture> {
+  exportDebugLog("info", "capture.fast", "prepareFastAnimationCapture begin", {
+    canvasId,
+    targetWidth,
+  })
   const node = findCanvasElement(canvasId)
   if (!node) throw new Error("Canvas not found")
 
@@ -924,10 +1013,20 @@ export async function prepareFastAnimationCapture(
   const pixelRatio = targetWidth / renderedWidth
   const outputWidth = Math.round(renderedWidth * pixelRatio)
   const outputHeight = Math.round(renderedHeight * pixelRatio)
+  exportDebugLog("info", "capture.fast", "layout dims", {
+    renderedWidth,
+    renderedHeight,
+    pixelRatio,
+    outputWidth,
+    outputHeight,
+  })
 
   // Read the on-screen container context BEFORE cloning so cqw reads on the clone
   // resolve to the same pixels as in the live editor.
   const containerContext = findNearestContainerContext(node)
+  exportDebugLog("debug", "capture.fast", "container context", {
+    containerContext,
+  })
 
   const exportTarget = prepareExportNode(
     node,
@@ -1001,29 +1100,52 @@ export async function prepareFastAnimationCapture(
     throw new Error("Could not get 2d context for fast capture")
   }
 
+  let captureCallCount = 0
   const captureFrame = async () => {
     // Bake computed styles (resolving theme colors + cqw → px for this frame)
     // just for the serialization, then restore the var-driven inline styles.
-    const body = withBakedComputedStyles(bakeEls(), () =>
-      serializer.serializeToString(exportTarget.node)
-    )
-    const url =
-      dataUrlHead + encodedOpen + encodeURIComponent(body) + encodedClose
-    // `Image.decode()` rejects on SVG-with-<foreignObject> in some Firefox
-    // builds, so wait on load/error events — reliable in every engine.
-    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
-      const image = new Image()
-      image.onload = () => resolve(image)
-      image.onerror = () =>
-        reject(new Error("Fast capture: SVG frame failed to load"))
-      image.src = url
-    })
-    ctx.clearRect(0, 0, outputWidth, outputHeight)
-    ctx.drawImage(img, 0, 0, outputWidth, outputHeight)
-    return frameCanvas
+    const call = ++captureCallCount
+    const t0 = performance.now()
+    try {
+      const body = withBakedComputedStyles(bakeEls(), () =>
+        serializer.serializeToString(exportTarget.node)
+      )
+      const url =
+        dataUrlHead + encodedOpen + encodeURIComponent(body) + encodedClose
+      // `Image.decode()` rejects on SVG-with-<foreignObject> in some Firefox
+      // builds, so wait on load/error events — reliable in every engine.
+      const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+        const image = new Image()
+        image.onload = () => resolve(image)
+        image.onerror = () =>
+          reject(new Error("Fast capture: SVG frame failed to load"))
+        image.src = url
+      })
+      ctx.clearRect(0, 0, outputWidth, outputHeight)
+      ctx.drawImage(img, 0, 0, outputWidth, outputHeight)
+      if (call <= 4 || call % 30 === 0) {
+        exportDebugLog("debug", "capture.fast", `frame ok (#${call})`, {
+          call,
+          durationMs: Math.round(performance.now() - t0),
+          bodyChars: body.length,
+        })
+      }
+      return frameCanvas
+    } catch (err) {
+      exportDebugLog("error", "capture.fast", `frame failed (#${call})`, {
+        call,
+        durationMs: Math.round(performance.now() - t0),
+        error: err instanceof Error ? err.message : String(err),
+      })
+      throw err
+    }
   }
 
   await warmUpWebKitCapture(captureFrame)
+  getActiveExportDebug()?.setMeta(
+    "fastCaptureCallsAfterWarmup",
+    captureCallCount
+  )
 
   return {
     node: exportTarget.node,

--- a/tests/lib/editor/animation-export/video-media.test.ts
+++ b/tests/lib/editor/animation-export/video-media.test.ts
@@ -10,11 +10,24 @@ import {
 } from "@/lib/editor/animation-export/video-media/audio"
 import { seekTo } from "@/lib/editor/animation-export/video-media/dom-video"
 import {
+  applyExportStackVisibility,
+  countExportStack,
+} from "@/lib/editor/animation-export/video-media/export-stack"
+import {
   MAX_GIF_TOTAL_PIXELS,
   gifExportExceedsMemory,
 } from "@/lib/editor/animation-export/video-media/encode-gif"
+import {
+  chooseQuadSubdivision,
+  quadAffineError,
+} from "@/lib/editor/animation-export/video-media/frame-renderer"
 import { planFrames } from "@/lib/editor/animation-export/video-media/frames"
 import { measureVideoRegion } from "@/lib/editor/animation-export/video-media/region"
+import {
+  drawImageToQuadGL,
+  resetQuadWarperForTest,
+  type QuadCornerH,
+} from "@/lib/editor/animation-export/video-media/warp-gl"
 import { AnimationExportAbortedError } from "@/lib/editor/animation-export/utils"
 import { useEditorStore } from "@/lib/editor/store"
 import { Mp4OutputFormat, WebMOutputFormat } from "mediabunny"
@@ -482,5 +495,260 @@ describe("canvasIsVideoMedia", () => {
 
   it("is false for an unknown canvas id", () => {
     expect(canvasIsVideoMedia("does-not-exist")).toBe(false)
+  })
+})
+
+describe("export stack visibility", () => {
+  /**
+   * Scene shaped like the real canvas: a backdrop, a media shell holding the
+   * <video>, a foreground overlay that must land on top of the video, and an
+   * untagged node that belongs to neither pass.
+   */
+  function buildScene() {
+    const root = document.createElement("div")
+    root.innerHTML = `
+      <div data-export-stack="underlay" id="backdrop"></div>
+      <div data-export-stack="media" id="shell">
+        <video id="video"></video>
+      </div>
+      <div data-export-stack="foreground" id="lighting"></div>
+      <div id="untagged"></div>
+    `
+    document.body.appendChild(root)
+    const el = (id: string) => root.querySelector<HTMLElement>(`#${id}`)!
+    return { root, el }
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("underlay pass keeps the backdrop and media shell but drops the video", () => {
+    const { root, el } = buildScene()
+    applyExportStackVisibility(root, "underlay")
+
+    // The shell stays visible so its shadow/radius/letterbox plate bake in
+    // behind the composited video.
+    expect(el("backdrop").style.visibility).not.toBe("hidden")
+    expect(el("shell").style.visibility).not.toBe("hidden")
+    expect(el("video").style.visibility).toBe("hidden")
+    expect(el("lighting").style.visibility).toBe("hidden")
+  })
+
+  it("foreground pass hides by exclusion so untagged nodes can't draw twice", () => {
+    const { root, el } = buildScene()
+    applyExportStackVisibility(root, "foreground")
+
+    // visibility inherits, so hiding the root and re-showing only foreground
+    // leaves everything else — tagged or not — out of the transparent raster.
+    expect(root.style.visibility).toBe("hidden")
+    expect(el("lighting").style.visibility).toBe("visible")
+    expect(el("untagged").style.visibility).not.toBe("visible")
+    expect(el("video").style.visibility).toBe("hidden")
+  })
+
+  it("restores every touched style after a pass", () => {
+    const { root, el } = buildScene()
+    el("lighting").style.visibility = "visible"
+
+    const restoreUnderlay = applyExportStackVisibility(root, "underlay")
+    restoreUnderlay()
+    const restoreForeground = applyExportStackVisibility(root, "foreground")
+    restoreForeground()
+
+    expect(root.style.visibility).toBe("")
+    expect(el("shell").style.visibility).toBe("")
+    expect(el("video").style.visibility).toBe("")
+    expect(el("untagged").style.visibility).toBe("")
+    expect(el("lighting").style.visibility).toBe("visible")
+  })
+
+  it("counts each layer for the export debug log", () => {
+    const { root } = buildScene()
+    expect(countExportStack(root)).toEqual({
+      underlay: 1,
+      media: 1,
+      foreground: 1,
+      videos: 1,
+    })
+  })
+})
+
+describe("perspective quad subdivision", () => {
+  const W = 1026.6875
+  const H = 614
+
+  /**
+   * The real shell matrix from a Safari export log (tilt rx15/ry20/rz-9). The
+   * 4th column is non-zero — the editor's tilt bakes perspective() in, so a
+   * point's w varies (~0.82–1.18) and CSS divides by it to flatten to 2D.
+   */
+  const M = [
+    0.928123, -0.063673, -0.366787, 0.000262, 0.147, 0.967881, 0.203952,
+    -0.000146, 0.34202, -0.24321, 0.907673, -0.000648, 0, 0, 0, 1,
+  ]
+
+  /** Apply the column-major matrix about the box centre, then divide by w. */
+  function project(u: number, v: number) {
+    const x = u * W - W / 2
+    const y = v * H - H / 2
+    const at = (r: number, c: number) => M[c * 4 + r]
+    const tx = at(0, 0) * x + at(0, 1) * y + at(0, 3)
+    const ty = at(1, 0) * x + at(1, 1) * y + at(1, 3)
+    const tw = at(3, 0) * x + at(3, 1) * y + at(3, 3)
+    return { x: tx / tw + W / 2, y: ty / tw + H / 2 }
+  }
+
+  it("two triangles cannot approximate a perspective quad", () => {
+    // Why subdivision exists at all: the old 1×1 affine map bowed the video by
+    // ~100px, which is what mis-drew the tilted export.
+    expect(quadAffineError(project, 1)).toBeGreaterThan(50)
+  })
+
+  it("error shrinks monotonically as the grid refines", () => {
+    const errors = [1, 2, 4, 8, 16].map((n) => quadAffineError(project, n))
+    for (let i = 1; i < errors.length; i++) {
+      expect(errors[i]).toBeLessThan(errors[i - 1])
+    }
+  })
+
+  it("picks a grid that holds the affine error under a pixel", () => {
+    const n = chooseQuadSubdivision(project)
+    expect(n).toBeGreaterThan(1)
+    expect(quadAffineError(project, n)).toBeLessThanOrEqual(0.5)
+  })
+
+  it("does not subdivide when there is no perspective", () => {
+    // Pure rotate/scale/translate is affine, so one cell is already exact.
+    const affine = (u: number, v: number) => ({
+      x: 0.8 * (u * W) - 0.3 * (v * H) + 12,
+      y: 0.2 * (u * W) + 0.9 * (v * H) - 5,
+    })
+    expect(quadAffineError(affine, 1)).toBeLessThan(1e-6)
+    expect(chooseQuadSubdivision(affine)).toBe(1)
+  })
+})
+
+describe("export stack — media shell in the underlay", () => {
+  function scene() {
+    const root = document.createElement("div")
+    root.innerHTML = `
+      <div data-export-stack="underlay" id="backdrop"></div>
+      <div data-export-stack="media" id="shell"><video id="video"></video></div>
+      <div data-export-stack="foreground" id="lighting"></div>
+    `
+    document.body.appendChild(root)
+    return {
+      root,
+      el: (id: string) => root.querySelector<HTMLElement>(`#${id}`)!,
+    }
+  }
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("keeps the shell by default so its shadow and plate bake in", () => {
+    const { root, el } = scene()
+    applyExportStackVisibility(root, "underlay")
+    expect(el("shell").style.visibility).not.toBe("hidden")
+  })
+
+  it("drops a bent layer when asked, without touching the backdrop", () => {
+    // WebKit rasterizes a perspective transform inside foreignObject flattened,
+    // so a tilted shell would bake in at the wrong shape and fight the
+    // correctly-projected video — the second-plate artifact.
+    const { root, el } = scene()
+    applyExportStackVisibility(root, "underlay", { alsoHide: [el("shell")] })
+    expect(el("shell").style.visibility).toBe("hidden")
+    expect(el("backdrop").style.visibility).not.toBe("hidden")
+  })
+
+  it("restores the shell after an alsoHide pass", () => {
+    const { root, el } = scene()
+    const restore = applyExportStackVisibility(root, "underlay", {
+      alsoHide: [el("shell")],
+    })
+    restore()
+    expect(el("shell").style.visibility).toBe("")
+  })
+})
+
+describe("export stack — isolating single layers", () => {
+  function scene() {
+    const root = document.createElement("div")
+    root.innerHTML = `
+      <div data-export-stack="underlay" id="backdrop"></div>
+      <div data-export-stack="media" id="shell"><video id="video"></video></div>
+      <div data-export-stack="foreground" id="lighting"></div>
+      <div data-export-stack="foreground" id="text"></div>
+    `
+    document.body.appendChild(root)
+    return {
+      root,
+      el: (id: string) => root.querySelector<HTMLElement>(`#${id}`)!,
+    }
+  }
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("shows only the named foreground layers", () => {
+    // Perspective-carrying layers are captured one at a time so they can be
+    // projected by hand; the rest come from one flat pass.
+    const { root, el } = scene()
+    applyExportStackVisibility(root, "foreground", {
+      only: [el("lighting")],
+    })
+    expect(el("lighting").style.visibility).toBe("visible")
+    expect(el("text").style.visibility).not.toBe("visible")
+    expect(root.style.visibility).toBe("hidden")
+  })
+
+  it("shows every foreground layer when not narrowed", () => {
+    const { root, el } = scene()
+    applyExportStackVisibility(root, "foreground")
+    expect(el("lighting").style.visibility).toBe("visible")
+    expect(el("text").style.visibility).toBe("visible")
+  })
+})
+
+describe("drawImageToQuadGL", () => {
+  beforeEach(() => resetQuadWarperForTest())
+  afterEach(() => resetQuadWarperForTest())
+
+  const quad = (): [QuadCornerH, QuadCornerH, QuadCornerH, QuadCornerH] => [
+    { x: 0, y: 0, w: 1.1 },
+    { x: 100, y: 10, w: 0.9 },
+    { x: 100, y: 100, w: 0.9 },
+    { x: 0, y: 90, w: 1.1 },
+  ]
+
+  function ctx2d(w = 128, h = 128) {
+    const c = document.createElement("canvas")
+    c.width = w
+    c.height = h
+    return {
+      drawImage: () => {},
+      canvas: c,
+    } as unknown as CanvasRenderingContext2D
+  }
+
+  it("reports failure instead of throwing when WebGL is unavailable", () => {
+    // jsdom has no WebGL — the same shape as a browser that denies a context,
+    // which must degrade to the 2D grid rather than kill the export.
+    const img = document.createElement("canvas")
+    expect(drawImageToQuadGL(ctx2d(), img, 64, 64, quad())).toBe(false)
+  })
+
+  it("rejects a quad with a corner at or behind the eye plane", () => {
+    const img = document.createElement("canvas")
+    const behind = quad()
+    behind[1] = { x: 100, y: 10, w: -0.2 }
+    expect(drawImageToQuadGL(ctx2d(), img, 64, 64, behind)).toBe(false)
+  })
+
+  it("rejects a zero-sized destination", () => {
+    const img = document.createElement("canvas")
+    expect(drawImageToQuadGL(ctx2d(0, 0), img, 64, 64, quad())).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Fixes a series of WebKit-only bugs in the animated **video** export path. On Safari, `html-to-image` can't reliably re-rasterize a changing `<video>` inside a `foreignObject`, so video export uses a **composite path**: it rasterizes the scene once with the video hidden and draws each WebCodecs-decoded frame in 2D onto that template. Chrome is unaffected — it re-rasters the whole clone per frame and lets the browser composite — so all of these reproduced only in Safari and needed the layered export stack to be correct.

This branch builds out that layered stack and then fixes the three ways it broke once a **device frame** or a **reordered annotation** was in play.

## What's fixed

**1. Export geometry & the layered stack** (`73e8d17`)
- Split the scene into `underlay` / `media` / `foreground` passes (declared by components via `data-export-stack`) so layers above the video composite *over* the decoded frame instead of behind it.
- Find the element carrying the tilt by its `matrix3d` computed transform rather than a marker attribute (the attribute guess picked an untransformed wrapper and exported the video axis-aligned).
- Apply the perspective divide to `DOMPoint.matrixTransform` results and warp quads on the GPU (canvas2d is affine and seams a subdivided approximation).
- Reconstruct portrait depth-of-field, which `backdrop-filter` can't rasterize.

**2. Projected layers clipped by a device frame** (`7a320a0`)
- A carrier's transform also carries the layout's `translate(-50%, -50%)` centering; neutralizing it dropped the centering and rasterized a clipped fragment. Place the neutralized box at a known spot and crop where it actually lands; neutralize with an identity matrix (not `none`) to preserve the containing block for abs-positioned chrome.

**3. Inner lighting painted behind the frame** (`10ce76e`)
- `framePositionedStyle` set `transform-style: preserve-3d` while its `filter` was only populated under a shadow/enhance preset. Inside a 3D context WebKit sorts children by depth instead of z-index, painting the z-10 lighting behind the opaque frame chrome. The children are coplanar, so the 3D context is dropped entirely.

**4. Layer order, device-frame chrome, and decode diagnostics** (`b60a77e`)
- **Bezel on top**: the device-frame bezel/notch lives at z-10 in the DOM but was baked into the underlay, so an opaque cover/fill video buried it. Re-project it over the video (`buildFrameChromeLayer`), leaving the untagged copy in the underlay so the drop-shadow still follows the PNG silhouette; the shadow filter is neutralized on the on-top copy to avoid a second phone-shaped shadow.
- **Corner clip**: clip the decoded video to the screen glass's real radius, not the square-cornered outer shell's (`0`) — sharp corners were poking past the bezel.
- **Stacking order**: foreground-tagged layers (annotations, text, assets) share the screenshot's `z-index: 60 + n` scale and can be sent *behind* it, where they must composite under the video. Split the foreground into above/below the video by real DOM paint order (`paintsAboveVideo`) instead of always drawing it on top.
- **Decode diagnostics**: log why a clip fails WebCodecs decode (codec, param string, decoder config, `VideoDecoder.isConfigSupported`) so the DOM-seek fallback flicker is diagnosable.

## Known follow-up

The DOM-seek fallback flicker is still open: some clips fail `track.canDecode()` and drop out of the composite pipeline entirely into the flickery per-frame raster path. The new decode logging (point 4) is there to capture the codec details needed to decide the real fix (transcode-on-import vs. a decoder-config fixup).

## Testing

`pnpm typecheck` and eslint pass (enforced by the pre-commit hook). Behavior verified against the export-debug layer dumps. Since this is the WebKit path, final visual confirmation needs a Safari MP4 export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved video and animation export quality for perspective, layered media, lighting, and depth-of-field effects.
  * Added more reliable frame rendering and fallback behavior across browsers.
  * Added optional developer diagnostics for export failures, blank frames, layout drift, and encoding details.

* **Bug Fixes**
  * Improved handling of failed video decoding and encoding.
  * Reduced rendering issues involving layer ordering, black frames, and WebKit compositing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a multi-layered set of WebKit-only bugs in the video export pipeline by introducing a full composite stack: the scene is split into underlay/foreground passes with components declaring their layer via `data-export-stack`, decoded video frames are projected through their CSS 3D quad (including perspective divide), the device-frame bezel is re-composited on top of the video, and a WebGL warp path eliminates the seam lattice that the subdivided 2D affine approximation left behind.

- **Layered export stack** (`canvas-backdrop.tsx`, `inner-lighting-overlay.tsx`, `screenshot-bare.tsx`, multiple component files): All editor elements now declare underlay/foreground membership so the composite renderer can sandwich the decoded video between them instead of painting it on top of everything.
- **`frame-renderer.ts`** (≈1,500 lines added): New geometry engine — `resolveTransformCarrier`, `projectElementQuad`, `collectProjectedLayers`, `paintsAboveVideo` — correctly measures, projects, and composites perspective-bent elements; `buildForegroundLayer` and `buildFrameChromeLayer` replace the old flat foreground capture with per-layer projected rasters.
- **`warp-gl.ts`**: A single-context WebGL quad warper provides perspective-correct compositing without the interior seams inherent to 2D affine subdivision; the grid fallback remains for when WebGL is unavailable.
- **`export-debug.ts` + `/api/dev/export-debug/route.ts`**: Comprehensive export debug logging with layer PNG snapshots, surfaced only in `NODE_ENV=development` or via localStorage flag.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness that Safari visual verification is still needed — the entire purpose of this branch is WebKit-specific behavior that can only be confirmed in Safari with an actual MP4 export.

The architecture (underlay/foreground split, perspective projection, GL warp, frame-chrome re-compositing) is coherent and well-commented. All findings are non-blocking: a blob URL left alive after the fallback overlay path, a module-level debug counter that accumulates across sessions, an overly conservative retry loop for near-black backgrounds, and an imprecise shadow-padding parser that can misattribute px values from adjacent CSS filter functions. None of these affect the exported video pixels under the normal (composite) path; they are isolated to the raster fallback, debug labelling, and padding heuristics.

frame-renderer.ts has all four issues and deserves a second read before merging; the other changed files look correct.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/editor/animation-export/video-media/frame-renderer.ts | Core of the WebKit composite fix — adds full perspective quad projection, foreground/underlay split, frame-chrome re-compositing, GL warp, and the `overlayVideoFrameImage` fallback. Well-structured but a blob URL from the last frame painted by `overlayVideoFrameImage` is never revoked, and the module-level `projectedSeq` counter accumulates across export sessions. |
| lib/editor/animation-export/video-media/warp-gl.ts | New GL quad warper: correctly handles premultiplied alpha, perspective-correct UV interpolation via `a_q`/`gl_Position.w`, and graceful fallback on context loss. Singleton context cap avoids the 16-context browser limit. |
| lib/editor/animation-export/video-media/export-stack.ts | Clean new module managing underlay/foreground visibility toggling; correctly uses CSS `visibility` inheritance so the foreground pass hides by exclusion without breaking layout. |
| lib/editor/animation-export/export-debug.ts | Comprehensive structured debug logger; well-guarded (dev/localStorage/URL flag only), active session is a controlled singleton. Payload serialisation and flush path look correct. |
| app/api/dev/export-debug/route.ts | Dev-only route with solid input validation: `NODE_ENV=production` guard, regex-validated session ID and kind, sanitised status string, layer name allowlist. No path-traversal vectors found. |
| lib/editor/animation-export/video-media/index.ts | Video-media export orchestrator — wires the new composite renderer, debug logging, and cleanup correctly. `logLiveVsCloneFraming` is a useful diagnostic. Cleanup nesting (decoded inside capture) is correct. |
| components/editor/canvas/helpers.ts | Removal of `transform-style: preserve-3d` from `framePositionedStyle` is correct — all children are coplanar so 3D context only caused WebKit's depth-sort to override z-index. |
| tests/lib/editor/animation-export/video-media.test.ts | New tests cover export-stack visibility toggling, affine error / subdivision selection, and GL quad fallback. Tests are well-scoped with proper `afterEach` cleanup. |
| components/editor/canvas/screenshot-mockup.tsx | Device frame image gets `data-export-frame-chrome`, used by `buildFrameChromeLayer` to re-composite the bezel on top of the video. The dual-copy strategy (underlay for shadow, foreground for masking) is clearly explained. |
| lib/editor/export.ts | Debug logging added to both `prepareAnimationCapture` and `prepareFastAnimationCapture`. Call counters are per-capture-object so they don't leak across exports. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Alib%2Feditor%2Fanimation-export%2Fvideo-media%2Fframe-renderer.ts%3A799-803%0AThe%20last%20blob%20URL%20created%20by%20the%20overlay%20image%20paint%20function%20is%20never%20revoked.%20Each%20call%20revokes%20%60lastBlobUrl%60%20before%20creating%20a%20new%20one%2C%20but%20the%20URL%20from%20the%20final%20frame%20of%20an%20export%20run%20is%20left%20alive%20until%20the%20page%20unloads.%20For%20a%2030%20fps%2C%2060-second%20export%20that%20falls%20back%20to%20this%20path%2C%20one%20several-hundred-KB%20JPEG%20blob%20leaks%20per%20run.%0A%0A%60%60%60suggestion%0A%20%20let%20lastFrame%3A%20CanvasImageSource%20%7C%20null%20%3D%20null%0A%20%20let%20lastBlobUrl%3A%20string%20%7C%20null%20%3D%20null%0A%0A%20%20const%20cleanup%20%3D%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28lastBlobUrl%29%20%7B%0A%20%20%20%20%20%20URL.revokeObjectURL%28lastBlobUrl%29%0A%20%20%20%20%20%20lastBlobUrl%20%3D%20null%0A%20%20%20%20%7D%0A%20%20%7D%0A%0A%20%20const%20paint%20%3D%20async%20%28frame%3A%20CanvasImageSource%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28frame%20%3D%3D%3D%20lastFrame%29%20return%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Feditor%2Fanimation-export%2Fvideo-media%2Fframe-renderer.ts%3A851-852%0AThe%20module-level%20%60projectedSeq%60%20counter%20is%20never%20reset%20between%20export%20runs.%20Debug%20layer%20tags%20like%20%600-foreground%60%20from%20the%20first%20export%20and%20%6047-foreground%60%20from%20a%20second%20export%20in%20the%20same%20session%20are%20ambiguous%20in%20log%20output.%20Reset%20it%20at%20the%20start%20of%20each%20composite%20renderer%20so%20tags%20are%20reproducible%20and%20comparable%20across%20sessions.%0A%0A%60%60%60suggestion%0A%2F**%20Distinguishes%20snapshots%20when%20several%20layers%20share%20a%20stack%20tag%20%28or%20none%29.%20*%2F%0Alet%20projectedSeq%20%3D%200%0A%0Afunction%20resetProjectedSeq%28%29%20%7B%0A%20%20projectedSeq%20%3D%200%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Alib%2Feditor%2Fanimation-export%2Fvideo-media%2Fframe-renderer.ts%3A1043-1058%0A**%60captureSceneTemplate%60%20may%20burn%208%20retries%20on%20legitimately%20near-black%20canvases**%0A%0AThe%20acceptance%20threshold%20%60score%20%3E%3D%201%60%20%281%25%20non-black%20pixels%29%20is%20tuned%20for%20canvases%20with%20visible%20backgrounds%2C%20but%20a%20canvas%20using%20a%20very%20dark%20or%20near-black%20solid%2Fgradient%20background%20could%20return%20a%20valid%20frame%20with%20%60nonBlackPct%20%3C%201%60.%20On%20WebKit%20that%20triggers%20all%208%20retry%20attempts%20%28~400%E2%80%93600%20ms%20of%20unnecessary%20%60sleep%60%20calls%29%20before%20accepting%20the%20frame%20that%20was%20already%20correct%20on%20the%20first%20attempt.%20The%20comment%20says%20%22accept%20anything%20that%20produced%20a%20non-zero%20canvas%22%2C%20but%20the%20guard%20is%20%60%3E%3D%201%60%2C%20not%20%60%3E%200%60.%0A%0A%23%23%23%20Issue%204%20of%204%0Alib%2Feditor%2Fanimation-export%2Fvideo-media%2Fframe-renderer.ts%3A115-138%0A**%60shadowExtentPx%60%20splits%20the%20%60filter%60%20string%20by%20comma%2C%20but%20CSS%20filter%20functions%20are%20space-separated**%0A%0A%60cs.boxShadow%60%20is%20correctly%20comma-split%20%28multiple%20box-shadows%20are%20comma-separated%29.%20However%2C%20%60cs.filter%60%20uses%20spaces%20between%20filter%20functions%20%E2%80%94%20%60drop-shadow%28A%29%20drop-shadow%28B%29%60%20%E2%80%94%20so%20the%20entire%20filter%20string%20is%20treated%20as%20a%20single%20%22part%22.%20The%20first%204%20px%20values%20across%20all%20filter%20functions%20are%20then%20destructured%20as%20%60%5Bdx%2C%20dy%2C%20blur%2C%20spread%5D%60%2C%20which%20silently%20mixes%20values%20from%20different%20%60drop-shadow%28%29%60%20calls.%20The%20result%20tends%20to%20be%20a%20conservative%20overestimate%2C%20but%20for%20complex%20filters%20%28e.g.%2C%20multiple%20shadows%20with%20large%20offsets%20in%20different%20directions%29%20the%20padding%20can%20be%20wrong%20in%20either%20direction.%0A%0A&repo=shivabhattacharjee%2Ftokokino&pr=23&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
lib/editor/animation-export/video-media/frame-renderer.ts:799-803
The last blob URL created by the overlay image paint function is never revoked. Each call revokes `lastBlobUrl` before creating a new one, but the URL from the final frame of an export run is left alive until the page unloads. For a 30 fps, 60-second export that falls back to this path, one several-hundred-KB JPEG blob leaks per run.

```suggestion
  let lastFrame: CanvasImageSource | null = null
  let lastBlobUrl: string | null = null

  const cleanup = () => {
    if (lastBlobUrl) {
      URL.revokeObjectURL(lastBlobUrl)
      lastBlobUrl = null
    }
  }

  const paint = async (frame: CanvasImageSource) => {
    if (frame === lastFrame) return
```

### Issue 2 of 4
lib/editor/animation-export/video-media/frame-renderer.ts:851-852
The module-level `projectedSeq` counter is never reset between export runs. Debug layer tags like `0-foreground` from the first export and `47-foreground` from a second export in the same session are ambiguous in log output. Reset it at the start of each composite renderer so tags are reproducible and comparable across sessions.

```suggestion
/** Distinguishes snapshots when several layers share a stack tag (or none). */
let projectedSeq = 0

function resetProjectedSeq() {
  projectedSeq = 0
}
```

### Issue 3 of 4
lib/editor/animation-export/video-media/frame-renderer.ts:1043-1058
**`captureSceneTemplate` may burn 8 retries on legitimately near-black canvases**

The acceptance threshold `score >= 1` (1% non-black pixels) is tuned for canvases with visible backgrounds, but a canvas using a very dark or near-black solid/gradient background could return a valid frame with `nonBlackPct < 1`. On WebKit that triggers all 8 retry attempts (~400–600 ms of unnecessary `sleep` calls) before accepting the frame that was already correct on the first attempt. The comment says "accept anything that produced a non-zero canvas", but the guard is `>= 1`, not `> 0`.

### Issue 4 of 4
lib/editor/animation-export/video-media/frame-renderer.ts:115-138
**`shadowExtentPx` splits the `filter` string by comma, but CSS filter functions are space-separated**

`cs.boxShadow` is correctly comma-split (multiple box-shadows are comma-separated). However, `cs.filter` uses spaces between filter functions — `drop-shadow(A) drop-shadow(B)` — so the entire filter string is treated as a single "part". The first 4 px values across all filter functions are then destructured as `[dx, dy, blur, spread]`, which silently mixes values from different `drop-shadow()` calls. The result tends to be a conservative overestimate, but for complex filters (e.g., multiple shadows with large offsets in different directions) the padding can be wrong in either direction.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: respect layer order and device-fram..."](https://github.com/shivabhattacharjee/tokokino/commit/b60a77ed159cc0ec9a1bbab3721855b3c341a404) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45147331)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->