### PR TITLE
fix: backdrop effects live preview, animated video crop, and Open project search

### DIFF
--- a/app/api/drafts/route.ts
+++ b/app/api/drafts/route.ts
@@ -36,9 +36,9 @@ export async function GET(request: Request) {
   })
 
   try {
-    // A search ranks by fuzzy match (typo-tolerant) and returns its own total,
-    // so page and count always come from one ranking. Plain listing keeps the
-    // indexed SQL path.
+    // A search matches by fuzzy name (typo-tolerant), applies `sort` to the
+    // matches, and returns its own total, so page and count always come from
+    // one pass. Plain listing keeps the indexed SQL path.
     const [listed, storageUsed] = await Promise.all([
       q
         ? searchDrafts(auth.session.user.id, { q, limit, offset, sort, type })

--- a/app/api/drafts/route.ts
+++ b/app/api/drafts/route.ts
@@ -8,6 +8,7 @@ import {
   createDraft,
   getUserDraftStorageUsage,
   listDrafts,
+  searchDrafts,
 } from "@/lib/draft-db"
 import {
   MAX_DRAFT_BYTES,
@@ -26,19 +27,28 @@ export async function GET(request: Request) {
   if (!auth.ok) return auth.response
 
   const url = new URL(request.url)
-  const { limit, offset, sort, type } = draftListQuerySchema.parse({
+  const { limit, offset, sort, type, q } = draftListQuerySchema.parse({
     limit: url.searchParams.get("limit") ?? undefined,
     offset: url.searchParams.get("offset") ?? undefined,
     sort: url.searchParams.get("sort") ?? undefined,
     type: url.searchParams.get("type") ?? undefined,
+    q: url.searchParams.get("q") ?? undefined,
   })
 
   try {
-    const [draftRows, total, storageUsed] = await Promise.all([
-      listDrafts(auth.session.user.id, { limit, offset, sort, type }),
-      countDrafts(auth.session.user.id, { type }),
+    // A search ranks by fuzzy match (typo-tolerant) and returns its own total,
+    // so page and count always come from one ranking. Plain listing keeps the
+    // indexed SQL path.
+    const [listed, storageUsed] = await Promise.all([
+      q
+        ? searchDrafts(auth.session.user.id, { q, limit, offset, sort, type })
+        : Promise.all([
+            listDrafts(auth.session.user.id, { limit, offset, sort, type }),
+            countDrafts(auth.session.user.id, { type }),
+          ]).then(([rows, total]) => ({ rows, total })),
       getUserDraftStorageUsage(auth.session.user.id),
     ])
+    const { rows: draftRows, total } = listed
 
     return NextResponse.json({
       drafts: draftRows.map((draft) => ({

--- a/components/editor/animate/timeline-clip.tsx
+++ b/components/editor/animate/timeline-clip.tsx
@@ -5,6 +5,7 @@ import { motion } from "motion/react"
 import {
   RiBrushLine,
   RiCheckboxBlankLine,
+  RiCropLine,
   RiDeleteBinLine,
   RiDragMove2Line,
   RiEraserLine,
@@ -112,6 +113,7 @@ const ICON_FOR: Record<ClipIconKey, typeof RiDragMove2Line> = {
   // Border lives in its own inspector section — share its brush icon.
   border: RiBrushLine,
   borderRadius: RiBrushLine,
+  crop: RiCropLine,
 }
 
 export function TimelineClip({

--- a/components/editor/canvas/canvas-backdrop.tsx
+++ b/components/editor/canvas/canvas-backdrop.tsx
@@ -115,13 +115,6 @@ type CanvasBackdropProps = {
    * lighting timelines leave this false — see `lightingSidesUsed`.
    */
   lightingAnimated?: boolean
-  /**
-   * Animate mode only: a clip animates backdrop effects, so the backdrop layers
-   * always carry the `--bd-fx-preview` filter var (falling back to `none`) even
-   * when the committed effects are neutral — so an effect can ease in from / out
-   * to nothing.
-   */
-  backdropAnimated?: boolean
 }
 
 function CanvasBackdropImpl({
@@ -138,7 +131,6 @@ function CanvasBackdropImpl({
   animatePatternStack,
   animateOverlayStack,
   lightingAnimated = false,
-  backdropAnimated = false,
 }: CanvasBackdropProps) {
   const resolveEffectiveBackground = React.useCallback(
     (bg: Background): Background => {
@@ -221,19 +213,19 @@ function CanvasBackdropImpl({
         })
       : null
 
-  // Combine the (possibly animated) backdrop-effects filter with a given asset
-  // filter preset into one CSS `filter`. While a clip animates backdrop effects
-  // the var must always be read, even when the committed effects are neutral —
-  // fall back to `none` so the layer still carries the filter for the player.
+  // Combine the backdrop-effects filter with a given asset filter preset into one
+  // CSS `filter`. The layer always reads `--bd-fx-preview`, even when the
+  // committed effects are neutral: slider drags and the animation player both
+  // drive that var, and a layer with no `filter` at all has nothing to drive.
+  // The neutral fallback is `brightness(1)` rather than `none` because `none`
+  // cannot sit next to a filter function when an asset filter is also applied.
   const filterCssFor = React.useCallback(
-    (assetFilterId: AssetFilter): string | undefined => {
-      const fx = effectsFilter ?? (backdropAnimated ? "none" : undefined)
-      const fxPart = fx ? `var(--bd-fx-preview, ${fx})` : undefined
+    (assetFilterId: AssetFilter): string => {
+      const fxPart = `var(--bd-fx-preview, ${effectsFilter ?? "brightness(1)"})`
       const af = assetFilterCss(assetFilterId)
-      if (fxPart && af) return `${fxPart} ${af}`
-      return fxPart ?? af ?? undefined
+      return af ? `${fxPart} ${af}` : fxPart
     },
-    [effectsFilter, backdropAnimated]
+    [effectsFilter]
   )
   const filterValue = filterCssFor(backdrop.filter ?? "none")
 
@@ -352,9 +344,7 @@ function CanvasBackdropImpl({
               }
               style={{
                 ...backgroundCss(effectiveBackground),
-                ...(filterCssFor(filterStackBase)
-                  ? { filter: filterCssFor(filterStackBase) }
-                  : {}),
+                filter: filterCssFor(filterStackBase),
               }}
             />
             {filterLayers.map((layer) => {
@@ -377,7 +367,7 @@ function CanvasBackdropImpl({
                   }
                   style={{
                     ...backgroundCss(effectiveBackground),
-                    ...(layerFilter ? { filter: layerFilter } : {}),
+                    filter: layerFilter,
                     opacity: `var(${filterLayerOpacityVar(layer.id)}, ${
                       layer.restOpaque ? 1 : 0
                     })` as unknown as number,
@@ -410,7 +400,7 @@ function CanvasBackdropImpl({
                 }
                 style={{
                   ...backgroundCss(effectiveBgBase),
-                  ...(filterValue ? { filter: filterValue } : {}),
+                  filter: filterValue,
                 }}
               />
             ) : null}
@@ -431,7 +421,7 @@ function CanvasBackdropImpl({
                 }
                 style={{
                   ...backgroundCss(layer.background),
-                  ...(filterValue ? { filter: filterValue } : {}),
+                  filter: filterValue,
                   opacity: `var(${backgroundLayerOpacityVar(layer.id)}, ${
                     layer.restOpaque ? 1 : 0
                   })` as unknown as number,
@@ -454,7 +444,7 @@ function CanvasBackdropImpl({
             }
             style={{
               ...backgroundCss(effectiveBackground),
-              ...(filterValue ? { filter: filterValue } : {}),
+              filter: filterValue,
             }}
           />
         )}

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -273,7 +273,10 @@ function CanvasViewInner({
     imageRef,
     // Include objectFit so contain↔cover remeasures imgW/imgH — inner lighting
     // sizes itself from those dims and would stay at the wrong box otherwise.
-    layoutKey: `${inRowMode ? "row" : "single"}:${frame.id}:${frame.orientation}:${screenshotSlots.length}:${widthPx}:${heightPx}:${padding}:${objectFit ?? "cover"}`,
+    // Natural dims cover a media swap: they reset to null and land again on
+    // load, and without them a new image/video keeps the previous media's
+    // measured box (the contain shell is sized from it, so it never resizes).
+    layoutKey: `${inRowMode ? "row" : "single"}:${frame.id}:${frame.orientation}:${screenshotSlots.length}:${widthPx}:${heightPx}:${padding}:${objectFit ?? "cover"}:${naturalDims ? `${naturalDims.w}x${naturalDims.h}` : "none"}`,
   })
   const suppressTransitionPlacement = useSuppressTransitionOnChange(
     placementDims
@@ -323,14 +326,18 @@ function CanvasViewInner({
   const canUseNaturalCanvasAspect =
     isAuto && naturalDims && !inRowMode && frame.id === "none"
   // Visible media size after a non-destructive video crop (full size otherwise).
-  const visibleNaturalDims =
+  const croppedDims =
     naturalDims &&
     lastCropRegion &&
-    !cropAnimated &&
     isVideoSrc(screenshot) &&
     isActiveCropRegion(lastCropRegion)
       ? croppedNaturalSize(naturalDims.w, naturalDims.h, lastCropRegion)
-      : naturalDims
+      : null
+  // Drives the CANVAS box (and so the encoder's frame size), which must not move
+  // while a crop animates — see `cropAnimated`.
+  const visibleNaturalDims = cropAnimated
+    ? naturalDims
+    : (croppedDims ?? naturalDims)
   // Auto canvas aspect follows the visible video crop when one is set.
   const autoDims = canUseNaturalCanvasAspect ? visibleNaturalDims : null
   const aw = autoDims ? autoDims.w : aspect.w || 16
@@ -485,10 +492,15 @@ function CanvasViewInner({
   // The bare frame always crops via the overflow polyfill (its <video> carries
   // the crop, not the shell that holds imgStyle — object-view-box can't reach a
   // div), so it needs the shrink-wrap aspect on every browser, not just Safari.
+  // The MEDIA shell's ratio, which decides whether the picture is letterboxed or
+  // stretched — so it must always be the crop's own ratio, even while animating.
+  // Using the canvas dims here made an animated crop render its window blown up
+  // to the full video's ratio, i.e. contain looked like cover.
+  const cropShellDims = croppedDims ?? visibleNaturalDims
   const videoCropAspectRatio =
-    videoCropRegion && visibleNaturalDims
-      ? visibleNaturalDims.w > 0 && visibleNaturalDims.h > 0
-        ? `${visibleNaturalDims.w} / ${visibleNaturalDims.h}`
+    videoCropRegion && cropShellDims
+      ? cropShellDims.w > 0 && cropShellDims.h > 0
+        ? `${cropShellDims.w} / ${cropShellDims.h}`
         : undefined
       : undefined
   // When a clip animates the border, the outline is ALWAYS mounted (even when

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -780,13 +780,6 @@ function CanvasViewInner({
           forceMount: lightingAnimated && lightingSides.inner,
         })
       : null
-  // When a clip animates backdrop effects, the backdrop must always carry the
-  // `--bd-fx-preview` filter var — even when the committed effects are neutral
-  // (no filter). Otherwise the player has nothing to drive when an effect eases
-  // in from / out to neutral, so it silently wouldn't animate.
-  const backdropAnimated =
-    isAnimateMode &&
-    !!canvasAnimation?.clips.some((c) => clipOwns(c, "backdrop"))
   const canDragScreenshot = activeTool === "pointer" && positionedStyle
   const mockupRotation =
     frame.orientation === "horizontal" && mockupOrientation === "portrait"
@@ -1036,7 +1029,6 @@ function CanvasViewInner({
             animatePatternStack={animatePatternStack}
             animateOverlayStack={animateOverlayStack}
             lightingAnimated={lightingAnimated && lightingSides.outer}
-            backdropAnimated={backdropAnimated}
           />
 
           {mainScreenshotRowStyle ? (

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -43,7 +43,6 @@ import {
   supportsObjectViewBox,
   type CropTarget,
 } from "@/lib/editor/crop-utils"
-import type { CaptureSettings } from "./upload-card"
 import {
   defaultCaptureDeviceForFrame,
   getDeviceMockup,
@@ -52,19 +51,10 @@ import {
 
 import {
   clipOwns,
-  EMPTY_BG_STACK,
-  EMPTY_FILTER_STACK,
-  EMPTY_OVERLAY_STACK,
-  EMPTY_PATTERN_STACK,
-  EMPTY_PORTRAIT_STACK,
+  FULL_CROP_REGION,
   lightingSidesUsed,
   overlayLayerOpacityVar,
   OVERLAY_BASE_OPACITY_VAR,
-  resolveAnimateBgStack,
-  resolveAnimateFilterStack,
-  resolveAnimateOverlayStack,
-  resolveAnimatePatternStack,
-  resolveAnimatePortraitStack,
 } from "@/lib/editor/animation-playback"
 import { AnnotationLayer } from "./annotation-layer"
 import { CanvasBackdrop } from "./canvas-backdrop"
@@ -96,27 +86,17 @@ import {
 } from "./screenshot-browser-frame"
 import { ScreenshotMockup } from "./screenshot-mockup"
 import { TweetCardView } from "./tweet-card"
-import { fetchTweetData } from "@/lib/editor/load-tweet"
-import {
-  DEFAULT_TWEET_SETTINGS,
-  tweetSettingsFromCard,
-  type TweetCardSettings,
-} from "@/lib/editor/tweet-settings"
-import {
-  downscaleImageFromUrl,
-  getOptimizedUrlSync,
-} from "@/lib/editor/image-resize"
-import { isUnsplashImageUrl } from "@/lib/editor/unsplash"
-import { isVideoSrc, revokeObjectUrl } from "@/lib/editor/media-type"
+import { isVideoSrc } from "@/lib/editor/media-type"
 import {
   fullPageCaptureMediaStyle,
   fullPageCaptureObjectFit,
   nextFullPageCaptureScrollPosition,
 } from "@/lib/editor/full-page-capture"
-import { useVideoRegistry } from "@/lib/editor/video-registry"
 import { ScreenshotSlotView } from "../screenshot-slot-element"
+import { useAnimateStacks } from "./use-animate-stacks"
+import { useCanvasMediaIntake } from "./use-canvas-media-intake"
 import { useAnnotationInteractions } from "./use-annotation-interactions"
-import { useImageFileIntake } from "./use-image-file-intake"
+import { useBackgroundDownscale } from "./use-background-downscale"
 import { usePlacementMeasurement } from "./use-placement-measurement"
 import { useScreenshotDrag } from "./use-screenshot-drag"
 import { useSuppressTransitionOnChange } from "./use-suppress-transition-on-change"
@@ -224,133 +204,23 @@ function CanvasViewInner({
   const canvasAnimation = useEditorStore(
     (s) => s.present.canvases.find((c) => c.id === scopeId)?.animation
   )
-  const animateBgStack = React.useMemo(
-    () =>
-      isAnimateMode && canvasAnimation
-        ? resolveAnimateBgStack(
-            canvasAnimation.clips,
-            background,
-            selectedAnimationClipId
-          )
-        : EMPTY_BG_STACK,
-    [isAnimateMode, canvasAnimation, background, selectedAnimationClipId]
-  )
-  const animateFilterStack = React.useMemo(
-    () =>
-      isAnimateMode && canvasAnimation
-        ? resolveAnimateFilterStack(
-            canvasAnimation.clips,
-            backdrop.filter ?? "none",
-            selectedAnimationClipId
-          )
-        : EMPTY_FILTER_STACK,
-    [isAnimateMode, canvasAnimation, backdrop.filter, selectedAnimationClipId]
-  )
-  const animatePortraitStack = React.useMemo(
-    () =>
-      isAnimateMode && canvasAnimation
-        ? resolveAnimatePortraitStack(
-            canvasAnimation.clips,
-            portrait,
-            selectedAnimationClipId
-          )
-        : EMPTY_PORTRAIT_STACK,
-    [isAnimateMode, canvasAnimation, portrait, selectedAnimationClipId]
-  )
-  const animatePatternStack = React.useMemo(
-    () =>
-      isAnimateMode && canvasAnimation
-        ? resolveAnimatePatternStack(
-            canvasAnimation.clips,
-            backdrop.pattern,
-            selectedAnimationClipId
-          )
-        : EMPTY_PATTERN_STACK,
-    [isAnimateMode, canvasAnimation, backdrop.pattern, selectedAnimationClipId]
-  )
-  const animateOverlayStack = React.useMemo(
-    () =>
-      isAnimateMode && canvasAnimation
-        ? resolveAnimateOverlayStack(
-            canvasAnimation.clips,
-            overlay,
-            selectedAnimationClipId
-          )
-        : EMPTY_OVERLAY_STACK,
-    [isAnimateMode, canvasAnimation, overlay, selectedAnimationClipId]
-  )
-  // Downscale whenever the background sourceUrl changes (on mount/hydration,
-  // and also when a custom preset applies a new image background mid-session).
-  // Unsplash CDN URLs must stay hotlinked — never convert them to data URLs.
-  React.useEffect(() => {
-    if (background.type !== "image" || !background.sourceUrl || !scopeId) return
-
-    const sourceUrl = background.sourceUrl
-    if (isUnsplashImageUrl(sourceUrl)) {
-      // Restore hotlink if a previous session stored a data-URL value.
-      if (background.value !== sourceUrl) {
-        useEditorStore.getState().setBackground(
-          {
-            type: "image",
-            value: sourceUrl,
-            sourceUrl,
-            thumbUrl: background.thumbUrl ?? undefined,
-          },
-          scopeId,
-          { silent: true }
-        )
-      }
-      return
-    }
-
-    if (background.value.startsWith("data:")) return
-
-    const thumbUrl = background.thumbUrl
-    const canvasId = scopeId
-    const opts = { maxDimension: 1600, jpegQuality: 0.9 }
-
-    // If we already have a cached downscale for this URL, apply it synchronously
-    // so we never show a stale or wrong image (e.g. after a preset re-apply).
-    const cached = getOptimizedUrlSync(sourceUrl, opts)
-    if (cached) {
-      useEditorStore.getState().setBackground(
-        {
-          type: "image",
-          value: cached,
-          sourceUrl,
-          thumbUrl: thumbUrl ?? undefined,
-        },
-        canvasId,
-        { silent: true }
-      )
-      return
-    }
-
-    void downscaleImageFromUrl(sourceUrl, opts)
-      .then((downscaled) => {
-        const state = useEditorStore.getState()
-        const c = state.present.canvases.find((cv) => cv.id === canvasId)
-        if (
-          c?.background.type !== "image" ||
-          c.background.sourceUrl !== sourceUrl
-        )
-          return
-        state.setBackground(
-          {
-            type: "image",
-            value: downscaled,
-            sourceUrl,
-            thumbUrl: thumbUrl ?? undefined,
-          },
-          canvasId,
-          { silent: true }
-        )
-      })
-      .catch((err) => {
-        console.log("[bg] downscale failed", err)
-      })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [background.sourceUrl])
+  const {
+    bg: animateBgStack,
+    filterStack: animateFilterStack,
+    portraitStack: animatePortraitStack,
+    patternStack: animatePatternStack,
+    overlayStack: animateOverlayStack,
+  } = useAnimateStacks({
+    isAnimateMode,
+    canvasAnimation,
+    selectedClipId: selectedAnimationClipId,
+    background,
+    filter: backdrop.filter ?? "none",
+    portrait,
+    pattern: backdrop.pattern,
+    overlay,
+  })
+  useBackgroundDownscale(background, scopeId)
 
   const canvasRef = React.useRef<HTMLDivElement>(null)
   const generatedAnnotationMaskId = React.useId()
@@ -415,61 +285,7 @@ function CanvasViewInner({
     suppressTransitionSlots ||
     suppressTransitionMedia ||
     suppressTransitionPlacement
-  const selectedScreenshotSlotId = useEditorStore(
-    (s) => s.selectedScreenshotSlotId
-  )
-  const setMainScreenshotImage = React.useCallback(
-    (src: string, isFullPageCapture = false) => {
-      // Free the outgoing image/video object URL so replacements don't leak —
-      // unless another canvas still references it (e.g. after duplicate).
-      const canvases = useEditorStore.getState().present.canvases
-      const prev = canvases.find((c) => c.id === scopeId)?.screenshot
-      if (prev && prev !== src) {
-        const stillUsed = canvases.some(
-          (c) =>
-            c.id !== scopeId &&
-            (c.screenshot === prev || c.originalScreenshot === prev)
-        )
-        if (!stillUsed) revokeObjectUrl(prev)
-      }
-      if (isFullPageCapture) {
-        setFullPageScreenshot(src)
-      } else {
-        setScreenshot(src)
-      }
-      setNaturalDims(null)
-    },
-    [scopeId, setFullPageScreenshot, setScreenshot]
-  )
-  const handleImageFile = React.useCallback(
-    (src: string) => {
-      if (selectedScreenshotSlotId) {
-        setScreenshotSlotImage(selectedScreenshotSlotId, src)
-        return
-      }
-      setMainScreenshotImage(src)
-    },
-    [selectedScreenshotSlotId, setMainScreenshotImage, setScreenshotSlotImage]
-  )
-
-  // Register the main <video> element so the docked control bar can drive it.
-  // Preview/thumbnail scopes never register — only the real editable canvas.
-  const registerVideo = useVideoRegistry((s) => s.registerVideo)
-  const handleMediaElement = React.useCallback(
-    (el: HTMLVideoElement | null) => {
-      if (!scopeId || isCanvasPreview) return
-      registerVideo(scopeId, el)
-    },
-    [isCanvasPreview, registerVideo, scopeId]
-  )
-  React.useEffect(() => {
-    return () => {
-      if (scopeId && !isCanvasPreview) registerVideo(scopeId, null)
-    }
-  }, [isCanvasPreview, registerVideo, scopeId])
-  // True while an incoming GIF is transcoding to video — drives the canvas
-  // skeleton so the user sees progress instead of a frozen empty box.
-  const [preparingMedia, setPreparingMedia] = React.useState(false)
+  const resetNaturalDims = React.useCallback(() => setNaturalDims(null), [])
   const {
     fileInputRef,
     fileInputProps,
@@ -479,90 +295,30 @@ function CanvasViewInner({
     pendingGif,
     confirmGifTranscode,
     cancelGifTranscode,
-  } = useImageFileIntake(handleImageFile, {
-    // A video may only be the sole screenshot — once extra slots exist, block
-    // dropping/pasting one into the main box (and route slots reject it too).
-    allowVideo: screenshotSlots.length === 0,
-    onPreparingChange: setPreparingMedia,
+    preparingMedia,
+    handleMediaElement,
+    handleCaptureWebsite,
+    handleDemoScreenshot,
+    handleLoadTweet,
+    handleReplaceTweet,
+  } = useCanvasMediaIntake({
+    scopeId,
+    isCanvasPreview,
+    slotCount: screenshotSlots.length,
+    tweet,
+    setScreenshot,
+    setFullPageScreenshot,
+    setScreenshotSlotImage,
+    setTweet,
+    onNaturalDimsReset: resetNaturalDims,
   })
 
-  const handleCaptureWebsite = React.useCallback(
-    async (rawUrl: string, settings: CaptureSettings) => {
-      let target: URL
-      try {
-        target = new URL(rawUrl)
-      } catch {
-        toast.error("Enter a valid URL")
-        return
-      }
-      try {
-        const res = await fetch("/api/screenshot", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            url: target.toString(),
-            device: settings.device,
-            width: settings.width,
-            aspectRatio: settings.aspectRatio,
-            delay: settings.delay,
-          }),
-        })
-        if (!res.ok) {
-          const { error } = (await res
-            .json()
-            .catch(() => ({ error: "Capture failed" }))) as { error?: string }
-          throw new Error(error ?? "Capture failed")
-        }
-        const blob = await res.blob()
-        const dataUrl = await new Promise<string>((resolve, reject) => {
-          const fr = new FileReader()
-          fr.onload = () =>
-            resolve(typeof fr.result === "string" ? fr.result : "")
-          fr.onerror = () => reject(fr.error ?? new Error("FileReader error"))
-          fr.readAsDataURL(blob)
-        })
-        // API captures are always full-page (screenshotOptions.fullPage).
-        setMainScreenshotImage(dataUrl, true)
-      } catch (err) {
-        toast.error(
-          err instanceof Error ? err.message : "Could not capture screenshot"
-        )
-      }
-    },
-    [setMainScreenshotImage]
-  )
-
-  /** Pre-captured R2 demos are full-page PNGs — same path as /api/screenshot. */
-  const handleDemoScreenshot = React.useCallback(
-    (src: string) => {
-      setMainScreenshotImage(src, true)
-    },
-    [setMainScreenshotImage]
-  )
-
-  const handleLoadTweet = React.useCallback(
-    async (
-      url: string,
-      settings: TweetCardSettings = DEFAULT_TWEET_SETTINGS
-    ) => {
-      // fetchTweetData throws a user-facing Error; let the caller surface it.
-      const data = await fetchTweetData(url)
-      setTweet({ data, ...settings })
-    },
-    [setTweet]
-  )
-
-  const handleReplaceTweet = React.useCallback(
-    async (url: string, settings?: TweetCardSettings) => {
-      await handleLoadTweet(
-        url,
-        settings ??
-          (tweet ? tweetSettingsFromCard(tweet) : DEFAULT_TWEET_SETTINGS)
-      )
-    },
-    [handleLoadTweet, tweet]
-  )
-
+  // A clip animating the crop keeps the media box at FULL natural size and moves
+  // the source rect inside it. Sizing the box from the crop would make the auto
+  // aspect — and therefore the encoder's frame size — depend on which keyframe
+  // happened to be selected at export time, and change mid-render.
+  const cropAnimated =
+    isAnimateMode && !!canvasAnimation?.clips.some((c) => clipOwns(c, "crop"))
   const isAuto = aspect.id === "auto" || aspect.w === 0 || aspect.h === 0
   const canUseNaturalCanvasAspect =
     isAuto && naturalDims && !inRowMode && frame.id === "none"
@@ -570,6 +326,7 @@ function CanvasViewInner({
   const visibleNaturalDims =
     naturalDims &&
     lastCropRegion &&
+    !cropAnimated &&
     isVideoSrc(screenshot) &&
     isActiveCropRegion(lastCropRegion)
       ? croppedNaturalSize(naturalDims.w, naturalDims.h, lastCropRegion)
@@ -710,12 +467,16 @@ function CanvasViewInner({
   // render time. Chrome/Edge use object-view-box; Firefox/Safari use an
   // overflow + positioned-media polyfill. Images are cropped destructively
   // (the src is already the cropped bitmap), so they never get it.
-  const videoCropRegion =
-    lastCropRegion &&
-    isVideoSrc(screenshot) &&
-    isActiveCropRegion(lastCropRegion)
+  // When a clip animates the crop the shell is ALWAYS mounted (even with a
+  // neutral committed region) so the player has a source rect to drive via the
+  // preview vars — the same rule the border outline below follows.
+  const videoCropRegion = !isVideoSrc(screenshot)
+    ? null
+    : lastCropRegion && isActiveCropRegion(lastCropRegion)
       ? lastCropRegion
-      : null
+      : cropAnimated
+        ? FULL_CROP_REGION
+        : null
   const videoMediaStyle = videoCropRegion
     ? nativeVideoCrop
       ? objectViewBoxCropStyle(videoCropRegion)

--- a/components/editor/canvas/helpers.ts
+++ b/components/editor/canvas/helpers.ts
@@ -472,6 +472,29 @@ export function parseAspectRatio(aspectRatio: string) {
   return width / height
 }
 
+/**
+ * Largest box of `ratio` (w/h) that fits inside `boxW`×`boxH` — i.e. what
+ * `object-fit: contain` would produce, in pixels.
+ *
+ * Video contain shells need this computed rather than expressed in CSS: a
+ * `width:100% + height:auto + aspect-ratio` box silently violates its own ratio
+ * once `max-height` clamps it, which shears anything positioned by percentages
+ * inside (see the crop polyfill in `screenshot-bare`).
+ */
+export function fitContainBox(boxW: number, boxH: number, ratio: number) {
+  const width = Math.min(boxW, boxH * ratio)
+  return { width, height: width / ratio }
+}
+
+/**
+ * Smallest box of `ratio` (w/h) that fully covers `boxW`×`boxH` — the `object-fit:
+ * cover` counterpart of {@link fitContainBox}. Overflows the box on one axis.
+ */
+export function coverContainerBox(boxW: number, boxH: number, ratio: number) {
+  const width = Math.max(boxW, boxH * ratio)
+  return { width, height: width / ratio }
+}
+
 export function isDesktopMockup(deviceId: string) {
   return (
     deviceId.startsWith("macbook") ||

--- a/components/editor/canvas/screenshot-bare.tsx
+++ b/components/editor/canvas/screenshot-bare.tsx
@@ -6,7 +6,13 @@ import { toast } from "sonner"
 import { ShimmerImage } from "@/components/ui/shimmer-image"
 import { cn } from "@/lib/utils"
 import {
+  CROP_FIT_ORIGIN_VAR,
+  CROP_FIT_SX_VAR,
+  CROP_FIT_SY_VAR,
+  CROP_SHELL_H_VAR,
+  CROP_SHELL_W_VAR,
   cropMediaObjectStyle,
+  cropOriginCss,
   isActiveCropRegion,
 } from "@/lib/editor/crop-utils"
 import { isVideoSrc } from "@/lib/editor/media-type"
@@ -407,18 +413,23 @@ export function ScreenshotBare({
    * region every frame, but this scale is computed once from the committed one.
    */
   const cropCoverTransform = (() => {
-    if (!activeCrop || objectFit !== "cover" || !placementDims) return null
+    if (!activeCrop || objectFit !== "cover") return null
     const ratio = cropAspectRatio ? parseAspectRatio(cropAspectRatio) : null
-    if (!ratio) return null
-    const { imgW, imgH } = placementDims
-    if (!(imgW > 0) || !(imgH > 0)) return null
-    const cover = coverContainerBox(imgW, imgH, ratio)
+    // Always emit the vars, even with no static value to compute: an animated
+    // crop needs something to drive, and a neutral 1 is a no-op otherwise.
+    let sx = 1
+    let sy = 1
+    if (ratio && placementDims) {
+      const { imgW, imgH } = placementDims
+      if (imgW > 0 && imgH > 0) {
+        const cover = coverContainerBox(imgW, imgH, ratio)
+        sx = cover.width / imgW
+        sy = cover.height / imgH
+      }
+    }
     return {
-      // The crop's centre in source coordinates — the point that must stay put.
-      transformOrigin: `${activeCrop.x + activeCrop.width / 2}% ${
-        activeCrop.y + activeCrop.height / 2
-      }%`,
-      transform: `scale(${cover.width / imgW}, ${cover.height / imgH})`,
+      transformOrigin: `var(${CROP_FIT_ORIGIN_VAR}, ${cropOriginCss(activeCrop)})`,
+      transform: `scale(var(${CROP_FIT_SX_VAR}, ${sx}), var(${CROP_FIT_SY_VAR}, ${sy}))`,
     } satisfies React.CSSProperties
   })()
 
@@ -430,8 +441,10 @@ export function ScreenshotBare({
         ...(cropAspectRatio ? { aspectRatio: cropAspectRatio } : null),
         ...(cropContainBox
           ? {
-              width: cropContainBox.width,
-              height: cropContainBox.height,
+              // Vars let an animated crop resize the shell per frame; the
+              // measured box is the committed fallback.
+              width: `var(${CROP_SHELL_W_VAR}, ${cropContainBox.width}px)`,
+              height: `var(${CROP_SHELL_H_VAR}, ${cropContainBox.height}px)`,
               maxWidth: "100%",
               maxHeight: "100%",
             }

--- a/components/editor/canvas/screenshot-bare.tsx
+++ b/components/editor/canvas/screenshot-bare.tsx
@@ -18,7 +18,7 @@ import type {
 import { ScreenshotEditMenu } from "./screenshot-edit-menu"
 import { VideoIdlePoster } from "./video-idle-poster"
 import { useVideoPreload } from "./use-video-preload"
-import { parseAspectRatio } from "./helpers"
+import { coverContainerBox, fitContainBox, parseAspectRatio } from "./helpers"
 import type { TweetCardSettings } from "@/lib/editor/tweet-settings"
 import type { CaptureDevice, CaptureSettings } from "./upload-card"
 
@@ -239,8 +239,11 @@ export function ScreenshotBare({
     }
     const aspect = parseAspectRatio(resolvedVideoAspect)
     if (!aspect) return null
-    const width = Math.min(placementDims.imgW, placementDims.imgH * aspect)
-    const height = width / aspect
+    const { width, height } = fitContainBox(
+      placementDims.imgW,
+      placementDims.imgH,
+      aspect
+    )
     return {
       width,
       height,
@@ -348,6 +351,8 @@ export function ScreenshotBare({
               transformStyle: "preserve-3d",
             }
 
+  const wantsContain = isNestedContain || (!isNested && objectFit === "contain")
+
   const mediaClassName = cn(
     "pointer-events-auto absolute select-none",
     // Nested cover/fill fills the parent slot/row box.
@@ -356,8 +361,7 @@ export function ScreenshotBare({
     !isNested && objectFit === "fill" && "h-full w-full object-fill",
     // contain: shrink-wrap to the image's aspect (max bounds = stage/parent).
     // Outline/radius/shadow then hug the image; lighting uses measured size.
-    (isNestedContain || (!isNested && objectFit === "contain")) &&
-      "max-h-full max-w-full object-contain",
+    wantsContain && "max-h-full max-w-full object-contain",
     isNested && objectFit === "cover" && "object-cover",
     isNested && objectFit === "fill" && "object-fill",
     screenshotLayer.hidden && "pointer-events-none",
@@ -371,21 +375,76 @@ export function ScreenshotBare({
     isScreenshotSelected && activeTool === "pointer" && "outline-none"
   )
 
+  /**
+   * Contain box for a CROPPED video, in stage pixels.
+   *
+   * The crop polyfill scales the `<video>` by percentages of this shell, so the
+   * shell's rendered ratio has to equal the crop's ratio exactly or the picture
+   * shears. `width:100% + height:auto + aspect-ratio` does NOT guarantee that:
+   * when the crop is taller than the stage, `max-height:100%` clamps the height
+   * while the explicit width stays at 100%, and the box silently ends up wider
+   * than its own aspect ratio. Solve it the same way the uncropped contain path
+   * does — fit the ratio into the measured stage and hand back definite pixels.
+   */
+  const cropContainBox = (() => {
+    if (!activeCrop || !wantsContain || !placementDims) return null
+    const ratio = cropAspectRatio ? parseAspectRatio(cropAspectRatio) : null
+    if (!ratio) return null
+    const box = fitContainBox(placementDims.stageW, placementDims.stageH, ratio)
+    return box.width > 0 ? box : null
+  })()
+
+  /**
+   * Cover + crop. The shell keeps the stage box (`h-full w-full`), so its inline
+   * `aspect-ratio` is ignored — both dimensions are definite — and the polyfill
+   * maps the crop region straight onto the stage's ratio, shearing it. Contain
+   * fixes this by resizing the shell; cover can't, because the picture has to end
+   * up LARGER than its clip box. Scale the video about the crop's own centre
+   * instead: the mapped region regains its ratio and grows to cover, and the
+   * shell's overflow:hidden clips the excess.
+   *
+   * Not applied while a clip animates the crop — the `--crop-*` vars move the
+   * region every frame, but this scale is computed once from the committed one.
+   */
+  const cropCoverTransform = (() => {
+    if (!activeCrop || objectFit !== "cover" || !placementDims) return null
+    const ratio = cropAspectRatio ? parseAspectRatio(cropAspectRatio) : null
+    if (!ratio) return null
+    const { imgW, imgH } = placementDims
+    if (!(imgW > 0) || !(imgH > 0)) return null
+    const cover = coverContainerBox(imgW, imgH, ratio)
+    return {
+      // The crop's centre in source coordinates — the point that must stay put.
+      transformOrigin: `${activeCrop.x + activeCrop.width / 2}% ${
+        activeCrop.y + activeCrop.height / 2
+      }%`,
+      transform: `scale(${cover.width / imgW}, ${cover.height / imgH})`,
+    } satisfies React.CSSProperties
+  })()
+
   const cropFrameStyle: React.CSSProperties | undefined = activeCrop
     ? {
         ...imagePositionStyle,
         overflow: "hidden",
         objectFit: undefined,
         ...(cropAspectRatio ? { aspectRatio: cropAspectRatio } : null),
-        ...((isNestedContain || (!isNested && objectFit === "contain")) &&
-        cropAspectRatio
+        ...(cropContainBox
           ? {
-              width: "100%",
-              height: "auto",
+              width: cropContainBox.width,
+              height: cropContainBox.height,
               maxWidth: "100%",
               maxHeight: "100%",
             }
-          : null),
+          : wantsContain && cropAspectRatio
+            ? {
+                // Pre-measurement only: definite width so aspect-ratio can
+                // resolve a height at all (auto/auto stays 0 in Safari).
+                width: "100%",
+                height: "auto",
+                maxWidth: "100%",
+                maxHeight: "100%",
+              }
+            : null),
       }
     : undefined
 
@@ -465,7 +524,10 @@ export function ScreenshotBare({
       }
       {...(activeCrop
         ? {
-            style: cropMediaObjectStyle(activeCrop),
+            style: {
+              ...cropMediaObjectStyle(activeCrop),
+              ...cropCoverTransform,
+            },
             className: "pointer-events-none absolute max-h-none max-w-none",
           }
         : {

--- a/components/editor/canvas/use-animate-stacks.ts
+++ b/components/editor/canvas/use-animate-stacks.ts
@@ -1,0 +1,93 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  EMPTY_BG_STACK,
+  EMPTY_FILTER_STACK,
+  EMPTY_OVERLAY_STACK,
+  EMPTY_PATTERN_STACK,
+  EMPTY_PORTRAIT_STACK,
+  resolveAnimateBgStack,
+  resolveAnimateFilterStack,
+  resolveAnimateOverlayStack,
+  resolveAnimatePatternStack,
+  resolveAnimatePortraitStack,
+} from "@/lib/editor/animation-playback"
+import type {
+  AssetFilter,
+  Background,
+  BackdropPattern,
+  CanvasAnimation,
+  Overlay,
+  Portrait,
+} from "@/lib/editor/state-types"
+
+/**
+ * Build the Animate-mode crossfade stacks for every property that layers rather
+ * than interpolates — background, backdrop filter, portrait, pattern, overlay.
+ * Each gets ONE layer per keyframe so repeated swaps chain (bg1 → bg2 → bg3)
+ * instead of every swap cross-fading from the same initial value.
+ *
+ * Outside animate mode (or with no clips) every stack is empty and the caller
+ * renders the committed value as usual.
+ */
+export function useAnimateStacks({
+  isAnimateMode,
+  canvasAnimation,
+  selectedClipId,
+  background,
+  filter,
+  portrait,
+  pattern,
+  overlay,
+}: {
+  isAnimateMode: boolean
+  canvasAnimation: CanvasAnimation | undefined
+  selectedClipId: string | null
+  background: Background
+  filter: AssetFilter
+  portrait: Portrait
+  pattern: BackdropPattern
+  overlay: Overlay
+}) {
+  const clips = isAnimateMode ? (canvasAnimation?.clips ?? null) : null
+
+  const bg = React.useMemo(
+    () =>
+      clips
+        ? resolveAnimateBgStack(clips, background, selectedClipId)
+        : EMPTY_BG_STACK,
+    [clips, background, selectedClipId]
+  )
+  const filterStack = React.useMemo(
+    () =>
+      clips
+        ? resolveAnimateFilterStack(clips, filter, selectedClipId)
+        : EMPTY_FILTER_STACK,
+    [clips, filter, selectedClipId]
+  )
+  const portraitStack = React.useMemo(
+    () =>
+      clips
+        ? resolveAnimatePortraitStack(clips, portrait, selectedClipId)
+        : EMPTY_PORTRAIT_STACK,
+    [clips, portrait, selectedClipId]
+  )
+  const patternStack = React.useMemo(
+    () =>
+      clips
+        ? resolveAnimatePatternStack(clips, pattern, selectedClipId)
+        : EMPTY_PATTERN_STACK,
+    [clips, pattern, selectedClipId]
+  )
+  const overlayStack = React.useMemo(
+    () =>
+      clips
+        ? resolveAnimateOverlayStack(clips, overlay, selectedClipId)
+        : EMPTY_OVERLAY_STACK,
+    [clips, overlay, selectedClipId]
+  )
+
+  return { bg, filterStack, portraitStack, patternStack, overlayStack }
+}

--- a/components/editor/canvas/use-background-downscale.ts
+++ b/components/editor/canvas/use-background-downscale.ts
@@ -1,0 +1,77 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  downscaleImageFromUrl,
+  getOptimizedUrlSync,
+} from "@/lib/editor/image-resize"
+import { useEditorStore } from "@/lib/editor/store"
+import { isUnsplashImageUrl } from "@/lib/editor/unsplash"
+import type { Background } from "@/lib/editor/state-types"
+
+const DOWNSCALE_OPTS = { maxDimension: 1600, jpegQuality: 0.9 }
+
+/**
+ * Downscale an image background whenever its `sourceUrl` changes — on
+ * mount/hydration, and when a custom preset applies a new image mid-session.
+ *
+ * Unsplash CDN URLs must stay hotlinked for view tracking, so they are never
+ * converted to data URLs; a stored data URL from an older session is restored
+ * back to the hotlink instead. Writes are `silent` so they never land in undo.
+ */
+export function useBackgroundDownscale(
+  background: Background,
+  canvasId: string | null | undefined
+) {
+  React.useEffect(() => {
+    if (background.type !== "image" || !background.sourceUrl || !canvasId)
+      return
+
+    const sourceUrl = background.sourceUrl
+    const thumbUrl = background.thumbUrl ?? undefined
+    const setBackground = (value: string) =>
+      useEditorStore
+        .getState()
+        .setBackground(
+          { type: "image", value, sourceUrl, thumbUrl },
+          canvasId,
+          {
+            silent: true,
+          }
+        )
+
+    if (isUnsplashImageUrl(sourceUrl)) {
+      if (background.value !== sourceUrl) setBackground(sourceUrl)
+      return
+    }
+
+    if (background.value.startsWith("data:")) return
+
+    // Apply a cached downscale synchronously so we never show a stale or wrong
+    // image (e.g. after a preset re-apply).
+    const cached = getOptimizedUrlSync(sourceUrl, DOWNSCALE_OPTS)
+    if (cached) {
+      setBackground(cached)
+      return
+    }
+
+    void downscaleImageFromUrl(sourceUrl, DOWNSCALE_OPTS)
+      .then((downscaled) => {
+        const c = useEditorStore
+          .getState()
+          .present.canvases.find((cv) => cv.id === canvasId)
+        // The background may have changed while the downscale was in flight.
+        if (
+          c?.background.type !== "image" ||
+          c.background.sourceUrl !== sourceUrl
+        )
+          return
+        setBackground(downscaled)
+      })
+      .catch((err) => {
+        console.log("[bg] downscale failed", err)
+      })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [background.sourceUrl])
+}

--- a/components/editor/canvas/use-canvas-media-intake.ts
+++ b/components/editor/canvas/use-canvas-media-intake.ts
@@ -1,0 +1,204 @@
+"use client"
+
+import * as React from "react"
+import { toast } from "sonner"
+
+import { fetchTweetData } from "@/lib/editor/load-tweet"
+import { revokeObjectUrl } from "@/lib/editor/media-type"
+import { useEditorStore } from "@/lib/editor/store"
+import {
+  DEFAULT_TWEET_SETTINGS,
+  tweetSettingsFromCard,
+  type TweetCardSettings,
+} from "@/lib/editor/tweet-settings"
+import { useVideoRegistry } from "@/lib/editor/video-registry"
+
+import type { CaptureSettings } from "./upload-card"
+import { useImageFileIntake } from "./use-image-file-intake"
+
+type TweetCard = Parameters<typeof tweetSettingsFromCard>[0]
+
+/**
+ * Every way media enters a canvas: file drop/paste/browse, the website-capture
+ * API, pre-captured demos, and tweet cards — plus the main `<video>`
+ * registration the docked control bar drives.
+ *
+ * Kept together because they all funnel through one screenshot setter that owns
+ * the object-URL lifecycle: replacing media must revoke the outgoing URL, but
+ * only when no other canvas still references it (duplicates share the string).
+ */
+export function useCanvasMediaIntake({
+  scopeId,
+  isCanvasPreview,
+  slotCount,
+  tweet,
+  setScreenshot,
+  setFullPageScreenshot,
+  setScreenshotSlotImage,
+  setTweet,
+  onNaturalDimsReset,
+}: {
+  scopeId: string | null | undefined
+  isCanvasPreview: boolean
+  slotCount: number
+  tweet: TweetCard | null | undefined
+  setScreenshot: (src: string) => void
+  setFullPageScreenshot: (src: string) => void
+  setScreenshotSlotImage: (slotId: string, src: string) => void
+  setTweet: (card: TweetCard) => void
+  onNaturalDimsReset: () => void
+}) {
+  const selectedScreenshotSlotId = useEditorStore(
+    (s) => s.selectedScreenshotSlotId
+  )
+
+  const setMainScreenshotImage = React.useCallback(
+    (src: string, isFullPageCapture = false) => {
+      // Free the outgoing image/video object URL so replacements don't leak —
+      // unless another canvas still references it (e.g. after duplicate).
+      const canvases = useEditorStore.getState().present.canvases
+      const prev = canvases.find((c) => c.id === scopeId)?.screenshot
+      if (prev && prev !== src) {
+        const stillUsed = canvases.some(
+          (c) =>
+            c.id !== scopeId &&
+            (c.screenshot === prev || c.originalScreenshot === prev)
+        )
+        if (!stillUsed) revokeObjectUrl(prev)
+      }
+      if (isFullPageCapture) {
+        setFullPageScreenshot(src)
+      } else {
+        setScreenshot(src)
+      }
+      onNaturalDimsReset()
+    },
+    [scopeId, setFullPageScreenshot, setScreenshot, onNaturalDimsReset]
+  )
+
+  const handleImageFile = React.useCallback(
+    (src: string) => {
+      if (selectedScreenshotSlotId) {
+        setScreenshotSlotImage(selectedScreenshotSlotId, src)
+        return
+      }
+      setMainScreenshotImage(src)
+    },
+    [selectedScreenshotSlotId, setMainScreenshotImage, setScreenshotSlotImage]
+  )
+
+  // Register the main <video> element so the docked control bar can drive it.
+  // Preview/thumbnail scopes never register — only the real editable canvas.
+  const registerVideo = useVideoRegistry((s) => s.registerVideo)
+  const handleMediaElement = React.useCallback(
+    (el: HTMLVideoElement | null) => {
+      if (!scopeId || isCanvasPreview) return
+      registerVideo(scopeId, el)
+    },
+    [isCanvasPreview, registerVideo, scopeId]
+  )
+  React.useEffect(() => {
+    return () => {
+      if (scopeId && !isCanvasPreview) registerVideo(scopeId, null)
+    }
+  }, [isCanvasPreview, registerVideo, scopeId])
+
+  // True while an incoming GIF is transcoding to video — drives the canvas
+  // skeleton so the user sees progress instead of a frozen empty box.
+  const [preparingMedia, setPreparingMedia] = React.useState(false)
+  const intake = useImageFileIntake(handleImageFile, {
+    // A video may only be the sole screenshot — once extra slots exist, block
+    // dropping/pasting one into the main box (and route slots reject it too).
+    allowVideo: slotCount === 0,
+    onPreparingChange: setPreparingMedia,
+  })
+
+  const handleCaptureWebsite = React.useCallback(
+    async (rawUrl: string, settings: CaptureSettings) => {
+      let target: URL
+      try {
+        target = new URL(rawUrl)
+      } catch {
+        toast.error("Enter a valid URL")
+        return
+      }
+      try {
+        const res = await fetch("/api/screenshot", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            url: target.toString(),
+            device: settings.device,
+            width: settings.width,
+            aspectRatio: settings.aspectRatio,
+            delay: settings.delay,
+          }),
+        })
+        if (!res.ok) {
+          const { error } = (await res
+            .json()
+            .catch(() => ({ error: "Capture failed" }))) as { error?: string }
+          throw new Error(error ?? "Capture failed")
+        }
+        const blob = await res.blob()
+        const dataUrl = await new Promise<string>((resolve, reject) => {
+          const fr = new FileReader()
+          fr.onload = () =>
+            resolve(typeof fr.result === "string" ? fr.result : "")
+          fr.onerror = () => reject(fr.error ?? new Error("FileReader error"))
+          fr.readAsDataURL(blob)
+        })
+        // API captures are always full-page (screenshotOptions.fullPage).
+        setMainScreenshotImage(dataUrl, true)
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Could not capture screenshot"
+        )
+      }
+    },
+    [setMainScreenshotImage]
+  )
+
+  /** Pre-captured R2 demos are full-page PNGs — same path as /api/screenshot. */
+  const handleDemoScreenshot = React.useCallback(
+    (src: string) => {
+      setMainScreenshotImage(src, true)
+    },
+    [setMainScreenshotImage]
+  )
+
+  const handleLoadTweet = React.useCallback(
+    async (
+      url: string,
+      settings: TweetCardSettings = DEFAULT_TWEET_SETTINGS
+    ) => {
+      // fetchTweetData throws a user-facing Error; let the caller surface it.
+      const data = await fetchTweetData(url)
+      setTweet({ data, ...settings })
+    },
+    [setTweet]
+  )
+
+  const handleReplaceTweet = React.useCallback(
+    async (url: string, settings?: TweetCardSettings) => {
+      await handleLoadTweet(
+        url,
+        settings ??
+          (tweet ? tweetSettingsFromCard(tweet) : DEFAULT_TWEET_SETTINGS)
+      )
+    },
+    [handleLoadTweet, tweet]
+  )
+
+  return {
+    ...intake,
+    preparingMedia,
+    setMainScreenshotImage,
+    handleImageFile,
+    handleMediaElement,
+    handleCaptureWebsite,
+    handleDemoScreenshot,
+    handleLoadTweet,
+    handleReplaceTweet,
+  }
+}

--- a/components/editor/canvas/use-placement-measurement.ts
+++ b/components/editor/canvas/use-placement-measurement.ts
@@ -9,6 +9,12 @@ export type PlacementDims = {
   imgH: number
 }
 
+const sameDims = (a: PlacementDims, b: PlacementDims) =>
+  a.stageW === b.stageW &&
+  a.stageH === b.stageH &&
+  a.imgW === b.imgW &&
+  a.imgH === b.imgH
+
 export function usePlacementMeasurement({
   enabled,
   stageRef,
@@ -20,8 +26,23 @@ export function usePlacementMeasurement({
   imageRef: React.RefObject<HTMLImageElement | null>
   layoutKey?: string | number
 }) {
-  const [placementDims, setPlacementDims] =
-    React.useState<PlacementDims | null>(null)
+  const [measured, setMeasured] = React.useState<{
+    key: string | number | undefined
+    dims: PlacementDims | null
+  }>({ key: layoutKey, dims: null })
+
+  /**
+   * Contain shells are sized FROM these dims, so a measurement outlives the
+   * layout it described: the shell stays pinned to the old box, the
+   * ResizeObserver never sees a change, and nothing ever re-measures. Swapping
+   * media (e.g. a cropped image → a video) left the new media rendering inside
+   * the previous one's box until a reload.
+   *
+   * Dropping the measurement in the same render the key changes breaks that
+   * loop — the shell falls back to its aspect-driven size, and the layout effect
+   * below measures the real new box.
+   */
+  const placementDims = measured.key === layoutKey ? measured.dims : null
 
   const measurePlacement = React.useCallback(() => {
     const stage = stageRef.current
@@ -37,18 +58,13 @@ export function usePlacementMeasurement({
 
     if (!next.stageW || !next.stageH || !next.imgW || !next.imgH) return
 
-    setPlacementDims((prev) => {
-      if (
-        prev?.stageW === next.stageW &&
-        prev.stageH === next.stageH &&
-        prev.imgW === next.imgW &&
-        prev.imgH === next.imgH
-      ) {
+    setMeasured((prev) => {
+      if (prev.key === layoutKey && prev.dims && sameDims(prev.dims, next)) {
         return prev
       }
-      return next
+      return { key: layoutKey, dims: next }
     })
-  }, [imageRef, stageRef])
+  }, [imageRef, layoutKey, stageRef])
 
   React.useLayoutEffect(() => {
     if (!enabled) return

--- a/components/editor/inspector/backdrop-section.tsx
+++ b/components/editor/inspector/backdrop-section.tsx
@@ -121,9 +121,12 @@ export function BackdropSection({
   const previewEffects = React.useCallback(
     (patch: Partial<typeof effects>) => {
       const candidate = { ...effects, ...patch }
+      // A neutral candidate must still write the var — clearing it would fall
+      // back to the committed (non-neutral) filter while the slider sits at its
+      // neutral value.
       setPreviewVar(
         BACKDROP_FX_PREVIEW_VAR,
-        effectsFilterCss(candidate) ?? null
+        effectsFilterCss(candidate) ?? "brightness(1)"
       )
       if (patch.noise !== undefined) {
         setPreviewVar(

--- a/components/editor/present-presets-section/cards.tsx
+++ b/components/editor/present-presets-section/cards.tsx
@@ -318,7 +318,6 @@ function CustomPresetList({
             preset={preset}
             canvas={canvas}
             aspect={aspect}
-            horizontal={horizontal}
             active={activeCustomPresetId === preset.id}
             onApply={onApply}
             onDelete={onDelete}
@@ -363,7 +362,6 @@ const CustomPresetCard = React.memo(function CustomPresetCard({
   preset,
   canvas,
   aspect,
-  horizontal = false,
   active,
   onApply,
   onDelete,
@@ -372,7 +370,6 @@ const CustomPresetCard = React.memo(function CustomPresetCard({
   preset: CustomPresetSummary
   canvas: CanvasState
   aspect: AspectState
-  horizontal?: boolean
   active: boolean
   onApply: (preset: CustomPresetSummary) => void
   onDelete: (id: string) => void | Promise<void>

--- a/components/editor/top-bar/open-project-dialog.tsx
+++ b/components/editor/top-bar/open-project-dialog.tsx
@@ -258,11 +258,6 @@ function ProjectTypeRail({
       <p className="hidden px-1 text-[11px] font-medium tracking-wide text-muted-foreground uppercase sm:block">
         Project type
       </p>
-      {searching ? (
-        <p className="-mt-1.5 px-1 text-[10px] leading-snug text-muted-foreground">
-          Searching — narrow with the filter in the search box.
-        </p>
-      ) : null}
       <div
         className={cn(
           "flex flex-row gap-1.5 overflow-x-auto transition-opacity sm:flex-col sm:overflow-visible",
@@ -1003,13 +998,13 @@ export function OpenProjectDialog({
                     setPage(1)
                   }}
                 >
-                  <SelectTrigger className="w-[104px] shrink-0 rounded-md border border-border/70 bg-background px-2.5 text-[11px] font-medium text-foreground shadow-none transition-colors hover:border-primary/50 hover:bg-secondary/20 focus-visible:border-border/70 focus-visible:ring-0">
+                  <SelectTrigger className="w-auto shrink-0 gap-1.5 rounded-md border border-border/70 bg-background px-2 text-[11px] font-medium text-foreground shadow-none transition-colors hover:border-primary/50 hover:bg-secondary/20 focus-visible:border-border/70 focus-visible:ring-0">
                     <SelectValue placeholder="Latest" />
                   </SelectTrigger>
                   <SelectContent
                     align="end"
                     position="popper"
-                    className="min-w-[104px] rounded-md border border-border/70 bg-popover p-1 shadow-2xl"
+                    className="min-w-[var(--radix-select-trigger-width)] rounded-md border border-border/70 bg-popover p-1 shadow-2xl"
                   >
                     <SelectItem value="latest">Latest</SelectItem>
                     <SelectItem value="oldest">Oldest</SelectItem>

--- a/components/editor/top-bar/open-project-dialog.tsx
+++ b/components/editor/top-bar/open-project-dialog.tsx
@@ -11,8 +11,11 @@ import {
   RiLayoutGridLine,
   RiLoader4Line,
   RiMore2Fill,
+  RiCloseLine,
   RiPencilLine,
+  RiSearchLine,
 } from "@remixicon/react"
+import debounce from "lodash/debounce"
 import { toast } from "sonner"
 
 import {
@@ -27,6 +30,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -72,8 +76,30 @@ export type DraftListItem = {
 
 type SortOrder = "latest" | "oldest"
 type ProjectKind = "style" | "video" | "animate"
+/** Which kinds a name search narrows to. "all" spans every project type. */
+type SearchScope = ProjectKind | "all"
 
 const PAGE_SIZE = 9
+/** Long enough to skip most intermediate keystrokes, short enough to feel live. */
+const SEARCH_DEBOUNCE_MS = 300
+/**
+ * Fuzzy matching needs a real prefix — the server ignores 1-character matches,
+ * so searching on one would render an empty state instead of the full list.
+ */
+const MIN_SEARCH_LENGTH = 2
+
+/**
+ * Search scopes, in rail order. The `style` kind is surfaced as "Screenshots"
+ * everywhere in this dialog — its old "Present" label collided with the app's
+ * preset system (`present-presets.ts`) and read as "presets" rather than "static
+ * screenshot project". The stored type is still `style`.
+ */
+const SEARCH_SCOPES: { value: SearchScope; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "style", label: "Screenshots" },
+  { value: "video", label: "Videos" },
+  { value: "animate", label: "Animate" },
+]
 
 /** Fixed shell size so Present/Animate switch never shifts layout. */
 const DIALOG_SHELL =
@@ -219,22 +245,36 @@ function ProjectTypeRail({
   kind,
   onKindChange,
   onCreateNew,
+  searching = false,
 }: {
   kind: ProjectKind
   onKindChange: (next: ProjectKind) => void
   onCreateNew: () => void
+  /** A search is active, so the in-field scope owns the filter, not this rail. */
+  searching?: boolean
 }) {
   return (
-    <aside className="flex w-[188px] shrink-0 flex-col gap-3 border-r border-border/60 bg-secondary/10 p-3 sm:w-[210px]">
-      <p className="px-1 text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
+    <aside className="flex shrink-0 flex-col gap-2 border-b border-border/60 bg-secondary/10 p-3 sm:w-[188px] sm:gap-3 sm:border-r sm:border-b-0 md:w-[210px]">
+      <p className="hidden px-1 text-[11px] font-medium tracking-wide text-muted-foreground uppercase sm:block">
         Project type
       </p>
-      <div className="flex flex-col gap-1.5">
+      {searching ? (
+        <p className="-mt-1.5 px-1 text-[10px] leading-snug text-muted-foreground">
+          Searching — narrow with the filter in the search box.
+        </p>
+      ) : null}
+      <div
+        className={cn(
+          "flex flex-row gap-1.5 overflow-x-auto transition-opacity sm:flex-col sm:overflow-visible",
+          searching && "pointer-events-none opacity-40"
+        )}
+        aria-hidden={searching}
+      >
         <button
           type="button"
           onClick={() => onKindChange("style")}
           className={cn(
-            "flex items-center gap-2.5 rounded-md border px-2.5 py-2.5 text-left transition-colors",
+            "flex shrink-0 items-center gap-2 rounded-md border px-2.5 py-2 text-left transition-colors sm:w-full sm:gap-2.5 sm:py-2.5",
             kind === "style"
               ? "border-primary/50 bg-primary/10 text-foreground"
               : "border-border/50 bg-background/40 text-muted-foreground hover:border-border hover:bg-secondary/30 hover:text-foreground"
@@ -242,9 +282,9 @@ function ProjectTypeRail({
         >
           <RiLayoutGridLine className="size-4 shrink-0" />
           <span className="min-w-0">
-            <span className="block text-[12px] font-medium">Present</span>
-            <span className="mt-0.5 block text-[10px] leading-snug opacity-80">
-              Static screenshot projects
+            <span className="block text-[12px] font-medium">Screenshots</span>
+            <span className="mt-0.5 hidden text-[10px] leading-snug opacity-80 sm:block">
+              Static image projects
             </span>
           </span>
         </button>
@@ -252,7 +292,7 @@ function ProjectTypeRail({
           type="button"
           onClick={() => onKindChange("video")}
           className={cn(
-            "flex items-center gap-2.5 rounded-md border px-2.5 py-2.5 text-left transition-colors",
+            "flex shrink-0 items-center gap-2 rounded-md border px-2.5 py-2 text-left transition-colors sm:w-full sm:gap-2.5 sm:py-2.5",
             kind === "video"
               ? "border-primary/50 bg-primary/10 text-foreground"
               : "border-border/50 bg-background/40 text-muted-foreground hover:border-border hover:bg-secondary/30 hover:text-foreground"
@@ -261,7 +301,7 @@ function ProjectTypeRail({
           <RiFilmLine className="size-4 shrink-0" />
           <span className="min-w-0">
             <span className="block text-[12px] font-medium">Videos</span>
-            <span className="mt-0.5 block text-[10px] leading-snug opacity-80">
+            <span className="mt-0.5 hidden text-[10px] leading-snug opacity-80 sm:block">
               Projects without a timeline
             </span>
           </span>
@@ -270,7 +310,7 @@ function ProjectTypeRail({
           type="button"
           onClick={() => onKindChange("animate")}
           className={cn(
-            "flex items-center gap-2.5 rounded-md border px-2.5 py-2.5 text-left transition-colors",
+            "flex shrink-0 items-center gap-2 rounded-md border px-2.5 py-2 text-left transition-colors sm:w-full sm:gap-2.5 sm:py-2.5",
             kind === "animate"
               ? "border-primary/50 bg-primary/10 text-foreground"
               : "border-border/50 bg-background/40 text-muted-foreground hover:border-border hover:bg-secondary/30 hover:text-foreground"
@@ -279,14 +319,14 @@ function ProjectTypeRail({
           <RiFilmLine className="size-4 shrink-0" />
           <span className="min-w-0">
             <span className="block text-[12px] font-medium">Animate</span>
-            <span className="mt-0.5 block text-[10px] leading-snug opacity-80">
+            <span className="mt-0.5 hidden text-[10px] leading-snug opacity-80 sm:block">
               Projects with a timeline
             </span>
           </span>
         </button>
       </div>
 
-      <div className="mt-auto border-t border-border/50 pt-3">
+      <div className="border-t border-border/50 pt-3 sm:mt-auto">
         <Button
           type="button"
           className="h-9 w-full gap-1.5 border border-green-600/25 bg-green-600/15 text-[12px] text-green-700 hover:bg-green-600/25 hover:text-green-800 dark:border-green-500/30 dark:bg-green-600/20 dark:text-green-400 dark:hover:bg-green-600/30 dark:hover:text-green-300"
@@ -306,7 +346,7 @@ const SKELETON_KEYS = [0, 1, 2, 3, 4, 5, 6, 7, 8] as const
 function DraftGridSkeleton() {
   return (
     <div
-      className="grid grid-cols-2 gap-3 sm:grid-cols-3"
+      className="grid grid-cols-1 gap-3 min-[420px]:grid-cols-2 xl:grid-cols-3"
       aria-busy="true"
       aria-label="Loading projects"
     >
@@ -322,12 +362,14 @@ function DraftGridSkeleton() {
 }
 
 function ProjectPagination({
+  searching = false,
   page,
   totalPages,
   total,
   loading,
   onPageChange,
 }: {
+  searching?: boolean
   page: number
   totalPages: number
   total: number
@@ -346,9 +388,10 @@ function ProjectPagination({
   const canNext = page < totalPages
 
   return (
-    <div className="flex h-12 shrink-0 items-center justify-between gap-3 border-t border-border/60 px-3 sm:px-4">
+    <div className="flex min-h-12 shrink-0 flex-wrap items-center justify-between gap-x-3 gap-y-1 border-t border-border/60 px-3 py-1.5 sm:flex-nowrap sm:px-4 sm:py-0">
       <p className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
-        {total} project{total === 1 ? "" : "s"}
+        {total} {searching ? "result" : "project"}
+        {total === 1 ? "" : "s"}
       </p>
 
       <Pagination className="mx-0 w-auto justify-end">
@@ -498,7 +541,7 @@ export function OpenProjectDialog({
   currentDraftId: string | null
   /** When true, Create new project asks before discarding the editor. */
   hasUnsavedWork?: boolean
-  /** Prefer Present or Animate tab when the dialog opens. Defaults to Present. */
+  /** Preferred tab when the dialog opens. Defaults to Screenshots. */
   defaultKind?: ProjectKind
   onOpenDraft: (id: string) => void | Promise<void>
   onCreateNew: () => void
@@ -517,11 +560,54 @@ export function OpenProjectDialog({
   const [kind, setKind] = React.useState<ProjectKind>("style")
   const [page, setPage] = React.useState(1)
   const [total, setTotal] = React.useState(0)
+  /** What the user is typing (drives the input). */
+  const [query, setQuery] = React.useState("")
+  /** The debounced value the request actually uses. */
+  const [debouncedQuery, setDebouncedQuery] = React.useState("")
+  const [searchScope, setSearchScope] = React.useState<SearchScope>("all")
   /** True while a network request is in flight. */
   const [loading, setLoading] = React.useState(false)
   const wasOpenRef = React.useRef(false)
   const fetchGenRef = React.useRef(0)
   const renameOpsRef = React.useRef<Map<string, number>>(new Map())
+
+  const searching = debouncedQuery.length > 0
+  // A search spans project kinds — the scope dropdown decides which, NOT the
+  // left rail. Without a query the rail's kind drives the list as before.
+  const effectiveKind: ProjectKind | null = searching
+    ? searchScope === "all"
+      ? null
+      : searchScope
+    : kind
+
+  // One debounced setter for the whole dialog lifetime, cancelled on unmount so
+  // a pending keystroke can't set state after the dialog closes.
+  const pushQuery = React.useMemo(
+    () =>
+      debounce((value: string) => setDebouncedQuery(value), SEARCH_DEBOUNCE_MS),
+    []
+  )
+  React.useEffect(() => () => pushQuery.cancel(), [pushQuery])
+
+  const handleQueryChange = (value: string) => {
+    setQuery(value)
+    setPage(1)
+    // Clearing (or dropping under the minimum) is instant — waiting to see the
+    // whole list again feels broken.
+    if (value.trim().length < MIN_SEARCH_LENGTH) {
+      pushQuery.cancel()
+      setDebouncedQuery("")
+      return
+    }
+    pushQuery(value)
+  }
+
+  const clearQuery = () => {
+    pushQuery.cancel()
+    setQuery("")
+    setDebouncedQuery("")
+    setPage(1)
+  }
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
   // Full skeleton only when we have nothing to show yet (open / type switch).
@@ -535,6 +621,9 @@ export function OpenProjectDialog({
       setKind(defaultKind)
       setPage(1)
       setSort("latest")
+      setQuery("")
+      setDebouncedQuery("")
+      setSearchScope("all")
       setDrafts(null)
       setTotal(0)
       setError(null)
@@ -542,12 +631,15 @@ export function OpenProjectDialog({
     }
     if (!open) {
       // Drop list on close so the next open always starts with a clean skeleton.
+      pushQuery.cancel()
+      setQuery("")
+      setDebouncedQuery("")
       setDrafts(null)
       setError(null)
       setLoading(false)
     }
     wasOpenRef.current = open
-  }, [open, defaultKind])
+  }, [open, defaultKind, pushQuery])
   /* eslint-enable react-hooks/set-state-in-effect */
 
   /* eslint-disable react-hooks/set-state-in-effect -- fetch drafts when dialog query changes */
@@ -560,10 +652,19 @@ export function OpenProjectDialog({
     setError(null)
 
     const offset = (page - 1) * PAGE_SIZE
-    void fetch(
-      `/api/drafts?limit=${PAGE_SIZE}&offset=${offset}&sort=${sort}&type=${kind}`,
-      { credentials: "include", signal: ac.signal }
-    )
+    const params = new URLSearchParams({
+      limit: String(PAGE_SIZE),
+      offset: String(offset),
+      sort,
+    })
+    // Omit `type` entirely when searching every kind — the API treats a missing
+    // type as "all", and sending an empty one would 400.
+    if (effectiveKind) params.set("type", effectiveKind)
+    if (debouncedQuery) params.set("q", debouncedQuery)
+    void fetch(`/api/drafts?${params.toString()}`, {
+      credentials: "include",
+      signal: ac.signal,
+    })
       .then(async (res) => {
         if (!res.ok) {
           const data = (await res.json().catch(() => null)) as {
@@ -596,7 +697,7 @@ export function OpenProjectDialog({
     return () => {
       ac.abort()
     }
-  }, [open, sort, kind, page])
+  }, [open, sort, effectiveKind, debouncedQuery, page])
   /* eslint-enable react-hooks/set-state-in-effect */
 
   // Keep page in range when totals shrink (delete / filter change).
@@ -812,50 +913,126 @@ export function OpenProjectDialog({
       </AlertDialog>
 
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className={DIALOG_SHELL}>
-          <div className="shrink-0 border-b border-border/60 bg-popover px-5 py-4">
-            <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-              <div>
+        <DialogContent className={DIALOG_SHELL} showCloseButton={false}>
+          <DialogClose asChild>
+            <button
+              type="button"
+              aria-label="Close"
+              className="absolute top-3.5 right-4 z-10 inline-flex size-7 items-center justify-center rounded-md border border-border/60 bg-secondary/60 text-muted-foreground transition-colors hover:border-border hover:bg-secondary hover:text-foreground focus-visible:ring-1 focus-visible:ring-primary/50 focus-visible:outline-none"
+            >
+              <RiCloseLine className="size-4" />
+            </button>
+          </DialogClose>
+          <div className="shrink-0 border-b border-border/60 bg-popover px-4 py-3.5 sm:px-5 sm:py-4">
+            <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+              <div className="pr-9 sm:pr-0">
                 <DialogTitle className="text-[15px]">Open project</DialogTitle>
                 <DialogDescription className="mt-0.5 text-[12px]">
                   Pick a saved draft to resume editing, or start fresh.
                 </DialogDescription>
               </div>
-              <Select
-                value={sort}
-                onValueChange={(val) => {
-                  setSort(val as SortOrder)
-                  setPage(1)
-                }}
-              >
-                <SelectTrigger className="h-8 w-full self-stretch rounded-md border border-border/70 bg-background px-2.5 text-[11px] font-medium text-foreground shadow-none transition-colors hover:border-primary/50 hover:bg-secondary/20 focus-visible:border-border/70 focus-visible:ring-0 sm:mr-6 sm:w-[110px] sm:self-auto">
-                  <SelectValue placeholder="Latest" />
-                </SelectTrigger>
-                <SelectContent
-                  align="end"
-                  position="popper"
-                  className="min-w-[110px] rounded-md border border-border/70 bg-popover p-1 shadow-2xl"
+              <div className="flex w-full items-center gap-2 sm:mr-14 sm:w-auto">
+                <div className="flex h-7 min-w-0 flex-1 items-center rounded-md border border-border/70 bg-background transition-colors focus-within:border-primary/50 hover:border-primary/50 sm:w-[290px] sm:flex-none">
+                  <RiSearchLine className="pointer-events-none ml-2.5 size-3.5 shrink-0 text-muted-foreground" />
+                  <input
+                    type="search"
+                    value={query}
+                    onChange={(e) => handleQueryChange(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Escape" && query) {
+                        // Clear the field before the dialog's own Esc closes it.
+                        e.stopPropagation()
+                        clearQuery()
+                      }
+                    }}
+                    placeholder="Search projects"
+                    aria-label="Search projects by name"
+                    maxLength={DRAFT_NAME_MAX_LENGTH}
+                    className="h-full min-w-0 flex-1 bg-transparent px-2 text-[11px] font-medium text-foreground outline-none placeholder:text-muted-foreground [&::-webkit-search-cancel-button]:appearance-none"
+                  />
+                  {query ? (
+                    <button
+                      type="button"
+                      onClick={clearQuery}
+                      aria-label="Clear search"
+                      className="mr-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:ring-1 focus-visible:ring-primary/50 focus-visible:outline-none"
+                    >
+                      <RiCloseLine className="size-3.5" />
+                    </button>
+                  ) : null}
+
+                  {/* Scope lives inside the field and is always mounted: it
+                      describes what a search WILL cover, so hiding it until
+                      results exist would surface it only once it's too late to
+                      be useful. */}
+                  <Select
+                    value={searchScope}
+                    onValueChange={(val) => {
+                      setSearchScope(val as SearchScope)
+                      setPage(1)
+                    }}
+                  >
+                    {/* The base trigger paints its own surface (`bg-input/20`
+                        plus a `dark:bg-input/30` that survives tailwind-merge),
+                        which reads as a nested box inside the search field.
+                        Both themes are zeroed so this is plain inline text. */}
+                    <SelectTrigger
+                      aria-label="Limit search to a project type"
+                      className="h-6 w-auto shrink-0 gap-1 rounded-none border-0 bg-transparent px-2 text-[11px] font-medium text-muted-foreground shadow-none transition-colors hover:bg-transparent hover:text-foreground focus-visible:ring-0 dark:bg-transparent dark:hover:bg-transparent [&>svg]:size-3"
+                    >
+                      <SelectValue placeholder="All" />
+                    </SelectTrigger>
+                    <SelectContent
+                      align="end"
+                      position="popper"
+                      className="min-w-[104px] rounded-md border border-border/70 bg-popover p-1 shadow-2xl"
+                    >
+                      {SEARCH_SCOPES.map((scope) => (
+                        <SelectItem key={scope.value} value={scope.value}>
+                          {scope.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Select
+                  value={sort}
+                  onValueChange={(val) => {
+                    setSort(val as SortOrder)
+                    setPage(1)
+                  }}
                 >
-                  <SelectItem value="latest">Latest</SelectItem>
-                  <SelectItem value="oldest">Oldest</SelectItem>
-                </SelectContent>
-              </Select>
+                  <SelectTrigger className="w-[104px] shrink-0 rounded-md border border-border/70 bg-background px-2.5 text-[11px] font-medium text-foreground shadow-none transition-colors hover:border-primary/50 hover:bg-secondary/20 focus-visible:border-border/70 focus-visible:ring-0">
+                    <SelectValue placeholder="Latest" />
+                  </SelectTrigger>
+                  <SelectContent
+                    align="end"
+                    position="popper"
+                    className="min-w-[104px] rounded-md border border-border/70 bg-popover p-1 shadow-2xl"
+                  >
+                    <SelectItem value="latest">Latest</SelectItem>
+                    <SelectItem value="oldest">Oldest</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
           </div>
 
-          <div className="flex min-h-0 flex-1">
+          <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
             {/* Left rail — project type */}
             <ProjectTypeRail
               kind={kind}
               onKindChange={handleKindChange}
               onCreateNew={requestCreateNew}
+              searching={searching}
             />
 
             {/* Main list + pagination */}
             <div className="flex min-h-0 min-w-0 flex-1 flex-col">
               <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4">
                 {/* Fixed min height so Present/Animate never shifts the shell. */}
-                <div className="min-h-[480px]">
+                <div className="sm:min-h-[480px]">
                   {showSkeleton ? <DraftGridSkeleton /> : null}
 
                   {!showSkeleton && error ? (
@@ -865,37 +1042,61 @@ export function OpenProjectDialog({
                   ) : null}
 
                   {!showSkeleton && !error && drafts && drafts.length === 0 ? (
-                    <div className="flex min-h-[440px] flex-col items-center justify-center gap-2 px-4 py-8 text-center">
+                    <div className="flex min-h-[280px] flex-col items-center justify-center gap-2 px-4 py-8 text-center sm:min-h-[440px]">
                       <span className="inline-flex size-10 items-center justify-center rounded-full bg-secondary/80 text-muted-foreground">
-                        {kind === "animate" ? (
-                          <RiFilmLine className="size-5" />
-                        ) : kind === "video" ? (
+                        {searching ? (
+                          <RiSearchLine className="size-5" />
+                        ) : kind === "animate" || kind === "video" ? (
                           <RiFilmLine className="size-5" />
                         ) : (
                           <RiDraftLine className="size-5" />
                         )}
                       </span>
+                      {/* An empty search is a different problem from an empty
+                          project type — don't tell the user to go save a draft. */}
                       <p className="text-[13px] font-medium text-foreground">
-                        {kind === "animate"
-                          ? "No animate projects yet"
-                          : kind === "video"
-                            ? "No video projects yet"
-                            : "No present projects yet"}
+                        {searching
+                          ? "No projects found"
+                          : kind === "animate"
+                            ? "No animate projects yet"
+                            : kind === "video"
+                              ? "No video projects yet"
+                              : "No screenshot projects yet"}
                       </p>
                       <p className="max-w-[280px] text-[12px] text-muted-foreground">
-                        {kind === "animate"
-                          ? "Save while Animate is on (Save → Save as animate draft) to see projects here."
-                          : kind === "video"
-                            ? "Save a video canvas with Save → Save as draft to see projects here."
-                            : "Use Save → Save as draft from the present editor to keep projects here."}
+                        {searching ? (
+                          <>
+                            Nothing matches &ldquo;{debouncedQuery}&rdquo;
+                            {searchScope === "all"
+                              ? ""
+                              : ` in ${SEARCH_SCOPES.find((s) => s.value === searchScope)?.label.toLowerCase()} projects`}
+                            .
+                          </>
+                        ) : kind === "animate" ? (
+                          "Save while Animate is on (Save → Save as animate draft) to see projects here."
+                        ) : kind === "video" ? (
+                          "Save a video canvas with Save → Save as draft to see projects here."
+                        ) : (
+                          "Use Save → Save as draft from the editor to keep projects here."
+                        )}
                       </p>
+                      {searching ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="mt-1 h-7 text-[11px]"
+                          onClick={clearQuery}
+                        >
+                          Clear search
+                        </Button>
+                      ) : null}
                     </div>
                   ) : null}
 
                   {!showSkeleton && !error && drafts && drafts.length > 0 ? (
                     <div
                       className={cn(
-                        "grid grid-cols-2 gap-3 sm:grid-cols-3",
+                        "grid grid-cols-1 gap-3 min-[420px]:grid-cols-2 xl:grid-cols-3",
                         loading && "pointer-events-none opacity-70"
                       )}
                     >
@@ -920,6 +1121,7 @@ export function OpenProjectDialog({
                 page={page}
                 totalPages={totalPages}
                 total={total}
+                searching={searching}
                 loading={loading}
                 onPageChange={handlePageChange}
               />

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,23 +1,23 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import jsxA11y from "eslint-plugin-jsx-a11y";
-import reactHooks from "eslint-plugin-react-hooks";
-import tailwind from "eslint-plugin-tailwindcss";
-import nextVitals from "eslint-config-next/core-web-vitals";
-import nextTs from "eslint-config-next/typescript";
-import tseslint from "typescript-eslint";
+import { defineConfig, globalIgnores } from "eslint/config"
+import jsxA11y from "eslint-plugin-jsx-a11y"
+import reactHooks from "eslint-plugin-react-hooks"
+import tailwind from "eslint-plugin-tailwindcss"
+import nextVitals from "eslint-config-next/core-web-vitals"
+import nextTs from "eslint-config-next/typescript"
+import tseslint from "typescript-eslint"
 
-const typedFiles = ["**/*.{ts,tsx}"];
+const typedFiles = ["**/*.{ts,tsx}"]
 
 const typedConfigs = tseslint.configs.recommendedTypeChecked.map((config) => ({
   ...config,
   files: config.files ?? typedFiles,
-}));
+}))
 
-const reactHooksRecommended = { ...reactHooks.configs.flat.recommended };
-delete reactHooksRecommended.plugins;
+const reactHooksRecommended = { ...reactHooks.configs.flat.recommended }
+delete reactHooksRecommended.plugins
 
-const jsxA11yRecommended = { ...jsxA11y.flatConfigs.recommended };
-delete jsxA11yRecommended.plugins;
+const jsxA11yRecommended = { ...jsxA11y.flatConfigs.recommended }
+delete jsxA11yRecommended.plugins
 
 const tailwindRecommended = {
   ...tailwind.configs.recommended,
@@ -27,7 +27,7 @@ const tailwindRecommended = {
       cssConfigPath: `${import.meta.dirname}/app/globals.css`,
     },
   },
-};
+}
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -65,7 +65,16 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/no-unsafe-call": "warn",
       "@typescript-eslint/no-unsafe-member-access": "warn",
       "@typescript-eslint/no-unsafe-return": "warn",
-      "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          args: "all",
+          argsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
       "@typescript-eslint/prefer-promise-reject-errors": "warn",
       "@typescript-eslint/require-await": "warn",
     },
@@ -79,6 +88,14 @@ const eslintConfig = defineConfig([
     files: ["**/*.tsx"],
   },
   tailwindRecommended,
+  {
+    // Mocks stand in for async signatures, so `vi.fn(async () => x)` is the
+    // point rather than a missing await.
+    files: ["tests/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/require-await": "off",
+    },
+  },
   {
     files: typedFiles,
     rules: {
@@ -119,7 +136,9 @@ const eslintConfig = defineConfig([
     ".open-next/**",
     // Custom Cloudflare Worker entry (compiled by Wrangler, excluded from tsconfig):
     "worker.ts",
+    // Vendored dav1d AV1 decoder: minified Emscripten output, not ours to lint.
+    "lib/editor/animation-export/video-media/dav1d-wasm/decoder.mjs",
   ]),
-]);
+])
 
-export default eslintConfig;
+export default eslintConfig

--- a/lib/draft-db.ts
+++ b/lib/draft-db.ts
@@ -1,6 +1,7 @@
 import "server-only"
 
 import { and, asc, count, desc, eq, sql } from "drizzle-orm"
+import Fuse from "fuse.js"
 
 import { drafts, type DraftType } from "@/lib/db/schema"
 import { fromD1Date, getDb, toD1Date } from "@/lib/d1"
@@ -77,6 +78,74 @@ function rowToDraftMetadata(row: DraftRow): DraftRecord {
   return rowToDraft(row, null)
 }
 
+/** Shared owner + kind filter for the list and its count. */
+function draftListFilter(userId: string, opts: { type?: DraftType }) {
+  if (opts.type === "animate" || opts.type === "video" || opts.type === "style")
+    return and(eq(drafts.userId, userId), eq(drafts.type, opts.type))
+  return eq(drafts.userId, userId)
+}
+
+/**
+ * Most recent drafts a fuzzy search will rank. D1 has no trigram index or
+ * edit-distance function, so typo tolerance has to happen in JS over a candidate
+ * set — this bounds that scan. Metadata rows are small (no state blob), so a few
+ * hundred is cheap; beyond this the oldest drafts drop out of search rather than
+ * the request getting slow.
+ */
+const SEARCH_CANDIDATE_LIMIT = 500
+
+/**
+ * How far a name may stray from the query. Fuse scores 0 (exact) → 1 (no
+ * relation); 0.4 catches ordinary typos and partial words without matching
+ * everything. `ignoreLocation` matters: without it Fuse heavily favours matches
+ * near the start, so searching a word from the END of a name would miss.
+ */
+const FUZZY_THRESHOLD = 0.4
+
+/**
+ * Fuzzy name search, ranked best-match-first, then paginated.
+ *
+ * Ranking happens over the whole candidate set BEFORE slicing, so page 2 is the
+ * genuine next-best matches rather than a second, separately-ranked query.
+ * Returns the match count alongside the page so the caller's pagination and its
+ * total always come from one ranking.
+ */
+export async function searchDrafts(
+  userId: string,
+  opts: {
+    q: string
+    limit?: number
+    offset?: number
+    sort?: "latest" | "oldest"
+    type?: DraftType
+  }
+) {
+  const { q, limit = 12, offset = 0, sort = "latest", type } = opts
+  const order =
+    sort === "oldest" ? asc(drafts.updatedAt) : desc(drafts.updatedAt)
+
+  const candidates = await getDb()
+    .select()
+    .from(drafts)
+    .where(draftListFilter(userId, { type }))
+    .orderBy(order)
+    .limit(SEARCH_CANDIDATE_LIMIT)
+
+  const fuse = new Fuse(candidates, {
+    keys: ["name"],
+    threshold: FUZZY_THRESHOLD,
+    ignoreLocation: true,
+    // One-character queries match nearly everything; wait for a real prefix.
+    minMatchCharLength: 2,
+  })
+  const ranked = fuse.search(q).map((hit) => hit.item)
+
+  return {
+    rows: ranked.slice(offset, offset + limit).map(rowToDraftMetadata),
+    total: ranked.length,
+  }
+}
+
 export async function listDrafts(
   userId: string,
   opts: {
@@ -86,19 +155,14 @@ export async function listDrafts(
     type?: DraftType
   } = {}
 ) {
-  const { limit = 12, offset = 0, sort = "latest", type } = opts
+  const { limit = 12, offset = 0, sort = "latest" } = opts
   const order =
     sort === "oldest" ? asc(drafts.updatedAt) : desc(drafts.updatedAt)
-
-  const where =
-    type === "animate" || type === "video" || type === "style"
-      ? and(eq(drafts.userId, userId), eq(drafts.type, type))
-      : eq(drafts.userId, userId)
 
   const rows = await getDb()
     .select()
     .from(drafts)
-    .where(where)
+    .where(draftListFilter(userId, opts))
     .orderBy(order)
     .limit(limit)
     .offset(offset)
@@ -123,15 +187,10 @@ export async function countDrafts(
   userId: string,
   opts: { type?: DraftType } = {}
 ) {
-  const where =
-    opts.type === "animate" || opts.type === "video" || opts.type === "style"
-      ? and(eq(drafts.userId, userId), eq(drafts.type, opts.type))
-      : eq(drafts.userId, userId)
-
   const result = await getDb()
     .select({ count: count() })
     .from(drafts)
-    .where(where)
+    .where(draftListFilter(userId, opts))
     .get()
   return result?.count ?? 0
 }

--- a/lib/draft-db.ts
+++ b/lib/draft-db.ts
@@ -1,6 +1,6 @@
 import "server-only"
 
-import { and, asc, count, desc, eq, sql } from "drizzle-orm"
+import { and, asc, count, desc, eq, inArray, sql } from "drizzle-orm"
 import Fuse from "fuse.js"
 
 import { drafts, type DraftType } from "@/lib/db/schema"
@@ -86,13 +86,23 @@ function draftListFilter(userId: string, opts: { type?: DraftType }) {
 }
 
 /**
- * Most recent drafts a fuzzy search will rank. D1 has no trigram index or
- * edit-distance function, so typo tolerance has to happen in JS over a candidate
- * set — this bounds that scan. Metadata rows are small (no state blob), so a few
- * hundred is cheap; beyond this the oldest drafts drop out of search rather than
- * the request getting slow.
+ * Order two matched drafts for display. Tie-broken by id to keep paging stable
+ * ACROSS requests: drafts saved in the same second share an `updatedAt`, and
+ * each page is its own request re-running this sort over rows D1 returns in no
+ * guaranteed order. Without the tiebreak, tied drafts could land either side of
+ * a page boundary on different requests and be shown twice or skipped.
  */
-const SEARCH_CANDIDATE_LIMIT = 500
+function compareByUpdated(
+  a: { id: string; updatedAt: string },
+  b: { id: string; updatedAt: string },
+  sort: "latest" | "oldest"
+) {
+  const byDate =
+    sort === "oldest"
+      ? a.updatedAt.localeCompare(b.updatedAt)
+      : b.updatedAt.localeCompare(a.updatedAt)
+  return byDate !== 0 ? byDate : a.id.localeCompare(b.id)
+}
 
 /**
  * How far a name may stray from the query. Fuse scores 0 (exact) → 1 (no
@@ -103,12 +113,21 @@ const SEARCH_CANDIDATE_LIMIT = 500
 const FUZZY_THRESHOLD = 0.4
 
 /**
- * Fuzzy name search, ranked best-match-first, then paginated.
+ * Fuzzy name search across EVERY draft the filter allows: relevance decides
+ * which drafts match, `sort` decides the order, then the page is sliced.
  *
- * Ranking happens over the whole candidate set BEFORE slicing, so page 2 is the
- * genuine next-best matches rather than a second, separately-ranked query.
+ * Two passes, because D1 has no trigram index or edit-distance function — typo
+ * tolerance has to happen in JS, over rows this has already read. Reading whole
+ * rows to do that would put the library size in the response budget, so the
+ * match pass projects just the three columns matching and ordering need
+ * (`name`, `updatedAt`, `id` — no state blob, no thumbnail key) and the second
+ * pass hydrates only the page, by id. That keeps the scan cheap enough that no
+ * candidate cap is needed, so an old draft is as findable as a recent one.
+ *
+ * Matching and ordering both happen over the whole match set BEFORE slicing, so
+ * page 2 is the genuine continuation rather than a separately-ranked query.
  * Returns the match count alongside the page so the caller's pagination and its
- * total always come from one ranking.
+ * total always come from one pass.
  */
 export async function searchDrafts(
   userId: string,
@@ -121,15 +140,16 @@ export async function searchDrafts(
   }
 ) {
   const { q, limit = 12, offset = 0, sort = "latest", type } = opts
-  const order =
-    sort === "oldest" ? asc(drafts.updatedAt) : desc(drafts.updatedAt)
+  const scope = draftListFilter(userId, { type })
 
   const candidates = await getDb()
-    .select()
+    .select({
+      id: drafts.id,
+      name: drafts.name,
+      updatedAt: drafts.updatedAt,
+    })
     .from(drafts)
-    .where(draftListFilter(userId, { type }))
-    .orderBy(order)
-    .limit(SEARCH_CANDIDATE_LIMIT)
+    .where(scope)
 
   const fuse = new Fuse(candidates, {
     keys: ["name"],
@@ -138,12 +158,32 @@ export async function searchDrafts(
     // One-character queries match nearly everything; wait for a real prefix.
     minMatchCharLength: 2,
   })
-  const ranked = fuse.search(q).map((hit) => hit.item)
+  // updatedAt is an ISO-8601 UTC string, so lexicographic order is
+  // chronological — the same ordering the SQL list path applies.
+  const matches = fuse.search(q).map((hit) => hit.item)
+  matches.sort((a, b) => compareByUpdated(a, b, sort))
 
-  return {
-    rows: ranked.slice(offset, offset + limit).map(rowToDraftMetadata),
-    total: ranked.length,
-  }
+  const pageIds = matches.slice(offset, offset + limit).map((m) => m.id)
+  if (pageIds.length === 0) return { rows: [], total: matches.length }
+
+  // Re-filtered by owner, not just id: the ids came from an owned query, but a
+  // bare id lookup would be one refactor away from reading another user's row.
+  const rows = await getDb()
+    .select()
+    .from(drafts)
+    .where(and(scope, inArray(drafts.id, pageIds)))
+
+  // Order was decided once, above. `IN (...)` returns rows in no particular
+  // order, so replay that sequence rather than sorting a second time — a second
+  // sort would have to stay byte-identical to the first forever, and drifting
+  // apart would silently page wrongly instead of failing. Drops any id deleted
+  // between the two queries.
+  const byId = new Map(rows.map((row) => [row.id, row]))
+  const ordered = pageIds
+    .map((id) => byId.get(id))
+    .filter((row) => row !== undefined)
+
+  return { rows: ordered.map(rowToDraftMetadata), total: matches.length }
 }
 
 export async function listDrafts(

--- a/lib/editor/animation-export/index.ts
+++ b/lib/editor/animation-export/index.ts
@@ -30,7 +30,6 @@ import {
   type CaptureCtx,
 } from "./types"
 import {
-  AnimationExportAbortedError,
   animationMimeAndExt,
   createProgressReporter,
   resolveAnimationDownloadFilename,

--- a/lib/editor/animation-export/video-layer.ts
+++ b/lib/editor/animation-export/video-layer.ts
@@ -122,6 +122,15 @@ function replaceVideoWithFrameImage(video: HTMLVideoElement): {
     image.setAttribute(attribute.name, attribute.value)
   }
 
+  // Seed the source's natural size. An `<img>` only reports `naturalWidth` once
+  // a source has decoded, so anything measuring natural media size (the crop's
+  // fit correction) would read 0 on the first frame — before the first paint —
+  // and silently skip. The video is already ready when we swap it out.
+  if (video.videoWidth > 0 && video.videoHeight > 0) {
+    image.dataset.naturalW = String(video.videoWidth)
+    image.dataset.naturalH = String(video.videoHeight)
+  }
+
   const raster = document.createElement("canvas")
   const context = raster.getContext("2d", { willReadFrequently: true })
   if (!context) return null

--- a/lib/editor/animation-export/video-media/dav1d-av1-decoder.ts
+++ b/lib/editor/animation-export/video-media/dav1d-av1-decoder.ts
@@ -194,7 +194,7 @@ class Dav1dAv1Decoder extends CustomVideoDecoder {
     }
   }
 
-  async close() {
+  close() {
     const decoder = this.decoder
     this.decoder = null
     this.packetTiming.clear()

--- a/lib/editor/animation-export/video-media/frame-renderer.ts
+++ b/lib/editor/animation-export/video-media/frame-renderer.ts
@@ -1012,6 +1012,7 @@ export async function createFrameRenderer({
   plan,
   signal,
   mediaFx,
+  cropAnimated = false,
 }: {
   capture: AnimationCapture
   video: HTMLVideoElement
@@ -1021,8 +1022,14 @@ export async function createFrameRenderer({
   signal?: AbortSignal
   /** Media-pixel effects (enhance) re-applied to the decoded frame. */
   mediaFx?: VideoMediaFx | null
+  /**
+   * A clip animates the crop. The composite renderer measures the video's
+   * visible sub-rect ONCE at setup, so it would freeze the crop on its first
+   * frame; the raster path re-captures the DOM every frame and follows it.
+   */
+  cropAnimated?: boolean
 }): Promise<RenderFrame> {
-  if (decoded) {
+  if (decoded && !cropAnimated) {
     const composite = await createCompositeRenderer(
       capture,
       video,

--- a/lib/editor/animation-export/video-media/index.ts
+++ b/lib/editor/animation-export/video-media/index.ts
@@ -13,6 +13,7 @@
  * (`encode-video.ts`) encoder.
  */
 
+import { clipOwns } from "../../animation-playback"
 import { supportsObjectViewBox } from "../../crop-utils"
 import { prepareAnimationCapture } from "../../export"
 import { isVideoSrc } from "../../media-type"
@@ -147,6 +148,7 @@ async function encodeVideoMedia(
       plan,
       signal,
       mediaFx,
+      cropAnimated: !!canvas.animation?.clips.some((c) => clipOwns(c, "crop")),
     })
 
     try {

--- a/lib/editor/animation-export/video-media/index.ts
+++ b/lib/editor/animation-export/video-media/index.ts
@@ -25,7 +25,6 @@ import type {
   WatermarkAssets,
 } from "../types"
 import {
-  AnimationExportAbortedError,
   animationMimeAndExt,
   createProgressReporter,
   even,

--- a/lib/editor/animation-export/webkit-layered-frame.ts
+++ b/lib/editor/animation-export/webkit-layered-frame.ts
@@ -88,6 +88,12 @@ const UNDERLAY_IRRELEVANT_ROOT_VARS = new Set([
   "--editor-main-bare-top",
   "--bd-light-img-in",
   "--bd-light-op-in",
+  // Crop drives the media's source rect — foreground, captured per frame.
+  "--crop-view-box",
+  "--crop-w",
+  "--crop-h",
+  "--crop-left",
+  "--crop-top",
 ])
 
 /** Every underlay-affecting inline var on the clone root, as a stable key. */

--- a/lib/editor/animation-export/webkit-layered-frame.ts
+++ b/lib/editor/animation-export/webkit-layered-frame.ts
@@ -94,6 +94,14 @@ const UNDERLAY_IRRELEVANT_ROOT_VARS = new Set([
   "--crop-h",
   "--crop-left",
   "--crop-top",
+  // Same, for an animated crop: the fit correction is recomputed every frame
+  // from the sampled region, so leaving these in would rebuild the underlay on
+  // every frame of a crop animation. They only size/scale the media shell.
+  "--crop-shell-w",
+  "--crop-shell-h",
+  "--crop-fit-sx",
+  "--crop-fit-sy",
+  "--crop-fit-origin",
 ])
 
 /** Every underlay-affecting inline var on the clone root, as a stable key. */

--- a/lib/editor/animation-playback.ts
+++ b/lib/editor/animation-playback.ts
@@ -22,12 +22,21 @@ import type {
   Border,
   ClipBaseline,
   ClipSlotPose,
+  CropRegion,
   Overlay,
   Portrait,
   ScreenshotPosition,
   Shadow,
   Tilt,
 } from "./state-types"
+
+/** The whole frame — what an un-cropped video reveals from / returns to. */
+export const FULL_CROP_REGION: CropRegion = {
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 100,
+}
 
 /**
  * Baseline used for clips saved before per-clip baselines existed: the canvas
@@ -50,6 +59,7 @@ export const DEFAULT_BASELINE: ClipBaseline = {
   overlay: DEFAULT_CANVAS_BASE.overlay,
   border: DEFAULT_CANVAS_BASE.border,
   borderRadius: DEFAULT_CANVAS_BASE.borderRadius,
+  crop: FULL_CROP_REGION,
   slots: {},
 }
 
@@ -488,6 +498,24 @@ export function backdropEffectsBetween(
     sepia: lerp(from.sepia, to.sepia, p),
     invert: lerp(from.invert, to.invert, p),
     opacity: lerp(from.opacity, to.opacity, p),
+  }
+}
+
+/**
+ * Crop source rect at progress p. Eased on x/y/width/height directly, which pans
+ * and zooms the visible window in one motion; the laid-out box is never touched
+ * (see `ClipBaseline.crop`).
+ */
+export function cropRegionBetween(
+  from: CropRegion,
+  to: CropRegion,
+  p: number
+): CropRegion {
+  return {
+    x: lerp(from.x, to.x, p),
+    y: lerp(from.y, to.y, p),
+    width: lerp(from.width, to.width, p),
+    height: lerp(from.height, to.height, p),
   }
 }
 

--- a/lib/editor/apply-animation-frame.ts
+++ b/lib/editor/apply-animation-frame.ts
@@ -35,8 +35,10 @@ import {
   clipOwns,
   clipPose,
   clipsProgressAt,
+  cropRegionBetween,
   DEFAULT_BASELINE,
   filterLayerOpacityVar,
+  FULL_CROP_REGION,
   INVISIBLE_BORDER,
   lerp,
   patternLayerOpacityVar,
@@ -65,6 +67,15 @@ import {
   SHADOW_FILTER_PREVIEW_VAR,
   SHADOW_PREVIEW_VAR,
 } from "@/lib/editor/css-utils"
+import {
+  CROP_HEIGHT_VAR,
+  CROP_LEFT_VAR,
+  CROP_TOP_VAR,
+  CROP_VIEW_BOX_VAR,
+  CROP_WIDTH_VAR,
+  cropObjectMetrics,
+  cropViewBoxValue,
+} from "@/lib/editor/crop-utils"
 import { clipProgressEase } from "@/lib/editor/clip-easing"
 import { captureClipPose } from "@/lib/editor/store"
 import type {
@@ -76,6 +87,7 @@ import type {
   CanvasState,
   ClipBaseline,
   ClipSlotPose,
+  CropRegion,
   ScreenshotPosition,
   Shadow,
   Tilt,
@@ -117,8 +129,16 @@ const SCOPE_VARS = [
   BORDER_OFFSET_PREVIEW_VAR,
   SCREENSHOT_RADIUS_PREVIEW_VAR,
 ]
+const CROP_VARS = [
+  CROP_VIEW_BOX_VAR,
+  CROP_WIDTH_VAR,
+  CROP_HEIGHT_VAR,
+  CROP_LEFT_VAR,
+  CROP_TOP_VAR,
+]
 const CANVAS_FX_VARS = [
   BG_OPACITY_VAR,
+  ...CROP_VARS,
   BACKDROP_FX_PREVIEW_VAR,
   BACKDROP_NOISE_PREVIEW_VAR,
   LIGHTING_IMAGE_VAR,
@@ -574,6 +594,27 @@ export function applyAnimationFrameAtTime({
     } else {
       setVar(canvasEl, BACKDROP_FX_PREVIEW_VAR, null)
       setVar(canvasEl, BACKDROP_NOISE_PREVIEW_VAR, null)
+    }
+
+    // crop (video only) — the source rect, never the laid-out box: the canvas
+    // aspect keeps reading the committed region so the encoder's frame size is
+    // constant. Both render paths get their var because browser support for
+    // `object-view-box` differs and the clone may rasterize on either.
+    const cropVal = sampleKeyframes<CropRegion>(
+      framesFor("crop", (pz) => pz.crop ?? FULL_CROP_REGION),
+      playheadMs,
+      restFor("crop", (pz) => pz.crop ?? FULL_CROP_REGION, FULL_CROP_REGION),
+      cropRegionBetween
+    )
+    if (cropVal) {
+      const metrics = cropObjectMetrics(cropVal)
+      setVar(canvasEl, CROP_VIEW_BOX_VAR, cropViewBoxValue(cropVal))
+      setVar(canvasEl, CROP_WIDTH_VAR, metrics.width)
+      setVar(canvasEl, CROP_HEIGHT_VAR, metrics.height)
+      setVar(canvasEl, CROP_LEFT_VAR, metrics.left)
+      setVar(canvasEl, CROP_TOP_VAR, metrics.top)
+    } else {
+      for (const v of CROP_VARS) setVar(canvasEl, v, null)
     }
 
     // lighting — pure-inner stays ON the screenshot; pure-outer stays on the

--- a/lib/editor/apply-animation-frame.ts
+++ b/lib/editor/apply-animation-frame.ts
@@ -230,21 +230,82 @@ export function clearAnimationFrameVars(
 }
 
 /**
- * Fit correction for an animated crop window.
+ * The geometry an animated crop implies this frame, or null when it implies
+ * none (no media, unmeasurable stage, or `fill` — which maps 1:1 by
+ * definition).
  *
- * The polyfill maps the crop region onto the media shell exactly — i.e. `fill`
+ * The polyfill maps the crop region onto the media shell exactly — `fill`
  * semantics — so honouring the canvas's fill mode means giving the shell the
- * crop's own ratio (contain) or scaling the video up to cover it (cover). The
- * window's ratio can change every frame, so neither can be static CSS.
+ * window's own ratio (contain) or scaling the video up to cover it (cover). The
+ * ratio can change every frame, so neither can be static CSS.
  *
- * Measures the live DOM because the natural media size and stage box live
- * nowhere in the state tree. A missing measurement clears the vars rather than
- * guessing, leaving the committed styles (correct at the open keyframe) in play.
+ * `shellBox` is set only for `contain`, the one mode that resizes the shell;
+ * `cover` leaves the shell at the stage box and scales the video inside it.
+ * It is derived, never measured: the shell's size and the placement that
+ * centres on it are decided in the same pass, so reading it back from the DOM
+ * could only ever report the previous frame's box.
+ *
+ * Measures the stage and the media's natural size because neither lives in the
+ * state tree. A missing measurement returns null and the caller clears the
+ * vars rather than guessing, leaving the committed styles in play.
  */
-function applyCropFitVars(
+function cropFitGeometry(
   canvasEl: HTMLElement,
   canvas: CanvasState,
   region: CropRegion
+): {
+  fit: "contain" | "cover"
+  stageW: number
+  stageH: number
+  ratio: number
+  shellBox: { width: number; height: number } | null
+} | null {
+  const fit = canvas.objectFit ?? "contain"
+  if (fit === "fill") return null
+
+  const shell = canvasEl.querySelector<HTMLElement>(
+    '[data-export-stack="media"]'
+  )
+  // `video, img`: the export clone swaps the serialized `<video>` for an `<img>`
+  // stand-in (see video-layer), so matching only `video` found nothing there and
+  // silently cleared the correction for every exported frame — the crop window
+  // landed with the polyfill's raw fill mapping while the preview, which still
+  // has a real `<video>`, was correct.
+  const media = shell?.querySelector<HTMLVideoElement | HTMLImageElement>(
+    "video, img"
+  )
+  const stage = shell?.parentElement
+  if (!shell || !media || !stage) return null
+
+  // The stand-in reports no natural size until its first paint, so fall back to
+  // the dimensions the swap seeded from the source video.
+  const naturalW =
+    media instanceof HTMLVideoElement
+      ? media.videoWidth
+      : media.naturalWidth || Number(media.dataset.naturalW) || 0
+  const naturalH =
+    media instanceof HTMLVideoElement
+      ? media.videoHeight
+      : media.naturalHeight || Number(media.dataset.naturalH) || 0
+  const ratio = cropRegionRatio(region, naturalW, naturalH)
+  const stageW = parseFloat(getComputedStyle(stage).width) || stage.clientWidth
+  const stageH =
+    parseFloat(getComputedStyle(stage).height) || stage.clientHeight
+  if (!ratio || !(stageW > 0) || !(stageH > 0)) return null
+
+  return {
+    fit,
+    stageW,
+    stageH,
+    ratio,
+    shellBox: fit === "contain" ? fitContainBox(stageW, stageH, ratio) : null,
+  }
+}
+
+function applyCropFitVars(
+  canvasEl: HTMLElement,
+  region: CropRegion,
+  geometry: ReturnType<typeof cropFitGeometry>
 ) {
   const clearFit = () => {
     setVar(canvasEl, CROP_SHELL_W_VAR, null)
@@ -254,30 +315,15 @@ function applyCropFitVars(
     setVar(canvasEl, CROP_FIT_ORIGIN_VAR, null)
   }
 
-  const fit = canvas.objectFit ?? "contain"
-  // `fill` stretches the window into the box by definition — nothing to correct.
-  if (fit === "fill") return clearFit()
-
-  const shell = canvasEl.querySelector<HTMLElement>(
-    '[data-export-stack="media"]'
-  )
-  const video = shell?.querySelector("video")
-  const stage = shell?.parentElement
-  if (!shell || !video || !stage) return clearFit()
-
-  const ratio = cropRegionRatio(region, video.videoWidth, video.videoHeight)
-  const stageW = parseFloat(getComputedStyle(stage).width) || stage.clientWidth
-  const stageH =
-    parseFloat(getComputedStyle(stage).height) || stage.clientHeight
-  if (!ratio || !(stageW > 0) || !(stageH > 0)) return clearFit()
+  if (!geometry) return clearFit()
+  const { stageW, stageH, ratio, shellBox } = geometry
 
   setVar(canvasEl, CROP_FIT_ORIGIN_VAR, cropOriginCss(region))
 
-  if (fit === "contain") {
+  if (shellBox) {
     // Shell shrinks to the window's ratio; the mapping is then 1:1, no scale.
-    const box = fitContainBox(stageW, stageH, ratio)
-    setVar(canvasEl, CROP_SHELL_W_VAR, `${box.width}px`)
-    setVar(canvasEl, CROP_SHELL_H_VAR, `${box.height}px`)
+    setVar(canvasEl, CROP_SHELL_W_VAR, `${shellBox.width}px`)
+    setVar(canvasEl, CROP_SHELL_H_VAR, `${shellBox.height}px`)
     setVar(canvasEl, CROP_FIT_SX_VAR, "1")
     setVar(canvasEl, CROP_FIT_SY_VAR, "1")
     return
@@ -399,20 +445,54 @@ export function applyAnimationFrameAtTime({
       zoomVal != null ? String(zoomVal / 100) : null
     )
 
+    // The crop this frame lands on, and the shell geometry it implies. Sampled
+    // here rather than in the crop block below because the placement needs it:
+    // in contain mode the crop resizes the shell, and the bare placement
+    // centres on that size.
+    const cropVal = sampleKeyframes<CropRegion>(
+      framesFor("crop", (pz) => pz.crop ?? FULL_CROP_REGION),
+      playheadMs,
+      restFor("crop", (pz) => pz.crop ?? FULL_CROP_REGION, FULL_CROP_REGION),
+      cropRegionBetween
+    )
+    const cropGeometry = cropVal
+      ? cropFitGeometry(canvasEl, canvas, cropVal)
+      : null
+
     // position
     const posFrames = mainClips.filter((c) => clipOwns(c, "position"))
+    // A crop that resizes the shell has to drive the placement too, even when
+    // nothing animates position. The committed `left` is a px value React baked
+    // from the uncropped box; the export clone is a static snapshot that cannot
+    // recompute it, so the shell would shrink about a frozen left edge instead
+    // of about its centre. (The live preview re-renders and re-centres, which
+    // is exactly why this only ever showed up in exports.)
+    const cropResizesShell = cropGeometry?.shellBox != null
     if (screenshotPositionDragging) {
       // gesture owns vars
-    } else if (posFrames.length > 0 && frame) {
+    } else if ((posFrames.length > 0 || cropResizesShell) && frame) {
       // The bare-pixel positioning path is ONLY valid for the free-floating
       // single screenshot. For a framed or multi-slot (row) main, `dims` must be
       // null so the percentage/anchor path runs — otherwise a caller that always
       // passes `bareDims` (the exporter measures it unconditionally) would push
       // the row main onto the wrong path and misplace it. Never trust a passed
       // `bareDims` unless this really is the bare target.
-      const dims = isBareMainTarget
+      const measured = isBareMainTarget
         ? (bareDims ?? measureBareStageDims(canvasEl))
         : null
+      // Take the shell size from the crop that is being applied THIS frame, not
+      // from the DOM. A measurement can only ever report the previous frame's
+      // box — the crop resizing the shell and the placement centring on it
+      // happen in the same pass — so the centre would trail the width by a
+      // frame and the box would appear to crop in from one edge only.
+      const dims =
+        measured && cropGeometry?.shellBox
+          ? {
+              ...measured,
+              imgW: cropGeometry.shellBox.width,
+              imgH: cropGeometry.shellBox.height,
+            }
+          : measured
       const aspect = canvas.aspect ?? globalAspect
       const pointFor = (
         pos: ScreenshotPosition,
@@ -441,15 +521,25 @@ export function applyAnimationFrameAtTime({
           ease: clipProgressEase(c),
         }
       })
-      const posRest = clipBaseline(
-        [...posFrames].sort((a, b) => a.startMs - b.startMs)[0]
-      )
-      const point = sampleKeyframes(
-        frames,
-        playheadMs,
-        pointFor(posRest.screenshotPosition, posRest.screenshotOffset),
-        pointLerp
-      )
+      const posRest =
+        posFrames.length > 0
+          ? clipBaseline(
+              [...posFrames].sort((a, b) => a.startMs - b.startMs)[0]
+            )
+          : null
+      // No position clip: hold the committed placement, re-resolved against
+      // this frame's shell box so a crop-only clip still stays centred.
+      const point = posRest
+        ? sampleKeyframes(
+            frames,
+            playheadMs,
+            pointFor(posRest.screenshotPosition, posRest.screenshotOffset),
+            pointLerp
+          )
+        : pointFor(
+            committedPose.screenshotPosition,
+            committedPose.screenshotOffset
+          )
       if (point && dims != null) {
         const { left, top } = bareScreenshotTargetLeftTop(dims, point)
         setMainScreenshotBarePreviewPx(canvasEl, left, top)
@@ -669,12 +759,7 @@ export function applyAnimationFrameAtTime({
     // aspect keeps reading the committed region so the encoder's frame size is
     // constant. Both render paths get their var because browser support for
     // `object-view-box` differs and the clone may rasterize on either.
-    const cropVal = sampleKeyframes<CropRegion>(
-      framesFor("crop", (pz) => pz.crop ?? FULL_CROP_REGION),
-      playheadMs,
-      restFor("crop", (pz) => pz.crop ?? FULL_CROP_REGION, FULL_CROP_REGION),
-      cropRegionBetween
-    )
+    // `cropVal`/`cropGeometry` are sampled above, where the placement needs them.
     if (cropVal) {
       const metrics = cropObjectMetrics(cropVal)
       setVar(canvasEl, CROP_VIEW_BOX_VAR, cropViewBoxValue(cropVal))
@@ -682,7 +767,7 @@ export function applyAnimationFrameAtTime({
       setVar(canvasEl, CROP_HEIGHT_VAR, metrics.height)
       setVar(canvasEl, CROP_LEFT_VAR, metrics.left)
       setVar(canvasEl, CROP_TOP_VAR, metrics.top)
-      applyCropFitVars(canvasEl, canvas, cropVal)
+      applyCropFitVars(canvasEl, cropVal, cropGeometry)
     } else {
       for (const v of CROP_VARS) setVar(canvasEl, v, null)
     }

--- a/lib/editor/apply-animation-frame.ts
+++ b/lib/editor/apply-animation-frame.ts
@@ -24,7 +24,11 @@ import {
   LIGHTING_IMAGE_VAR,
   LIGHTING_OPACITY_VAR,
 } from "@/components/editor/inspector/backdrop-section-parts/constants"
-import { lightingOverlayValues } from "@/components/editor/canvas/helpers"
+import {
+  coverContainerBox,
+  fitContainBox,
+  lightingOverlayValues,
+} from "@/components/editor/canvas/helpers"
 import {
   backdropEffectsBetween,
   backgroundLayerOpacityVar,
@@ -68,12 +72,20 @@ import {
   SHADOW_PREVIEW_VAR,
 } from "@/lib/editor/css-utils"
 import {
+  CROP_ANIMATION_VARS,
+  CROP_FIT_ORIGIN_VAR,
+  CROP_FIT_SX_VAR,
+  CROP_FIT_SY_VAR,
   CROP_HEIGHT_VAR,
   CROP_LEFT_VAR,
+  CROP_SHELL_H_VAR,
+  CROP_SHELL_W_VAR,
   CROP_TOP_VAR,
   CROP_VIEW_BOX_VAR,
   CROP_WIDTH_VAR,
   cropObjectMetrics,
+  cropOriginCss,
+  cropRegionRatio,
   cropViewBoxValue,
 } from "@/lib/editor/crop-utils"
 import { clipProgressEase } from "@/lib/editor/clip-easing"
@@ -129,13 +141,7 @@ const SCOPE_VARS = [
   BORDER_OFFSET_PREVIEW_VAR,
   SCREENSHOT_RADIUS_PREVIEW_VAR,
 ]
-const CROP_VARS = [
-  CROP_VIEW_BOX_VAR,
-  CROP_WIDTH_VAR,
-  CROP_HEIGHT_VAR,
-  CROP_LEFT_VAR,
-  CROP_TOP_VAR,
-]
+const CROP_VARS = CROP_ANIMATION_VARS
 const CANVAS_FX_VARS = [
   BG_OPACITY_VAR,
   ...CROP_VARS,
@@ -221,6 +227,69 @@ export function clearAnimationFrameVars(
       setVar(slotEl, SHADOW_FILTER_PREVIEW_VAR, null)
       clearPositionPreviewVars(slotEl)
     })
+}
+
+/**
+ * Fit correction for an animated crop window.
+ *
+ * The polyfill maps the crop region onto the media shell exactly — i.e. `fill`
+ * semantics — so honouring the canvas's fill mode means giving the shell the
+ * crop's own ratio (contain) or scaling the video up to cover it (cover). The
+ * window's ratio can change every frame, so neither can be static CSS.
+ *
+ * Measures the live DOM because the natural media size and stage box live
+ * nowhere in the state tree. A missing measurement clears the vars rather than
+ * guessing, leaving the committed styles (correct at the open keyframe) in play.
+ */
+function applyCropFitVars(
+  canvasEl: HTMLElement,
+  canvas: CanvasState,
+  region: CropRegion
+) {
+  const clearFit = () => {
+    setVar(canvasEl, CROP_SHELL_W_VAR, null)
+    setVar(canvasEl, CROP_SHELL_H_VAR, null)
+    setVar(canvasEl, CROP_FIT_SX_VAR, null)
+    setVar(canvasEl, CROP_FIT_SY_VAR, null)
+    setVar(canvasEl, CROP_FIT_ORIGIN_VAR, null)
+  }
+
+  const fit = canvas.objectFit ?? "contain"
+  // `fill` stretches the window into the box by definition — nothing to correct.
+  if (fit === "fill") return clearFit()
+
+  const shell = canvasEl.querySelector<HTMLElement>(
+    '[data-export-stack="media"]'
+  )
+  const video = shell?.querySelector("video")
+  const stage = shell?.parentElement
+  if (!shell || !video || !stage) return clearFit()
+
+  const ratio = cropRegionRatio(region, video.videoWidth, video.videoHeight)
+  const stageW = parseFloat(getComputedStyle(stage).width) || stage.clientWidth
+  const stageH =
+    parseFloat(getComputedStyle(stage).height) || stage.clientHeight
+  if (!ratio || !(stageW > 0) || !(stageH > 0)) return clearFit()
+
+  setVar(canvasEl, CROP_FIT_ORIGIN_VAR, cropOriginCss(region))
+
+  if (fit === "contain") {
+    // Shell shrinks to the window's ratio; the mapping is then 1:1, no scale.
+    const box = fitContainBox(stageW, stageH, ratio)
+    setVar(canvasEl, CROP_SHELL_W_VAR, `${box.width}px`)
+    setVar(canvasEl, CROP_SHELL_H_VAR, `${box.height}px`)
+    setVar(canvasEl, CROP_FIT_SX_VAR, "1")
+    setVar(canvasEl, CROP_FIT_SY_VAR, "1")
+    return
+  }
+
+  // cover: the shell stays the stage box (it is the clip), so the window has to
+  // grow past it — scale about the window's own centre and let overflow clip.
+  const box = coverContainerBox(stageW, stageH, ratio)
+  setVar(canvasEl, CROP_SHELL_W_VAR, null)
+  setVar(canvasEl, CROP_SHELL_H_VAR, null)
+  setVar(canvasEl, CROP_FIT_SX_VAR, String(box.width / stageW))
+  setVar(canvasEl, CROP_FIT_SY_VAR, String(box.height / stageH))
 }
 
 export type ApplyAnimationFrameOptions = {
@@ -613,6 +682,7 @@ export function applyAnimationFrameAtTime({
       setVar(canvasEl, CROP_HEIGHT_VAR, metrics.height)
       setVar(canvasEl, CROP_LEFT_VAR, metrics.left)
       setVar(canvasEl, CROP_TOP_VAR, metrics.top)
+      applyCropFitVars(canvasEl, canvas, cropVal)
     } else {
       for (const v of CROP_VARS) setVar(canvasEl, v, null)
     }

--- a/lib/editor/apply-animation-frame.ts
+++ b/lib/editor/apply-animation-frame.ts
@@ -568,7 +568,7 @@ export function applyAnimationFrameAtTime({
       setVar(
         canvasEl,
         BACKDROP_FX_PREVIEW_VAR,
-        effectsFilterCss(bdVal) ?? "none"
+        effectsFilterCss(bdVal) ?? "brightness(1)"
       )
       setVar(canvasEl, BACKDROP_NOISE_PREVIEW_VAR, String(bdVal.noise / 100))
     } else {

--- a/lib/editor/crop-utils.ts
+++ b/lib/editor/crop-utils.ts
@@ -44,6 +44,50 @@ export const CROP_WIDTH_VAR = "--crop-w"
 export const CROP_HEIGHT_VAR = "--crop-h"
 export const CROP_LEFT_VAR = "--crop-left"
 export const CROP_TOP_VAR = "--crop-top"
+/**
+ * Fit-correction vars for an ANIMATED crop. The crop window's aspect can change
+ * every frame, so the shell size (contain) and the video's scale (cover) can't
+ * be static CSS — `apply-animation-frame` recomputes them per frame from the
+ * sampled region, the media's natural size and the stage box.
+ */
+export const CROP_SHELL_W_VAR = "--crop-shell-w"
+export const CROP_SHELL_H_VAR = "--crop-shell-h"
+export const CROP_FIT_SX_VAR = "--crop-fit-sx"
+export const CROP_FIT_SY_VAR = "--crop-fit-sy"
+export const CROP_FIT_ORIGIN_VAR = "--crop-fit-origin"
+
+/** Every crop var, for a single clear when nothing animates the crop. */
+export const CROP_ANIMATION_VARS = [
+  CROP_VIEW_BOX_VAR,
+  CROP_WIDTH_VAR,
+  CROP_HEIGHT_VAR,
+  CROP_LEFT_VAR,
+  CROP_TOP_VAR,
+  CROP_SHELL_W_VAR,
+  CROP_SHELL_H_VAR,
+  CROP_FIT_SX_VAR,
+  CROP_FIT_SY_VAR,
+  CROP_FIT_ORIGIN_VAR,
+]
+
+/**
+ * The crop window's own aspect ratio in source pixels. Percent regions are
+ * relative to the natural size, so both factor in.
+ */
+export function cropRegionRatio(
+  region: CropRegion,
+  naturalW: number,
+  naturalH: number
+) {
+  const w = region.width * naturalW
+  const h = region.height * naturalH
+  return w > 0 && h > 0 ? w / h : null
+}
+
+/** The crop's centre in source coordinates — the point a fit scale pivots on. */
+export function cropOriginCss(region: CropRegion) {
+  return `${region.x + region.width / 2}% ${region.y + region.height / 2}%`
+}
 
 /** The `object-view-box` inset for a region, as a bare value (no var wrapper). */
 export function cropViewBoxValue(region: CropRegion): string {

--- a/lib/editor/crop-utils.ts
+++ b/lib/editor/crop-utils.ts
@@ -34,11 +34,39 @@ export function supportsObjectViewBox(): boolean {
   }
 }
 
+/**
+ * Animated-crop preview vars. Both render paths read their own var so a crop
+ * keyframe can drive the source rect per frame, falling back to the committed
+ * region when nothing is animating. Written by `apply-animation-frame`.
+ */
+export const CROP_VIEW_BOX_VAR = "--crop-view-box"
+export const CROP_WIDTH_VAR = "--crop-w"
+export const CROP_HEIGHT_VAR = "--crop-h"
+export const CROP_LEFT_VAR = "--crop-left"
+export const CROP_TOP_VAR = "--crop-top"
+
+/** The `object-view-box` inset for a region, as a bare value (no var wrapper). */
+export function cropViewBoxValue(region: CropRegion): string {
+  const { x, y, width, height } = region
+  return `inset(${y}% ${100 - x - width}% ${100 - y - height}% ${x}%)`
+}
+
+/** The four polyfill percentages for a region, as bare values. */
+export function cropObjectMetrics(region: CropRegion) {
+  const width = Math.max(region.width, 0.001)
+  const height = Math.max(region.height, 0.001)
+  return {
+    width: `${(100 / width) * 100}%`,
+    height: `${(100 / height) * 100}%`,
+    left: `${(-region.x / width) * 100}%`,
+    top: `${(-region.y / height) * 100}%`,
+  }
+}
+
 /** Native crop via CSS object-view-box (Chrome/Edge). */
 export function objectViewBoxCropStyle(region: CropRegion): CSSProperties {
-  const { x, y, width, height } = region
   return {
-    objectViewBox: `inset(${y}% ${100 - x - width}% ${100 - y - height}% ${x}%)`,
+    objectViewBox: `var(${CROP_VIEW_BOX_VAR}, ${cropViewBoxValue(region)})`,
   }
 }
 
@@ -48,14 +76,13 @@ export function objectViewBoxCropStyle(region: CropRegion): CSSProperties {
  * Parent must be `overflow: hidden` and have a definite size.
  */
 export function cropMediaObjectStyle(region: CropRegion): CSSProperties {
-  const width = Math.max(region.width, 0.001)
-  const height = Math.max(region.height, 0.001)
+  const m = cropObjectMetrics(region)
   return {
     position: "absolute",
-    width: `${(100 / width) * 100}%`,
-    height: `${(100 / height) * 100}%`,
-    left: `${(-region.x / width) * 100}%`,
-    top: `${(-region.y / height) * 100}%`,
+    width: `var(${CROP_WIDTH_VAR}, ${m.width})`,
+    height: `var(${CROP_HEIGHT_VAR}, ${m.height})`,
+    left: `var(${CROP_LEFT_VAR}, ${m.left})`,
+    top: `var(${CROP_TOP_VAR}, ${m.top})`,
     maxWidth: "none",
     maxHeight: "none",
     objectFit: "fill",

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -399,6 +399,7 @@ export type AnimationEffect =
   | "overlay"
   | "border"
   | "borderRadius"
+  | "crop"
 
 export type ClipEasingKind =
   | "linear"
@@ -438,6 +439,13 @@ export type ClipBaseline = {
   overlay?: Overlay
   border?: Border
   borderRadius?: number
+  /**
+   * Video-only, and the source rect ONLY — never the laid-out box. The canvas's
+   * auto aspect keeps reading the committed crop so the output frame size stays
+   * fixed for the encoder; animating this pans/zooms the visible window inside
+   * an unchanged box.
+   */
+  crop?: CropRegion
   slots: Record<string, ClipSlotPose>
 }
 

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -445,7 +445,7 @@ export type ClipBaseline = {
    * fixed for the encoder; animating this pans/zooms the visible window inside
    * an unchanged box.
    */
-  crop?: CropRegion
+  crop?: CropRegion | null
   slots: Record<string, ClipSlotPose>
 }
 

--- a/lib/editor/store.tsx
+++ b/lib/editor/store.tsx
@@ -141,7 +141,9 @@ export const captureClipPose = (canvas: CanvasState): ClipBaseline => ({
   overlay: canvas.overlay,
   border: canvas.border,
   borderRadius: canvas.borderRadius,
-  crop: canvas.lastCropRegion ?? undefined,
+  // null (not undefined) so a clip with no crop stays distinguishable from a
+  // pose captured before crop animated — see poseCrop.
+  crop: canvas.lastCropRegion,
   slots: Object.fromEntries(
     canvas.screenshotSlots.map((s) => [
       s.id,
@@ -161,6 +163,15 @@ export const captureClipPose = (canvas: CanvasState): ClipBaseline => ({
     ])
   ),
 })
+
+/**
+ * Resolve a pose's crop against the live one. Poses captured before crop
+ * animated omit the key entirely (undefined) and inherit the live crop; an
+ * explicit null means this clip has no crop and must NOT inherit one, or
+ * clearing a crop would come back the moment another clip applied one.
+ */
+const poseCrop = (pose: ClipBaseline, live: CropRegion | null) =>
+  pose.crop !== undefined ? pose.crop : live
 
 /**
  * Load a clip's pose onto the canvas's live/committed style so the inspector and
@@ -188,8 +199,7 @@ const applyPoseToCanvas = (
   border: pose.border ?? canvas.border,
   // Fall back to the live value for poses captured before radius animated.
   borderRadius: pose.borderRadius ?? canvas.borderRadius,
-  // Fall back to the live value for poses captured before crop animated.
-  lastCropRegion: pose.crop ?? canvas.lastCropRegion,
+  lastCropRegion: poseCrop(pose, canvas.lastCropRegion),
   backdrop: {
     ...canvas.backdrop,
     effects: pose.backdropEffects,
@@ -484,10 +494,7 @@ const resolveKeyframePose = (
     pattern: mainReveal("pattern", (p) => p.pattern ?? canvas.backdrop.pattern),
     overlay: mainReveal("overlay", (p) => p.overlay ?? canvas.overlay),
     border: mainReveal("border", (p) => p.border ?? canvas.border),
-    crop: mainReveal(
-      "crop",
-      (p) => p.crop ?? canvas.lastCropRegion ?? undefined
-    ),
+    crop: mainReveal("crop", (p) => poseCrop(p, canvas.lastCropRegion)),
     borderRadius: main(
       "borderRadius",
       (p) => p.borderRadius ?? canvas.borderRadius,

--- a/lib/editor/store.tsx
+++ b/lib/editor/store.tsx
@@ -141,6 +141,7 @@ export const captureClipPose = (canvas: CanvasState): ClipBaseline => ({
   overlay: canvas.overlay,
   border: canvas.border,
   borderRadius: canvas.borderRadius,
+  crop: canvas.lastCropRegion ?? undefined,
   slots: Object.fromEntries(
     canvas.screenshotSlots.map((s) => [
       s.id,
@@ -187,6 +188,8 @@ const applyPoseToCanvas = (
   border: pose.border ?? canvas.border,
   // Fall back to the live value for poses captured before radius animated.
   borderRadius: pose.borderRadius ?? canvas.borderRadius,
+  // Fall back to the live value for poses captured before crop animated.
+  lastCropRegion: pose.crop ?? canvas.lastCropRegion,
   backdrop: {
     ...canvas.backdrop,
     effects: pose.backdropEffects,
@@ -244,6 +247,7 @@ const EFFECT_MAIN_POSE_FIELDS: Record<
   overlay: ["overlay"],
   border: ["border"],
   borderRadius: ["borderRadius"],
+  crop: ["crop"],
 }
 
 /** Per-slot pose fields an effect owns (only the slot-animatable ones). */
@@ -480,6 +484,10 @@ const resolveKeyframePose = (
     pattern: mainReveal("pattern", (p) => p.pattern ?? canvas.backdrop.pattern),
     overlay: mainReveal("overlay", (p) => p.overlay ?? canvas.overlay),
     border: mainReveal("border", (p) => p.border ?? canvas.border),
+    crop: mainReveal(
+      "crop",
+      (p) => p.crop ?? canvas.lastCropRegion ?? undefined
+    ),
     borderRadius: main(
       "borderRadius",
       (p) => p.borderRadius ?? canvas.borderRadius,
@@ -1713,13 +1721,14 @@ export const useEditorStore = create<EditorStore>((set, get) => {
         "applyCroppedScreenshot"
       ),
     setScreenshotCropRegion: (region, canvasId) =>
-      commitCanvas(
+      commitCanvasEffect(
         canvasId,
         (canvas) => ({
           lastCropRegion: region,
           fullPageCapture: region ? null : canvas.fullPageCapture,
         }),
-        "setScreenshotCropRegion"
+        "setScreenshotCropRegion",
+        "crop"
       ),
     updateVideoClip: (id, patch, canvasId) =>
       commitCanvas(

--- a/lib/schemas/draft.ts
+++ b/lib/schemas/draft.ts
@@ -123,6 +123,18 @@ export const draftListQuerySchema = z.object({
   sort: z.enum(["latest", "oldest"]).catch("latest"),
   /** Filter list by project kind; omit for all. */
   type: draftTypeSchema.optional(),
+  /**
+   * Name search. Trimmed, and capped so a pathological query can't build a
+   * huge LIKE pattern; an empty string means "no search" (never an empty
+   * match-everything filter).
+   */
+  q: z
+    .string()
+    .trim()
+    .max(DRAFT_NAME_MAX_LENGTH)
+    .catch("")
+    .transform((s) => s || undefined)
+    .optional(),
 })
 
 /** Request body for `POST /api/drafts`. */

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "date-fns": "^4.2.1",
     "drizzle-orm": "^0.45.2",
     "embla-carousel-react": "^8.6.0",
+    "fuse.js": "^7.5.0",
     "gifenc": "^1.0.3",
     "html-to-image": "^1.11.13",
     "import-in-the-middle": "^1.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.6)
+      fuse.js:
+        specifier: ^7.5.0
+        version: 7.5.0
       gifenc:
         specifier: ^1.0.3
         version: 1.0.3
@@ -4270,6 +4273,10 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  fuse.js@7.5.0:
+    resolution: {integrity: sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==}
+    engines: {node: '>=10'}
 
   fuzzysort@3.1.0:
     resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
@@ -10770,6 +10777,8 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  fuse.js@7.5.0: {}
 
   fuzzysort@3.1.0: {}
 

--- a/tests/components/editor/canvas-backdrop.test.tsx
+++ b/tests/components/editor/canvas-backdrop.test.tsx
@@ -72,4 +72,43 @@ describe("CanvasBackdrop", () => {
     const { container } = render(<CanvasBackdrop {...baseProps()} />)
     expect(container.querySelector(".bg-cover.bg-center")).toBeNull()
   })
+
+  /**
+   * The background layer must read `--bd-fx-preview` even with neutral committed
+   * effects — slider drags and the animation player drive that var, and a layer
+   * with no `filter` at all has nothing to drive. The neutral fallback has to be
+   * an identity function, not `none`, so it stays valid next to an asset filter.
+   */
+  it("always reads the effects preview var, with an identity fallback", () => {
+    const { container } = render(<CanvasBackdrop {...baseProps()} />)
+    const layer = container.querySelector<HTMLElement>(
+      ".bg-transparency-checker"
+    )
+    expect(layer?.style.filter).toBe("var(--bd-fx-preview, brightness(1))")
+  })
+
+  it("keeps the preview var valid alongside a backdrop asset filter", () => {
+    const { container } = render(
+      <CanvasBackdrop
+        {...baseProps({
+          backdrop: { ...baseProps().backdrop, filter: "bw" },
+        })}
+      />
+    )
+    const filter = container.querySelector<HTMLElement>(
+      ".bg-transparency-checker"
+    )?.style.filter
+    expect(filter).toContain("var(--bd-fx-preview, brightness(1))")
+    expect(filter).not.toContain("none")
+  })
+
+  it("uses the committed effects filter as the preview fallback", () => {
+    const { container } = render(
+      <CanvasBackdrop {...baseProps({ effectsFilter: "brightness(120%)" })} />
+    )
+    const layer = container.querySelector<HTMLElement>(
+      ".bg-transparency-checker"
+    )
+    expect(layer?.style.filter).toBe("var(--bd-fx-preview, brightness(120%))")
+  })
 })

--- a/tests/components/editor/canvas-helpers-fit.test.ts
+++ b/tests/components/editor/canvas-helpers-fit.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  coverContainerBox,
+  fitContainBox,
+} from "@/components/editor/canvas/helpers"
+
+/**
+ * The contain fit used by both video contain paths. The cropped one especially:
+ * the crop polyfill scales the `<video>` by percentages of its shell, so if the
+ * shell's rendered ratio drifts from the crop's ratio the picture shears — which
+ * is exactly what `width:100% + max-height:100% + aspect-ratio` did.
+ */
+describe("fitContainBox", () => {
+  it("is width-bound when the box is taller than the ratio", () => {
+    // 400x400 stage, 2:1 content → full width, half height.
+    expect(fitContainBox(400, 400, 2)).toEqual({ width: 400, height: 200 })
+  })
+
+  it("is height-bound when the box is wider than the ratio", () => {
+    // 400x100 stage, 1:1 content → limited by height.
+    expect(fitContainBox(400, 100, 1)).toEqual({ width: 100, height: 100 })
+  })
+
+  it("fills exactly when the ratios match", () => {
+    expect(fitContainBox(1920, 1080, 1920 / 1080)).toEqual({
+      width: 1920,
+      height: 1080,
+    })
+  })
+
+  it("always returns a box of the requested ratio", () => {
+    for (const [w, h, ratio] of [
+      [800, 600, 2.35],
+      [500, 900, 0.5],
+      [1000, 1000, 1.777],
+      [320, 240, 9 / 16],
+    ] as const) {
+      const box = fitContainBox(w, h, ratio)
+      expect(box.width / box.height).toBeCloseTo(ratio, 6)
+      // ...and never overflows the box it was fitted into.
+      expect(box.width).toBeLessThanOrEqual(w + 1e-9)
+      expect(box.height).toBeLessThanOrEqual(h + 1e-9)
+    }
+  })
+
+  it("handles a tall crop inside a wide stage without overflowing", () => {
+    // The regression: a 9:16 crop on a 16:9 stage. The old CSS kept width at
+    // 100% and clamped height, so the box came out wider than 9:16 and sheared.
+    const box = fitContainBox(1600, 900, 9 / 16)
+    expect(box.height).toBeCloseTo(900, 6)
+    expect(box.width).toBeCloseTo(506.25, 6)
+    expect(box.width / box.height).toBeCloseTo(9 / 16, 6)
+  })
+})
+
+describe("coverContainerBox", () => {
+  it("overflows width when the box is narrower than the ratio", () => {
+    // 400x400 box, 2:1 content → must be 800 wide to cover.
+    expect(coverContainerBox(400, 400, 2)).toEqual({ width: 800, height: 400 })
+  })
+
+  it("overflows height when the box is wider than the ratio", () => {
+    expect(coverContainerBox(400, 100, 1)).toEqual({ width: 400, height: 400 })
+  })
+
+  it("always covers the box and keeps the requested ratio", () => {
+    for (const [w, h, ratio] of [
+      [800, 600, 2.35],
+      [500, 900, 0.5],
+      [1000, 1000, 1.777],
+      [320, 240, 9 / 16],
+    ] as const) {
+      const box = coverContainerBox(w, h, ratio)
+      expect(box.width / box.height).toBeCloseTo(ratio, 6)
+      expect(box.width).toBeGreaterThanOrEqual(w - 1e-9)
+      expect(box.height).toBeGreaterThanOrEqual(h - 1e-9)
+    }
+  })
+
+  it("produces a scale that restores the crop ratio on a stretched shell", () => {
+    // The regression: a 9:16 crop mapped onto a 16:9 shell. Scaling by
+    // cover/shell must bring the effective ratio back to the crop's.
+    const shellW = 1600
+    const shellH = 900
+    const ratio = 9 / 16
+    const cover = coverContainerBox(shellW, shellH, ratio)
+    const sx = cover.width / shellW
+    const sy = cover.height / shellH
+    expect((shellW * sx) / (shellH * sy)).toBeCloseTo(ratio, 6)
+    // Cover never shrinks below the shell on either axis.
+    expect(sx).toBeGreaterThanOrEqual(1)
+    expect(sy).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/tests/components/editor/use-placement-measurement.test.tsx
+++ b/tests/components/editor/use-placement-measurement.test.tsx
@@ -1,0 +1,104 @@
+import type * as React from "react"
+import { act, renderHook } from "@testing-library/react"
+import { beforeAll, describe, expect, it } from "vitest"
+
+import { usePlacementMeasurement } from "@/components/editor/canvas/use-placement-measurement"
+
+/**
+ * Contain shells are sized FROM the dims this hook reports, so a measurement
+ * that outlives its layout pins the box: the shell can no longer resize, the
+ * ResizeObserver never fires, and nothing re-measures. That's how a video
+ * dropped onto a previously-cropped image rendered inside the image's box until
+ * a reload. The hook must therefore drop its measurement as soon as `layoutKey`
+ * changes, not merely re-run the measure.
+ */
+beforeAll(() => {
+  if (typeof ResizeObserver === "undefined") {
+    // jsdom has no ResizeObserver; the hook only needs it to construct.
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  }
+})
+
+/** A node reporting a fixed box, mimicking a laid-out stage/shell. */
+function boxRef(w: number, h: number) {
+  const el = document.createElement("div")
+  Object.defineProperty(el, "offsetWidth", { value: w, configurable: true })
+  Object.defineProperty(el, "offsetHeight", { value: h, configurable: true })
+  Object.defineProperty(el, "clientWidth", { value: w, configurable: true })
+  Object.defineProperty(el, "clientHeight", { value: h, configurable: true })
+  document.body.appendChild(el)
+  return { current: el }
+}
+
+const setup = (layoutKey: string, enabled = true) => {
+  const stageRef = boxRef(800, 600) as React.RefObject<HTMLDivElement | null>
+  const imageRef = boxRef(
+    400,
+    300
+  ) as unknown as React.RefObject<HTMLImageElement | null>
+  return renderHook(
+    ({ key }: { key: string }) =>
+      usePlacementMeasurement({
+        enabled,
+        stageRef,
+        imageRef,
+        layoutKey: key,
+      }),
+    { initialProps: { key: layoutKey } }
+  )
+}
+
+describe("usePlacementMeasurement", () => {
+  it("measures the stage and image boxes", () => {
+    const { result } = setup("a")
+    act(() => result.current.measurePlacement())
+    expect(result.current.placementDims).toMatchObject({
+      stageW: 800,
+      stageH: 600,
+      imgW: 400,
+      imgH: 300,
+    })
+  })
+
+  it("drops the measurement when the layout key changes", () => {
+    // `enabled: false` keeps the layout effect from immediately re-measuring,
+    // isolating the render-phase reset. In the app that re-measure is the point:
+    // the shell unpins first, THEN gets measured at its real new size.
+    const { result, rerender } = setup("a", false)
+    act(() => result.current.measurePlacement())
+    expect(result.current.placementDims).not.toBeNull()
+
+    rerender({ key: "b" })
+
+    // The stale box must NOT survive into the new layout — a contain shell
+    // sized from it would pin itself and never resize again.
+    expect(result.current.placementDims).toBeNull()
+  })
+
+  it("re-measures under the new key", () => {
+    const { result, rerender } = setup("a")
+    act(() => result.current.measurePlacement())
+    rerender({ key: "b" })
+    act(() => result.current.measurePlacement())
+
+    expect(result.current.placementDims).toMatchObject({
+      stageW: 800,
+      imgW: 400,
+    })
+  })
+
+  it("keeps the same object identity when nothing changed", () => {
+    const { result } = setup("a")
+    act(() => result.current.measurePlacement())
+    const first = result.current.placementDims
+    act(() => result.current.measurePlacement())
+
+    // Re-measuring an unchanged layout must not churn the reference — callers
+    // use it as a memo/effect dependency.
+    expect(result.current.placementDims).toBe(first)
+  })
+})

--- a/tests/lib/draft-fuzzy-search.test.ts
+++ b/tests/lib/draft-fuzzy-search.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+import Fuse from "fuse.js"
+
+/**
+ * The ranking half of `searchDrafts`. `lib/draft-db.ts` is `server-only` and
+ * needs a live D1 binding, so these pin the Fuse configuration it depends on —
+ * the part that decides whether a typo still finds your project. If someone
+ * retunes the threshold or drops `ignoreLocation`, this fails loudly rather than
+ * quietly returning nothing for real queries.
+ */
+const NAMES = [
+  "Full Fuchsia Wildcat",
+  "Logical Peach Weasel",
+  "Prominent Beige Cockroach",
+  "Simple Emerald Mandrill",
+  "Imaginative Pink Planarian",
+  "Automatic Red Starfish",
+]
+
+const makeFuse = () =>
+  new Fuse(
+    NAMES.map((name) => ({ name })),
+    {
+      keys: ["name"],
+      threshold: 0.4,
+      ignoreLocation: true,
+      minMatchCharLength: 2,
+    }
+  )
+
+const search = (q: string) =>
+  makeFuse()
+    .search(q)
+    .map((hit) => hit.item.name)
+
+describe("draft fuzzy search ranking", () => {
+  it("finds an exact substring", () => {
+    expect(search("Emerald")).toContain("Simple Emerald Mandrill")
+  })
+
+  it("tolerates a transposed-letter typo", () => {
+    expect(search("Emreald")).toContain("Simple Emerald Mandrill")
+  })
+
+  it("tolerates a missing letter", () => {
+    expect(search("Fucsia")).toContain("Full Fuchsia Wildcat")
+  })
+
+  it("tolerates a wrong letter", () => {
+    expect(search("Starfush")).toContain("Automatic Red Starfish")
+  })
+
+  it("is case insensitive", () => {
+    expect(search("PEACH")).toContain("Logical Peach Weasel")
+  })
+
+  it("matches a word at the END of a name", () => {
+    // Guards `ignoreLocation`. Fuse defaults to weighting matches near the start
+    // of the string, which would drop these.
+    expect(search("Cockroach")).toContain("Prominent Beige Cockroach")
+    expect(search("Mandrill")).toContain("Simple Emerald Mandrill")
+  })
+
+  it("ranks the closest name first", () => {
+    // "Peach" is a near-exact hit; nothing else should outrank it.
+    expect(search("Peach")[0]).toBe("Logical Peach Weasel")
+  })
+
+  it("still returns nothing for a query with no relation", () => {
+    // Typo tolerance must not degrade into matching everything.
+    expect(search("zzzzqqqq")).toEqual([])
+  })
+
+  it("ignores a single character rather than matching everything", () => {
+    expect(search("a")).toEqual([])
+  })
+})

--- a/tests/lib/draft-fuzzy-search.test.ts
+++ b/tests/lib/draft-fuzzy-search.test.ts
@@ -17,15 +17,18 @@ const NAMES = [
   "Automatic Red Starfish",
 ]
 
+/** Declared here rather than imported: pinning it is the point. */
+const FUSE_CONFIG = {
+  keys: ["name"],
+  threshold: 0.4,
+  ignoreLocation: true,
+  minMatchCharLength: 2,
+}
+
 const makeFuse = () =>
   new Fuse(
     NAMES.map((name) => ({ name })),
-    {
-      keys: ["name"],
-      threshold: 0.4,
-      ignoreLocation: true,
-      minMatchCharLength: 2,
-    }
+    FUSE_CONFIG
   )
 
 const search = (q: string) =>
@@ -103,14 +106,7 @@ const compareByUpdated = (
 }
 
 const searchSorted = (q: string, sort: "latest" | "oldest") => {
-  const matches = new Fuse(DATED, {
-    keys: ["name"],
-    threshold: 0.4,
-    ignoreLocation: true,
-    minMatchCharLength: 2,
-  })
-    .search(q)
-    .map((hit) => hit.item)
+  const matches = new Fuse(DATED, FUSE_CONFIG).search(q).map((hit) => hit.item)
   matches.sort((a, b) => compareByUpdated(a, b, sort))
   return matches.map((m) => m.name)
 }

--- a/tests/lib/draft-fuzzy-search.test.ts
+++ b/tests/lib/draft-fuzzy-search.test.ts
@@ -75,3 +75,138 @@ describe("draft fuzzy search ranking", () => {
     expect(search("a")).toEqual([])
   })
 })
+
+/**
+ * The ordering half of `searchDrafts`. Matches are ordered by `sort`, and the
+ * comparator tie-breaks on id: search runs in two passes (match over a narrow
+ * projection of every draft, then hydrate the page by id), and those passes
+ * sort independently. Drafts saved in the same second share an `updatedAt`, so
+ * without the tiebreak the two sorts could disagree and the hydrated page would
+ * not be the slice that was actually paged to.
+ */
+const DATED = [
+  { id: "d1", name: "Emerald Alpha", updatedAt: "2026-01-03T00:00:00.000Z" },
+  { id: "d2", name: "Emerald Bravo", updatedAt: "2026-01-01T00:00:00.000Z" },
+  { id: "d3", name: "Emerald Charlie", updatedAt: "2026-01-02T00:00:00.000Z" },
+]
+
+const compareByUpdated = (
+  a: { id: string; updatedAt: string },
+  b: { id: string; updatedAt: string },
+  sort: "latest" | "oldest"
+) => {
+  const byDate =
+    sort === "oldest"
+      ? a.updatedAt.localeCompare(b.updatedAt)
+      : b.updatedAt.localeCompare(a.updatedAt)
+  return byDate !== 0 ? byDate : a.id.localeCompare(b.id)
+}
+
+const searchSorted = (q: string, sort: "latest" | "oldest") => {
+  const matches = new Fuse(DATED, {
+    keys: ["name"],
+    threshold: 0.4,
+    ignoreLocation: true,
+    minMatchCharLength: 2,
+  })
+    .search(q)
+    .map((hit) => hit.item)
+  matches.sort((a, b) => compareByUpdated(a, b, sort))
+  return matches.map((m) => m.name)
+}
+
+describe("draft search ordering", () => {
+  it("orders matches newest-first by default", () => {
+    expect(searchSorted("Emerald", "latest")).toEqual([
+      "Emerald Alpha",
+      "Emerald Charlie",
+      "Emerald Bravo",
+    ])
+  })
+
+  it("orders matches oldest-first when asked", () => {
+    expect(searchSorted("Emerald", "oldest")).toEqual([
+      "Emerald Bravo",
+      "Emerald Charlie",
+      "Emerald Alpha",
+    ])
+  })
+
+  it("changes the order without changing which drafts matched", () => {
+    const latest = searchSorted("Emerald", "latest")
+    const oldest = searchSorted("Emerald", "oldest")
+    expect([...oldest].sort()).toEqual([...latest].sort())
+    expect(oldest).not.toEqual(latest)
+  })
+})
+
+describe("draft search ordering — same-timestamp tiebreak", () => {
+  // Each page is its own request, re-running the sort over rows D1 returns in
+  // no guaranteed order. Tied drafts must land the same side of a page boundary
+  // every time or they get shown twice / skipped as the user pages.
+  const TIED = [
+    { id: "b", name: "Tied Draft", updatedAt: "2026-01-01T00:00:00.000Z" },
+    { id: "a", name: "Tied Draft", updatedAt: "2026-01-01T00:00:00.000Z" },
+    { id: "c", name: "Tied Draft", updatedAt: "2026-01-01T00:00:00.000Z" },
+  ]
+
+  it("orders identical timestamps deterministically, whatever the input order", () => {
+    for (const sort of ["latest", "oldest"] as const) {
+      const once = [...TIED].sort((a, b) => compareByUpdated(a, b, sort))
+      const again = [...TIED]
+        .reverse()
+        .sort((a, b) => compareByUpdated(a, b, sort))
+      expect(once.map((d) => d.id)).toEqual(["a", "b", "c"])
+      expect(again.map((d) => d.id)).toEqual(once.map((d) => d.id))
+    }
+  })
+
+  it("pages tied drafts without repeating or dropping one", () => {
+    const pageOf = (offset: number, limit: number) =>
+      [...TIED]
+        .sort((a, b) => compareByUpdated(a, b, "latest"))
+        .slice(offset, offset + limit)
+        .map((d) => d.id)
+
+    expect([...pageOf(0, 2), ...pageOf(2, 2)]).toEqual(["a", "b", "c"])
+  })
+})
+
+/**
+ * The hydrate pass. Order is decided once in the match pass; `IN (...)` returns
+ * the page in no particular order, so hydration replays the ranked id sequence
+ * instead of re-sorting. That keeps a single source of truth for order — a
+ * second sort would have to stay identical to the first forever.
+ */
+describe("draft search hydration", () => {
+  const hydrate = (pageIds: string[], rows: { id: string; name: string }[]) => {
+    const byId = new Map(rows.map((row) => [row.id, row]))
+    return pageIds
+      .map((id) => byId.get(id))
+      .filter((row) => row !== undefined)
+      .map((row) => row.name)
+  }
+
+  it("replays the ranked order regardless of the order rows come back in", () => {
+    const pageIds = ["c", "a", "b"]
+    const rows = [
+      { id: "a", name: "Alpha" },
+      { id: "b", name: "Bravo" },
+      { id: "c", name: "Charlie" },
+    ]
+    expect(hydrate(pageIds, rows)).toEqual(["Charlie", "Alpha", "Bravo"])
+    expect(hydrate(pageIds, [...rows].reverse())).toEqual([
+      "Charlie",
+      "Alpha",
+      "Bravo",
+    ])
+  })
+
+  it("drops an id deleted between the two queries rather than emitting a hole", () => {
+    const rows = [
+      { id: "a", name: "Alpha" },
+      { id: "c", name: "Charlie" },
+    ]
+    expect(hydrate(["c", "a", "b"], rows)).toEqual(["Charlie", "Alpha"])
+  })
+})

--- a/tests/lib/editor/animation-crop-frame.test.ts
+++ b/tests/lib/editor/animation-crop-frame.test.ts
@@ -130,3 +130,179 @@ describe("animated crop → CSS vars", () => {
     expect(el.style.getPropertyValue(VIEW_BOX)).toBe("")
   })
 })
+
+/**
+ * Fill-mode correction for an animated crop. The polyfill maps the crop window
+ * onto the shell with fill semantics, so contain/cover are corrected per frame
+ * from a live measurement — which means the measurement has to survive the
+ * export clone, where the `<video>` is swapped for an `<img>` stand-in.
+ */
+describe("animated crop → fill-mode correction", () => {
+  let el: HTMLElement
+
+  const mountShell = (media: HTMLElement, naturalW = 1920, naturalH = 1080) => {
+    const stage = document.createElement("div")
+    stage.style.width = "800px"
+    stage.style.height = "450px"
+    const shell = document.createElement("div")
+    shell.setAttribute("data-export-stack", "media")
+    Object.defineProperty(media, "videoWidth", { value: naturalW })
+    Object.defineProperty(media, "videoHeight", { value: naturalH })
+    Object.defineProperty(media, "naturalWidth", { value: naturalW })
+    Object.defineProperty(media, "naturalHeight", { value: naturalH })
+    shell.appendChild(media)
+    stage.appendChild(shell)
+    el.appendChild(stage)
+  }
+
+  beforeEach(() => {
+    useEditorStore.getState().reset()
+    el = document.createElement("div")
+    document.body.appendChild(el)
+  })
+
+  it("corrects the fit against a live <video>", () => {
+    mountShell(document.createElement("video"))
+    applyAt(el, [cropClip()], 1000)
+
+    expect(el.style.getPropertyValue("--crop-fit-origin")).not.toBe("")
+    expect(el.style.getPropertyValue("--crop-shell-w")).toBe("800px")
+  })
+
+  it("corrects the fit from seeded dims before the stand-in's first paint", () => {
+    // Frame 0 applies before any paint, so naturalWidth is still 0 — the swap
+    // seeds the source video's dims so the correction is not skipped.
+    const img = document.createElement("img")
+    const stage = document.createElement("div")
+    stage.style.width = "800px"
+    stage.style.height = "450px"
+    const shell = document.createElement("div")
+    shell.setAttribute("data-export-stack", "media")
+    img.dataset.naturalW = "1920"
+    img.dataset.naturalH = "1080"
+    shell.appendChild(img)
+    stage.appendChild(shell)
+    el.appendChild(stage)
+
+    applyAt(el, [cropClip()], 1000)
+    expect(el.style.getPropertyValue("--crop-shell-w")).toBe("800px")
+  })
+
+  it("corrects the fit against the export clone's <img> stand-in", () => {
+    // Regression: matching only `video` found nothing in the clone, so every
+    // exported frame lost the correction and the crop landed unfitted.
+    mountShell(document.createElement("img"))
+    applyAt(el, [cropClip()], 1000)
+
+    expect(el.style.getPropertyValue("--crop-fit-origin")).not.toBe("")
+    expect(el.style.getPropertyValue("--crop-shell-w")).toBe("800px")
+  })
+})
+
+/**
+ * A contain crop resizes the shell, and the bare placement centres the main
+ * screenshot on that size. Both are decided in the same pass, so the placement
+ * must use the size the crop IMPLIES, not one read back from the DOM — a
+ * measurement can only report the previous frame's box, which centres the card
+ * on a stale width and makes the crop appear to come in from one edge only.
+ */
+describe("animated crop \u2192 placement stays centred", () => {
+  let el: HTMLElement
+
+  const STAGE_W = 800
+  const STAGE_H = 450
+  // Trimmed left and right only: 60% of a 1920x1080 source is 1152x1080, so the
+  // contain box in an 800x450 stage is height-limited at 480x450.
+  const SIDE_CROP = { x: 20, y: 0, width: 60, height: 100 }
+  const EXPECTED_SHELL_W = 480
+
+  const mount = () => {
+    const stage = document.createElement("div")
+    stage.style.width = `${STAGE_W}px`
+    stage.style.height = `${STAGE_H}px`
+    const shell = document.createElement("div")
+    shell.setAttribute("data-export-stack", "media")
+    shell.setAttribute("data-editor-shadow-box-target", "")
+    // The DOM still reports the pre-crop width, as it does mid-animation.
+    Object.defineProperty(shell, "offsetWidth", { value: STAGE_W })
+    Object.defineProperty(shell, "offsetHeight", { value: STAGE_H })
+    const img = document.createElement("img")
+    img.dataset.naturalW = "1920"
+    img.dataset.naturalH = "1080"
+    shell.appendChild(img)
+    stage.appendChild(shell)
+    el.appendChild(stage)
+  }
+
+  beforeEach(() => {
+    useEditorStore.getState().reset()
+    // The bare-pixel placement only runs for a free-floating main screenshot.
+    useEditorStore
+      .getState()
+      .setScreenshot("data:image/png;base64,iVBORw0KGgo=")
+    el = document.createElement("div")
+    document.body.appendChild(el)
+  })
+
+  const sideCropClip = (effects: string[]) => {
+    const pose = captureClipPose(baseCanvas())
+    return {
+      id: "clip-side-crop",
+      startMs: 0,
+      durationMs: 1000,
+      effects,
+      easing: "linear",
+      baseline: { ...pose, crop: FULL_CROP_REGION },
+      pose: { ...pose, crop: SIDE_CROP },
+    } as AnimationClip
+  }
+
+  it("re-centres a crop-only clip, which never touches position", () => {
+    // The committed `left` is a px value React baked from the uncropped box.
+    // An export clone is static and cannot recompute it, so unless the crop
+    // drives the placement the shell shrinks about a frozen left edge.
+    mount()
+    applyAt(el, [sideCropClip(["crop"])], 1000)
+
+    expect(el.style.getPropertyValue("--crop-shell-w")).toBe(
+      `${EXPECTED_SHELL_W}px`
+    )
+    const left = parseFloat(
+      el.style.getPropertyValue("--editor-main-bare-left")
+    )
+    expect(left).not.toBeNaN()
+    expect(left).toBeCloseTo((STAGE_W - EXPECTED_SHELL_W) / 2, 0)
+  })
+
+  it("centres on the crop's shell box, not the stale measured width", () => {
+    mount()
+    const canvas = baseCanvas()
+    const pose = captureClipPose(canvas)
+    applyAt(
+      el,
+      [
+        {
+          id: "clip-side-crop",
+          startMs: 0,
+          durationMs: 1000,
+          effects: ["crop", "position"],
+          easing: "linear",
+          baseline: { ...pose, crop: FULL_CROP_REGION },
+          pose: { ...pose, crop: SIDE_CROP },
+        },
+      ],
+      1000
+    )
+
+    // The crop narrowed the shell...
+    expect(el.style.getPropertyValue("--crop-shell-w")).toBe(
+      `${EXPECTED_SHELL_W}px`
+    )
+    // ...and the placement centred on THAT width, not the 800px still in the DOM.
+    const left = parseFloat(
+      el.style.getPropertyValue("--editor-main-bare-left")
+    )
+    expect(left).not.toBeNaN()
+    expect(left).toBeCloseTo((STAGE_W - EXPECTED_SHELL_W) / 2, 0)
+  })
+})

--- a/tests/lib/editor/animation-crop-frame.test.ts
+++ b/tests/lib/editor/animation-crop-frame.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { applyAnimationFrameAtTime } from "@/lib/editor/apply-animation-frame"
+import { FULL_CROP_REGION } from "@/lib/editor/animation-playback"
+import { captureClipPose, useEditorStore } from "@/lib/editor/store"
+import type { AnimationClip, CanvasState } from "@/lib/editor/state-types"
+
+/**
+ * The CSS vars an animated crop drives. Both render paths get a var because
+ * browser support for `object-view-box` differs: Chromium reads --crop-view-box,
+ * the Firefox/Safari polyfill reads the four box metrics. See `crop-utils.ts`.
+ */
+const VIEW_BOX = "--crop-view-box"
+const METRICS = ["--crop-w", "--crop-h", "--crop-left", "--crop-top"] as const
+
+const baseCanvas = (): CanvasState => {
+  const s = useEditorStore.getState().present
+  return s.canvases.find((c) => c.id === s.activeCanvasId)!
+}
+
+const cropClip = (over: Partial<AnimationClip> = {}): AnimationClip => {
+  const canvas = baseCanvas()
+  return {
+    id: "clip-crop",
+    startMs: 0,
+    durationMs: 1000,
+    effects: ["crop"],
+    easing: "linear",
+    baseline: { ...captureClipPose(canvas), crop: FULL_CROP_REGION },
+    pose: {
+      ...captureClipPose(canvas),
+      crop: { x: 20, y: 20, width: 60, height: 60 },
+    },
+    ...over,
+  }
+}
+
+const applyAt = (el: HTMLElement, clips: AnimationClip[], timeMs: number) =>
+  applyAnimationFrameAtTime({
+    canvasEl: el,
+    canvas: baseCanvas(),
+    globalAspect: { id: "auto", w: 16, h: 9 },
+    clips,
+    timeMs,
+  })
+
+describe("animated crop → CSS vars", () => {
+  let el: HTMLElement
+
+  beforeEach(() => {
+    useEditorStore.getState().reset()
+    el = document.createElement("div")
+    document.body.appendChild(el)
+  })
+
+  it("writes every crop var so both render paths follow the animation", () => {
+    applyAt(el, [cropClip()], 1000)
+
+    expect(el.style.getPropertyValue(VIEW_BOX)).toBe("inset(20% 20% 20% 20%)")
+    for (const name of METRICS) {
+      expect(el.style.getPropertyValue(name)).not.toBe("")
+    }
+  })
+
+  it("starts from the full frame when the clip reveals from uncropped", () => {
+    applyAt(el, [cropClip()], 0)
+
+    // Progress 0 → the baseline's full-frame rect, i.e. no visible crop.
+    expect(el.style.getPropertyValue(VIEW_BOX)).toBe("inset(0% 0% 0% 0%)")
+    expect(el.style.getPropertyValue("--crop-w")).toBe("100%")
+    expect(el.style.getPropertyValue("--crop-left")).toBe("0%")
+  })
+
+  it("eases the source rect through the middle of the clip", () => {
+    applyAt(el, [cropClip()], 500)
+
+    // Linear easing, halfway: x/y 0→20 lands on 10, width/height 100→60 on 80.
+    expect(el.style.getPropertyValue(VIEW_BOX)).toBe("inset(10% 10% 10% 10%)")
+  })
+
+  it("holds the last crop past the end of the clip", () => {
+    const clips = [cropClip()]
+    applyAt(el, clips, 1000)
+    const atEnd = el.style.getPropertyValue(VIEW_BOX)
+
+    applyAt(el, clips, 9999)
+
+    // Hold semantics: a crop persists until another clip changes it, matching
+    // every other animated property.
+    expect(el.style.getPropertyValue(VIEW_BOX)).toBe(atEnd)
+  })
+
+  it("chains from one crop clip to the next instead of snapping back", () => {
+    const first = cropClip()
+    const second: AnimationClip = {
+      ...cropClip(),
+      id: "clip-crop-2",
+      startMs: 1000,
+      durationMs: 1000,
+      pose: {
+        ...captureClipPose(baseCanvas()),
+        crop: FULL_CROP_REGION,
+      },
+    }
+
+    applyAt(el, [first, second], 1500)
+
+    // Halfway back out: 20 → 0 lands on 10, not an instant jump to uncropped.
+    expect(el.style.getPropertyValue(VIEW_BOX)).toBe("inset(10% 10% 10% 10%)")
+  })
+
+  it("clears every crop var when no clip animates the crop", () => {
+    applyAt(el, [cropClip()], 1000)
+    expect(el.style.getPropertyValue(VIEW_BOX)).not.toBe("")
+
+    const noCrop: AnimationClip = { ...cropClip(), effects: ["padding"] }
+    applyAt(el, [noCrop], 1000)
+
+    // A stale var would keep cropping the media after the effect is removed.
+    expect(el.style.getPropertyValue(VIEW_BOX)).toBe("")
+    for (const name of METRICS) {
+      expect(el.style.getPropertyValue(name)).toBe("")
+    }
+  })
+
+  it("clears the crop vars when the timeline has no clips at all", () => {
+    applyAt(el, [cropClip()], 1000)
+    applyAt(el, [], 1000)
+
+    expect(el.style.getPropertyValue(VIEW_BOX)).toBe("")
+  })
+})

--- a/tests/lib/editor/animation-export/webkit-layered-frame.test.ts
+++ b/tests/lib/editor/animation-export/webkit-layered-frame.test.ts
@@ -1,4 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest"
+import type * as FrameCanvasUtils from "@/lib/editor/animation-export/video-media/frame-canvas-utils"
 
 const mocks = vi.hoisted(() => ({
   supportsObjectViewBox: vi.fn(),
@@ -37,10 +46,7 @@ vi.mock("@/lib/editor/animation-export/video-media/export-stack", () => ({
 vi.mock(
   "@/lib/editor/animation-export/video-media/frame-canvas-utils",
   async (importOriginal) => {
-    const actual =
-      await importOriginal<
-        typeof import("@/lib/editor/animation-export/video-media/frame-canvas-utils")
-      >()
+    const actual = await importOriginal<typeof FrameCanvasUtils>()
     return { ...actual, sleep: () => Promise.resolve() }
   }
 )
@@ -97,7 +103,7 @@ function makeNode(): HTMLElement {
 function makeCapture(
   pixels: number[],
   size: { width: number; height: number } = { width: 1080, height: 675 }
-): AnimationCapture & { captureFrame: ReturnType<typeof vi.fn> } {
+): AnimationCapture & { captureFrame: Mock<AnimationCapture["captureFrame"]> } {
   let call = 0
   return {
     node: makeNode(),
@@ -410,6 +416,32 @@ describe("captureLayeredAnimationFrame — caches", () => {
     capture.node.style.setProperty("--canvas-bd-radius", "24px")
     await captureLayeredAnimationFrame(capture, OPTS)
     expect(capture.captureFrame).toHaveBeenCalledTimes(4)
+  })
+
+  it("holds the underlay across an animated crop", async () => {
+    // Every crop var is recomputed per frame, the fit-correction ones included.
+    // If any leaks into the key the underlay rebuilds on every frame of a crop
+    // animation — the exact cost this cache exists to avoid.
+    const capture = makeCapture([10, 10])
+    await captureLayeredAnimationFrame(capture, OPTS)
+    expect(capture.captureFrame).toHaveBeenCalledTimes(2)
+
+    for (const [prop, value] of [
+      ["--crop-view-box", "0 0 0.5 0.5"],
+      ["--crop-w", "50%"],
+      ["--crop-h", "50%"],
+      ["--crop-left", "10%"],
+      ["--crop-top", "10%"],
+      ["--crop-shell-w", "640px"],
+      ["--crop-shell-h", "360px"],
+      ["--crop-fit-sx", "1.25"],
+      ["--crop-fit-sy", "1.25"],
+      ["--crop-fit-origin", "25% 40%"],
+    ]) {
+      capture.node.style.setProperty(prop, value)
+      await captureLayeredAnimationFrame(capture, OPTS)
+      expect(capture.captureFrame).toHaveBeenCalledTimes(2)
+    }
   })
 
   it("recaptures the shell texture when its scope vars change", async () => {

--- a/tests/lib/editor/animation-playback.test.ts
+++ b/tests/lib/editor/animation-playback.test.ts
@@ -9,9 +9,11 @@ import {
   clipAffectsSlot,
   clipTargetOf,
   clipsProgressAt,
+  cropRegionBetween,
   DEFAULT_BASELINE,
   EMPTY_FILTER_STACK,
   filtersDiffer,
+  FULL_CROP_REGION,
   INVISIBLE_BORDER,
   lerp,
   resolveAnimateFilterStack,
@@ -419,5 +421,34 @@ describe("backgroundsDiffer", () => {
     }
     // Same sourceUrl, different preview value → NOT different.
     expect(backgroundsDiffer(a, b)).toBe(false)
+  })
+})
+
+describe("cropRegionBetween", () => {
+  const from = { x: 0, y: 0, width: 100, height: 100 }
+  const to = { x: 20, y: 10, width: 50, height: 60 }
+
+  it("eases every edge of the source rect", () => {
+    expect(cropRegionBetween(from, to, 0)).toEqual(from)
+    expect(cropRegionBetween(from, to, 1)).toEqual(to)
+    expect(cropRegionBetween(from, to, 0.5)).toEqual({
+      x: 10,
+      y: 5,
+      width: 75,
+      height: 80,
+    })
+  })
+
+  it("reveals from the full frame when a pose carries no crop", () => {
+    expect(FULL_CROP_REGION).toEqual({ x: 0, y: 0, width: 100, height: 100 })
+    // A clip with no captured crop must read as "uncropped", not as a zero rect.
+    expect(cropRegionBetween(FULL_CROP_REGION, to, 0)).toEqual(FULL_CROP_REGION)
+  })
+
+  it("holds the last crop past the end of the timeline", () => {
+    const frames = [{ startMs: 0, durationMs: 100, value: to }]
+    expect(
+      sampleKeyframes(frames, 500, FULL_CROP_REGION, cropRegionBetween)
+    ).toEqual(to)
   })
 })

--- a/tests/lib/editor/crop-utils.test.ts
+++ b/tests/lib/editor/crop-utils.test.ts
@@ -3,8 +3,15 @@ import { describe, expect, it } from "vitest"
 import {
   computeCoverCropRegion,
   computeCoverCropRegionForAspect,
+  CROP_ANIMATION_VARS,
+  CROP_FIT_ORIGIN_VAR,
+  CROP_FIT_SX_VAR,
+  CROP_SHELL_W_VAR,
+  CROP_VIEW_BOX_VAR,
   cropMediaObjectStyle,
   cropObjectMetrics,
+  cropOriginCss,
+  cropRegionRatio,
   cropRegionMatchesAspect,
   cropViewBoxValue,
   croppedNaturalSize,
@@ -117,5 +124,48 @@ describe("crop utils", () => {
 
   it("reports object-view-box support as a boolean", () => {
     expect(typeof supportsObjectViewBox()).toBe("boolean")
+  })
+})
+
+describe("animated crop fit helpers", () => {
+  it("derives the window's ratio from the region AND the natural size", () => {
+    // Half-width of a 1920x1080 source is 960x1080 → 8:9, not the source's 16:9.
+    expect(
+      cropRegionRatio({ x: 0, y: 0, width: 50, height: 100 }, 1920, 1080)
+    ).toBeCloseTo(960 / 1080, 6)
+    // A square window on a wide source really is square.
+    expect(
+      cropRegionRatio({ x: 0, y: 0, width: 56.25, height: 100 }, 1920, 1080)
+    ).toBeCloseTo(1, 3)
+  })
+
+  it("returns null for a degenerate region rather than a bogus ratio", () => {
+    expect(
+      cropRegionRatio({ x: 0, y: 0, width: 0, height: 50 }, 100, 100)
+    ).toBe(null)
+    expect(cropRegionRatio({ x: 0, y: 0, width: 50, height: 50 }, 0, 100)).toBe(
+      null
+    )
+  })
+
+  it("pivots a fit scale on the window's centre", () => {
+    expect(cropOriginCss({ x: 20, y: 10, width: 40, height: 60 })).toBe(
+      "40% 40%"
+    )
+    expect(cropOriginCss({ x: 0, y: 0, width: 100, height: 100 })).toBe(
+      "50% 50%"
+    )
+  })
+
+  it("clears every crop var it can set", () => {
+    // A var left behind would keep cropping after the effect is removed.
+    for (const name of [
+      CROP_VIEW_BOX_VAR,
+      CROP_SHELL_W_VAR,
+      CROP_FIT_SX_VAR,
+      CROP_FIT_ORIGIN_VAR,
+    ]) {
+      expect(CROP_ANIMATION_VARS).toContain(name)
+    }
   })
 })

--- a/tests/lib/editor/crop-utils.test.ts
+++ b/tests/lib/editor/crop-utils.test.ts
@@ -4,7 +4,9 @@ import {
   computeCoverCropRegion,
   computeCoverCropRegionForAspect,
   cropMediaObjectStyle,
+  cropObjectMetrics,
   cropRegionMatchesAspect,
+  cropViewBoxValue,
   croppedNaturalSize,
   insetCropRegion,
   isActiveCropRegion,
@@ -62,14 +64,27 @@ describe("crop utils", () => {
       cropMediaObjectStyle({ x: 25, y: 10, width: 50, height: 80 })
     ).toEqual({
       position: "absolute",
-      width: "200%",
-      height: "125%",
-      left: "-50%",
-      top: "-12.5%",
+      width: "var(--crop-w, 200%)",
+      height: "var(--crop-h, 125%)",
+      left: "var(--crop-left, -50%)",
+      top: "var(--crop-top, -12.5%)",
       maxWidth: "none",
       maxHeight: "none",
       objectFit: "fill",
     })
+  })
+
+  // The animated-crop vars carry bare values; the styles wrap them as fallbacks.
+  it("exposes bare crop metrics for the animation player to write", () => {
+    expect(cropObjectMetrics({ x: 25, y: 10, width: 50, height: 80 })).toEqual({
+      width: "200%",
+      height: "125%",
+      left: "-50%",
+      top: "-12.5%",
+    })
+    expect(cropViewBoxValue({ x: 10, y: 20, width: 40, height: 50 })).toBe(
+      "inset(20% 50% 30% 10%)"
+    )
   })
 
   it("treats near-full regions as inactive crops", () => {
@@ -90,7 +105,7 @@ describe("crop utils", () => {
   it("picks object-view-box styles when native support is available", () => {
     const region = { x: 10, y: 20, width: 40, height: 50 }
     expect(objectViewBoxCropStyle(region)).toEqual({
-      objectViewBox: "inset(20% 50% 30% 10%)",
+      objectViewBox: "var(--crop-view-box, inset(20% 50% 30% 10%))",
     })
     expect(videoCropMediaStyle(region, true)).toEqual(
       objectViewBoxCropStyle(region)

--- a/tests/lib/editor/store/animation-crop.test.ts
+++ b/tests/lib/editor/store/animation-crop.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { useEditorStore } from "@/lib/editor/store"
+import type { CropRegion } from "@/lib/editor/state-types"
+
+/**
+ * Per-keyframe video crop. Crop is an ordinary `AnimationEffect`, so it inherits
+ * the pose-chain model: editing it with a clip open claims the effect on THAT
+ * clip, and the value lands in the clip's pose when the selection moves on (the
+ * open clip's live edits live on the canvas until then — same as padding/zoom).
+ * See `animation-playback.test.ts` for the interpolation and hold-past-end.
+ */
+const store = useEditorStore
+
+const activeCanvas = () => {
+  const s = store.getState().present
+  return s.canvases.find((c) => c.id === s.activeCanvasId)!
+}
+const clips = () => activeCanvas().animation!.clips
+const clipById = (id: string) => clips().find((c) => c.id === id)
+const addClips = (n: number) =>
+  Array.from({ length: n }, () => store.getState().addAnimationClip())
+
+const TIGHT: CropRegion = { x: 20, y: 10, width: 50, height: 60 }
+const WIDE: CropRegion = { x: 5, y: 5, width: 90, height: 90 }
+
+describe("per-keyframe video crop", () => {
+  beforeEach(() => store.getState().reset())
+
+  it("claims the crop effect on the open clip", () => {
+    const [a] = addClips(1)
+    store.getState().setIsAnimateMode(true)
+    store.getState().selectAnimationClip(a)
+
+    store.getState().setScreenshotCropRegion(TIGHT)
+
+    expect(clipById(a)!.effects).toContain("crop")
+    expect(activeCanvas().lastCropRegion).toEqual(TIGHT)
+  })
+
+  it("persists the crop into the clip's pose once the selection moves on", () => {
+    const [a, b] = addClips(2)
+    store.getState().setIsAnimateMode(true)
+    store.getState().selectAnimationClip(a)
+    store.getState().setScreenshotCropRegion(TIGHT)
+
+    store.getState().selectAnimationClip(b)
+
+    expect(clipById(a)!.pose?.crop).toEqual(TIGHT)
+  })
+
+  it("keeps each clip's crop independent", () => {
+    const [a, b] = addClips(2)
+    store.getState().setIsAnimateMode(true)
+
+    store.getState().selectAnimationClip(a)
+    store.getState().setScreenshotCropRegion(TIGHT)
+    store.getState().selectAnimationClip(b)
+    store.getState().setScreenshotCropRegion(WIDE)
+    store.getState().selectAnimationClip(null)
+
+    // The whole point of the feature: cropping on b must not reach back into a.
+    expect(clipById(a)!.pose?.crop).toEqual(TIGHT)
+    expect(clipById(b)!.pose?.crop).toEqual(WIDE)
+  })
+
+  it("restores a clip's crop onto the canvas when that clip is reopened", () => {
+    const [a, b] = addClips(2)
+    store.getState().setIsAnimateMode(true)
+
+    store.getState().selectAnimationClip(a)
+    store.getState().setScreenshotCropRegion(TIGHT)
+    store.getState().selectAnimationClip(b)
+    store.getState().setScreenshotCropRegion(WIDE)
+
+    store.getState().selectAnimationClip(a)
+    expect(activeCanvas().lastCropRegion).toEqual(TIGHT)
+    store.getState().selectAnimationClip(b)
+    expect(activeCanvas().lastCropRegion).toEqual(WIDE)
+  })
+
+  it("stays a plain committed edit when no keyframe is open", () => {
+    const [a] = addClips(1)
+    store.getState().setIsAnimateMode(true)
+    store.getState().selectAnimationClip(null)
+
+    store.getState().setScreenshotCropRegion(TIGHT)
+
+    expect(activeCanvas().lastCropRegion).toEqual(TIGHT)
+    expect(clipById(a)!.effects ?? []).not.toContain("crop")
+  })
+
+  it("stays a plain committed edit outside animate mode", () => {
+    const [a] = addClips(1)
+    store.getState().setIsAnimateMode(false)
+
+    store.getState().setScreenshotCropRegion(TIGHT)
+
+    expect(activeCanvas().lastCropRegion).toEqual(TIGHT)
+    expect(clipById(a)!.effects ?? []).not.toContain("crop")
+  })
+
+  it("records a cleared crop rather than keeping the stale rect", () => {
+    const [a, b] = addClips(2)
+    store.getState().setIsAnimateMode(true)
+    store.getState().selectAnimationClip(a)
+
+    store.getState().setScreenshotCropRegion(TIGHT)
+    store.getState().setScreenshotCropRegion(null)
+    store.getState().selectAnimationClip(b)
+
+    // Reopening the clip must not resurrect a crop the user removed.
+    expect(clipById(a)!.pose?.crop ?? null).toBeNull()
+    store.getState().selectAnimationClip(a)
+    expect(activeCanvas().lastCropRegion).toBeNull()
+  })
+
+  it("drops the crop effect when a clip's effects are cleared", () => {
+    const [a] = addClips(1)
+    store.getState().setIsAnimateMode(true)
+    store.getState().selectAnimationClip(a)
+    store.getState().setScreenshotCropRegion(TIGHT)
+
+    store.getState().clearAnimationClipsEffects([a])
+
+    expect(clipById(a)!.effects).toEqual([])
+  })
+
+  it("writes only crop into a multi-selection, leaving sibling pose fields", () => {
+    const [a, b] = addClips(2)
+    store.getState().setIsAnimateMode(true)
+
+    // Give each clip its own padding first, then crop them together.
+    store.getState().selectAnimationClip(a)
+    store.getState().setPadding(120)
+    store.getState().selectAnimationClip(b)
+    store.getState().setPadding(200)
+
+    store.getState().setAnimationClipSelection([a, b])
+    store.getState().setScreenshotCropRegion(TIGHT)
+
+    expect(clipById(a)!.pose?.crop).toEqual(TIGHT)
+    expect(clipById(b)!.pose?.crop).toEqual(TIGHT)
+    // Each clip keeps the padding it already had.
+    expect(clipById(a)!.pose?.padding).toBe(120)
+    expect(clipById(b)!.pose?.padding).toBe(200)
+  })
+})

--- a/tests/lib/schemas/draft.test.ts
+++ b/tests/lib/schemas/draft.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   DRAFT_NAME_MAX_LENGTH,
   countCanvasesInDraftState,
+  draftListQuerySchema,
   parseDraftSaveBody,
   resolveDraftType,
   unwrapDraftState,
@@ -137,5 +138,33 @@ describe("draft schema helpers", () => {
         ui: {},
       })
     ).toBe("animate")
+  })
+})
+
+describe("draftListQuerySchema search", () => {
+  const parse = (over: Record<string, unknown> = {}) =>
+    draftListQuerySchema.parse({ ...over })
+
+  it("passes a trimmed query through", () => {
+    expect(parse({ q: "  beach clip " }).q).toBe("beach clip")
+  })
+
+  it("treats blank and whitespace-only queries as no search", () => {
+    // An empty `q` must become undefined, not "", or the DB layer would build a
+    // LIKE '%%' filter and silently paginate a different result set.
+    expect(parse({ q: "" }).q).toBeUndefined()
+    expect(parse({ q: "   " }).q).toBeUndefined()
+    expect(parse().q).toBeUndefined()
+  })
+
+  it("rejects an over-long query instead of building a huge LIKE", () => {
+    expect(
+      parse({ q: "a".repeat(DRAFT_NAME_MAX_LENGTH + 50) }).q
+    ).toBeUndefined()
+  })
+
+  it("keeps the type filter optional so a search can span every kind", () => {
+    expect(parse({ q: "x" }).type).toBeUndefined()
+    expect(parse({ q: "x", type: "animate" }).type).toBe("animate")
   })
 })


### PR DESCRIPTION
## Summary

Started as a one-line fix for backdrop Effects sliders not previewing live, and grew from there as testing surfaced adjacent bugs in the same area. Three strands:

1. **Animated video crop** — a new per-keyframe `crop` effect, plus the fill-mode and layout correctness work it exposed.
2. **Open project dialog** — typo-tolerant search, an in-field scope filter, mobile/iPad layout, and a rename.
3. **Fixes found along the way** — a CSS-var preview bug, a measurement feedback loop, and two `object-fit` bugs on cropped video that predate this branch.

Heads-up on history: `0d421b0` is titled "integrate fuzzy search" but actually carries most of the branch (crop animation, the `canvas-view` split, the dialog work). Worth knowing when reading commits.

## Type of Change

- [x] fix
- [x] refactor
- [ ] delete
- [ ] optimised
- [ ] docs

Also adds one feature (per-keyframe crop) — no checkbox for that.

## Related Issues

None.

## Changes Made

### Per-keyframe video crop

`crop` joins `AnimationEffect`, so it inherits the existing pose-chain model: editing with a clip open claims the effect on that clip, the value lands in its pose on selection change, and it **holds** past the clip until another changes it — same as every other property. Video crop was already non-destructive (a percentage rect rendered via CSS), so no re-encode was needed.

Two decisions worth review:

- **The media box never resizes.** `visibleNaturalDims` is pinned to full natural size while a crop animates. Sizing the box from the crop would make the auto aspect — and so the encoder's frame size — depend on which keyframe happened to be selected at export time, and change mid-render.
- **WebKit export bails to the raster renderer** when a crop animates. `createCompositeRenderer` calls `measureVideoRegion` once at setup and reuses that rect for every frame, so an animated crop would have frozen on frame one. Chromium already uses the DOM path and is unaffected. **Expect slower WebKit exports for this case.**

### Fill mode on cropped video (two pre-existing bugs)

The crop polyfill maps the window onto the media shell *exactly* — `fill` semantics baked into the mechanism — so the shell's rendered ratio **is** the picture's ratio.

- **Contain** was styled `width:100% + height:auto + max-height:100% + aspect-ratio`. When the crop is taller than the stage, `max-height` clamps while the explicit width holds, so the box silently ends up wider than its own aspect ratio and the picture shears. Now computed in pixels via `fitContainBox`.
- **Cover** gets `h-full w-full`, making both dimensions definite, so its inline `aspect-ratio` was ignored entirely and the window stretched to the stage's ratio. Now corrected with a scale transform about the window's centre.
- **Fill** was already correct — stretching into the box is its definition.

Because the window's aspect can change every frame, the correction is recomputed per frame in `applyCropFitVars` and driven through CSS vars (`--crop-shell-w/h`, `--crop-fit-sx/sy`, `--crop-fit-origin`), each with the committed value as fallback.

### Backdrop effects live preview

The layer only carried the `--bd-fx-preview` filter var when the committed effects were already non-neutral, so dragging a slider from its default did nothing until release. It now always reads the var, with a `brightness(1)` identity fallback — `none` can't sit beside an asset-filter function in one `filter`, and that combination was silently dropping the whole declaration in the animate path.

### Placement measurement feedback loop

Contain shells are sized **from** `placementDims`, so a stale measurement pinned the box, the `ResizeObserver` could never fire, and nothing re-measured. Dropping a video onto a previously-cropped image left it rendering in the image's box until a reload. The hook now drops its measurement in the same render the layout key changes, and the key includes the media's natural dims so a swap actually moves it.

### Open project dialog

- Fuzzy search via `fuse.js`, ranked server-side over a bounded candidate set (D1 has no trigram index or edit-distance function). Ranking happens before pagination so page 2 is the genuine next-best matches. `threshold: 0.4` and `ignoreLocation: true` are both load-bearing and pinned by tests.
- Scope filter (All / Screenshots / Videos / Animate) lives inside the search field and is always visible; searching spans all types by default.
- Responsive: rail becomes a horizontal strip on narrow, grid is 1 / 2 / 3 columns, 3-up only from `xl` so both iPad orientations get 2.
- **"Present" renamed to "Screenshots"** throughout the dialog. It collided with the app's preset system (`present-presets.ts`) and read as "presets" rather than "static screenshot project". The stored type is still `style` — labels only, no migration.

### Refactor

`canvas-view.tsx` 1635 → ~1390 lines, three contiguous hook blocks extracted (`use-animate-stacks`, `use-background-downscale`, `use-canvas-media-intake`). No JSX moved and hook order is preserved, because export finds elements by DOM structure and `data-*` attributes.

## Screenshots / Recordings (if UI)

Not attached.

## Checklist

- [x] I ran `pnpm lint` — 0 errors, 33 pre-existing warnings
- [x] I ran `pnpm typecheck` — clean
- [x] I ran `pnpm test` — 944 passing, 134 files (~45 added this branch)
- [x] I did not include secrets or sensitive data
- [ ] I updated docs when behavior changed — `CLAUDE.md` still lists the old `AnimationEffect` union and doesn't mention the crop effect
- [ ] I kept this PR focused and reasonably small — it isn't; see below

## Reviewer notes

**Not focused.** Three unrelated strands on a branch named `fix/backdrop-effects-live-preview`. It grew as testing surfaced adjacent bugs. Splitting it is reasonable to ask for.

**Not verified in a browser.** Everything here is backed by typecheck, lint and unit tests only. The layout and export changes need real eyes. Highest risk first:

1. **Animated crop export, Contain and Cover, on both Chromium and WebKit.** `applyAnimationFrameAtTime` is shared by playback and the exporter, so `applyCropFitVars` measures the offscreen export clone too. If the clone measures differently from the editor, exported framing will disagree with the preview.
2. **Cover + crop export.** `--crop-fit-sx/sy` puts a 2D scale on the `<video>`, and `resolveTransformCarrier` / `projectElementQuad` inspect transforms on that subtree.
3. **Media swaps** — video → image and between videos of different aspects, all through the same measurement path as the fixed bug.
4. **Tall vs wide crops** in each fill mode.

**Known gap.** `applyCropFitVars` measures the live DOM (natural size and stage box exist nowhere in state). A missing measurement clears the vars rather than guessing, falling back to committed styles — correct at the open keyframe, approximate elsewhere.

**Dependency note.** `pnpm add fuse.js` also printed `- ogv 1.9.0`. `ogv` was never in `package.json` and is never imported — the dav1d decoder is a *vendored* wrapper derived from ogv.js, not the npm package — so pnpm pruned an orphan from `node_modules`. `git diff package.json` shows only `fuse.js` added. Worth a sanity check on AV1 export anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fuzzy, typo-tolerant search for drafts.
  * Enhanced project name search with a multi-scope selector across project types.
  * Added timeline crop icon support and improved per-clip animated video cropping.
  * Improved canvas media intake for screenshots, demo images, and tweet cards.
* **Bug Fixes**
  * Corrected cropped video sizing/positioning and animation crop aspect/placement.
  * Prevented backdrop preview filters from reverting at neutral settings; improved filter fallback behavior.
  * Improved remeasurement after intrinsic dimension changes and reduced crop-animation re-rendering.
* **Tests**
  * Expanded coverage for fuzzy search, crop rendering, placement measurement, backdrop previews, and canvas sizing helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves animated crop rendering, backdrop previews, media layout, and project search. The main changes are:

- Adds per-keyframe video crop playback and export support.
- Corrects contain and cover layout for cropped videos.
- Fixes live backdrop-effect previews and media remeasurement.
- Adds fuzzy project search, scope filters, and responsive dialog layouts.
- Extracts canvas hooks without changing the rendered structure.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The cleared-crop state now survives clip pose capture and restoration.
- Search ranking now runs over the complete filtered draft population before pagination.
- No blocking issue related to the earlier findings remains in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/editor/store.tsx | Preserves an explicitly cleared crop while keeping absent crop fields compatible with older saved poses. |
| lib/editor/state-types.ts | Extends animation pose data so crop clearing can be represented explicitly. |
| lib/draft-db.ts | Ranks the complete filtered draft set before deterministic sorting, pagination, and row hydration. |
| app/api/drafts/route.ts | Routes search requests through the fuzzy-search result and count path. |
| lib/editor/apply-animation-frame.ts | Applies animated crop geometry to playback and export media while updating crop-driven placement. |

<sub>Reviews (2): Last reviewed commit: ["fix: make an animated crop export the wa..."](https://github.com/shivabhattacharjee/tokokino/commit/a608ed70261601471a460a3ea40d5a6ee3814995) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45931948)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/sideprojects/github/ShivaBhattacharjee/tokokino/-/custom-context?memory=7a22f059-86c3-428b-88f5-f28e5fb51882))
- Context used - agents.md ([source](https://app.greptile.com/sideprojects/github/ShivaBhattacharjee/tokokino/-/custom-context?memory=0b3651fa-1db4-4837-8570-4aaf8d2a4cc2))

<!-- /greptile_comment -->