### PR TITLE
Animation clips return to default, and crop previews the frame you're on

### DIFF
--- a/components/editor/animate/clip-transition-toolbar.tsx
+++ b/components/editor/animate/clip-transition-toolbar.tsx
@@ -207,7 +207,9 @@ function TransitionPanel({
         <div className="flex flex-col">
           <span className="text-[11px] text-foreground">Return to default</span>
           <span className="text-[10px] text-muted-foreground">
-            Unwinds over {activeMs}ms after the clip
+            {returns
+              ? `Unwinds over ${activeMs}ms after the clip`
+              : "Holds its pose after the clip"}
           </span>
         </div>
         <Switch

--- a/components/editor/animate/clip-transition-toolbar.tsx
+++ b/components/editor/animate/clip-transition-toolbar.tsx
@@ -9,10 +9,12 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 import { Slider } from "@/components/ui/slider"
+import { Switch } from "@/components/ui/switch"
 import {
   CLIP_EASING_KINDS,
   CLIP_EASING_LABELS,
   clipEasingKind,
+  clipReturnsToDefault,
   clipSpeed,
   DEFAULT_CLIP_EASING,
   DEFAULT_CLIP_SPEED,
@@ -96,8 +98,14 @@ function TransitionPanel({
   const speed = clipSpeed(clip)
   const [hovered, setHovered] = React.useState<ClipEasingKind | null>(null)
 
+  const returns = clipReturnsToDefault(clip)
+
   const reset = () =>
-    onUpdate({ easing: DEFAULT_CLIP_EASING, speed: DEFAULT_CLIP_SPEED })
+    onUpdate({
+      easing: DEFAULT_CLIP_EASING,
+      speed: DEFAULT_CLIP_SPEED,
+      returnToDefault: true,
+    })
 
   // The slider is driven by the effective transition duration in ms, not the raw
   // speed multiplier: RIGHT (max) = the full clip window (speed 1), and dragging
@@ -192,6 +200,21 @@ function TransitionPanel({
           step={1}
           aria-label="Transition speed"
           onValueChange={([v]) => onSpeedMs(v)}
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-2 pt-0.5">
+        <div className="flex flex-col">
+          <span className="text-[11px] text-foreground">Return to default</span>
+          <span className="text-[10px] text-muted-foreground">
+            Unwinds over {activeMs}ms after the clip
+          </span>
+        </div>
+        <Switch
+          size="sm"
+          checked={returns}
+          aria-label="Return to default after the clip"
+          onCheckedChange={(v) => onUpdate({ returnToDefault: v })}
         />
       </div>
     </div>

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -35,6 +35,7 @@ import {
   useEditorStore,
 } from "@/lib/editor/store"
 import { useVideoRegistry } from "@/lib/editor/video-registry"
+import { sourceTimeAt } from "@/lib/editor/video-timeline-map"
 import {
   computeCropTarget,
   cropMediaObjectStyle,
@@ -206,6 +207,9 @@ function CanvasViewInner({
   const canvasAnimation = useEditorStore(
     (s) => s.present.canvases.find((c) => c.id === scopeId)?.animation
   )
+  const canvasVideoClips = useEditorStore(
+    (s) => s.present.canvases.find((c) => c.id === scopeId)?.videoClips
+  )
   const {
     bg: animateBgStack,
     filterStack: animateFilterStack,
@@ -324,6 +328,42 @@ function CanvasViewInner({
   // happened to be selected at export time, and change mid-render.
   const cropAnimated =
     isAnimateMode && !!canvasAnimation?.clips.some((c) => clipOwns(c, "crop"))
+
+  // Which video frame the crop dialog previews.
+  //
+  // With a keyframe open for editing, the crop being authored belongs to THAT
+  // clip, so preview the frame its pose lands on (the end of its window) even
+  // though selecting a clip doesn't move the playhead — otherwise you frame a
+  // crop for a clip at 00:05 against whatever the playhead happens to sit on.
+  // With no clip open, the playhead is what the user is looking at, so read the
+  // live element. Both go through the same timeline→source mapping the player
+  // uses, or a trimmed clip would preview a different frame than it plays.
+  const cropPosterTimeSec = React.useMemo(() => {
+    const videoEl = scopeId ? (registeredVideos[scopeId] ?? null) : null
+    if (!videoEl) return null
+    const duration = Number.isFinite(videoEl.duration)
+      ? videoEl.duration
+      : undefined
+    const openClip =
+      isAnimateMode && selectedAnimationClipId
+        ? canvasAnimation?.clips.find((c) => c.id === selectedAnimationClipId)
+        : null
+    if (openClip) {
+      const atMs = openClip.startMs + openClip.durationMs
+      const sec = sourceTimeAt(canvasVideoClips, atMs, duration)
+      if (sec != null) return sec
+      // The clip sits in a gap with no video under it — fall through to the
+      // playhead rather than previewing a frame this clip never shows.
+    }
+    return videoEl.currentTime
+  }, [
+    scopeId,
+    registeredVideos,
+    isAnimateMode,
+    selectedAnimationClipId,
+    canvasAnimation,
+    canvasVideoClips,
+  ])
   const isAuto = aspect.id === "auto" || aspect.w === 0 || aspect.h === 0
   const canUseNaturalCanvasAspect =
     isAuto && naturalDims && !inRowMode && frame.id === "none"
@@ -1331,13 +1371,7 @@ function CanvasViewInner({
           screenshotUrl={originalScreenshot ?? screenshot}
           initialRegion={mainCropRequest?.initialRegion}
           targetAspect={mainCropRequest?.aspect}
-          // Read at the render that opens the dialog, so the still preview is
-          // the frame the canvas is actually showing rather than the clip's
-          // first frame. Applies in Animate mode too — the playhead drives this
-          // same element there.
-          posterTimeSec={
-            scopeId ? (registeredVideos[scopeId]?.currentTime ?? null) : null
-          }
+          posterTimeSec={cropPosterTimeSec}
           onCrop={(cropped, region) => {
             // Video can't be re-encoded client-side — store a non-destructive
             // render-time crop region instead of a baked bitmap.

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -191,7 +191,6 @@ function CanvasViewInner({
   } = useEditor()
   const scopeId = useCanvasScopeId()
   const isCanvasPreview = useCanvasPreviewMode()
-  const registeredVideos = useVideoRegistry((s) => s.videos)
   const bulkEditMode = useEditorStore((s) => s.bulkEditMode)
   const isPreviewMode = useEditorStore((s) => s.isPreviewMode)
   const bulkCanvasDragging = useEditorStore((s) => s.bulkCanvasDragging)
@@ -206,9 +205,6 @@ function CanvasViewInner({
   )
   const canvasAnimation = useEditorStore(
     (s) => s.present.canvases.find((c) => c.id === scopeId)?.animation
-  )
-  const canvasVideoClips = useEditorStore(
-    (s) => s.present.canvases.find((c) => c.id === scopeId)?.videoClips
   )
   const {
     bg: animateBgStack,
@@ -331,39 +327,42 @@ function CanvasViewInner({
 
   // Which video frame the crop dialog previews.
   //
+  // A GETTER, deliberately: `video.currentTime` is not React state, so anything
+  // that caches it (a memo, a value prop computed on an unrelated render) serves
+  // whatever the playhead was when that render ran — which is 0, the frame the
+  // element registered at. The dialog calls this when it decodes the poster.
+  //
   // With a keyframe open for editing, the crop being authored belongs to THAT
-  // clip, so preview the frame its pose lands on (the end of its window) even
-  // though selecting a clip doesn't move the playhead — otherwise you frame a
-  // crop for a clip at 00:05 against whatever the playhead happens to sit on.
-  // With no clip open, the playhead is what the user is looking at, so read the
-  // live element. Both go through the same timeline→source mapping the player
-  // uses, or a trimmed clip would preview a different frame than it plays.
-  const cropPosterTimeSec = React.useMemo(() => {
-    const videoEl = scopeId ? (registeredVideos[scopeId] ?? null) : null
+  // clip, so preview the frame its pose lands on (the end of its window) — even
+  // though selecting a clip doesn't move the playhead. With no clip open, the
+  // playhead is what the user is looking at. Both go through the same
+  // timeline→source mapping the player uses, or a trimmed clip would preview a
+  // different frame than it plays.
+  const getCropPosterTimeSec = React.useCallback((): number | null => {
+    const videoEl = scopeId
+      ? (useVideoRegistry.getState().videos[scopeId] ?? null)
+      : null
     if (!videoEl) return null
     const duration = Number.isFinite(videoEl.duration)
       ? videoEl.duration
       : undefined
-    const openClip =
-      isAnimateMode && selectedAnimationClipId
-        ? canvasAnimation?.clips.find((c) => c.id === selectedAnimationClipId)
-        : null
+    const state = useEditorStore.getState()
+    const canvas = state.present.canvases.find((c) => c.id === scopeId)
+    const openClipId = state.isAnimateMode
+      ? state.selectedAnimationClipId
+      : null
+    const openClip = openClipId
+      ? canvas?.animation?.clips.find((c) => c.id === openClipId)
+      : null
     if (openClip) {
       const atMs = openClip.startMs + openClip.durationMs
-      const sec = sourceTimeAt(canvasVideoClips, atMs, duration)
+      const sec = sourceTimeAt(canvas?.videoClips, atMs, duration)
+      // A keyframe over a gap in the video has no frame of its own; fall through
+      // to the playhead rather than previewing one it never shows.
       if (sec != null) return sec
-      // The clip sits in a gap with no video under it — fall through to the
-      // playhead rather than previewing a frame this clip never shows.
     }
     return videoEl.currentTime
-  }, [
-    scopeId,
-    registeredVideos,
-    isAnimateMode,
-    selectedAnimationClipId,
-    canvasAnimation,
-    canvasVideoClips,
-  ])
+  }, [scopeId])
   const isAuto = aspect.id === "auto" || aspect.w === 0 || aspect.h === 0
   const canUseNaturalCanvasAspect =
     isAuto && naturalDims && !inRowMode && frame.id === "none"
@@ -1371,7 +1370,7 @@ function CanvasViewInner({
           screenshotUrl={originalScreenshot ?? screenshot}
           initialRegion={mainCropRequest?.initialRegion}
           targetAspect={mainCropRequest?.aspect}
-          posterTimeSec={cropPosterTimeSec}
+          getPosterTimeSec={getCropPosterTimeSec}
           onCrop={(cropped, region) => {
             // Video can't be re-encoded client-side — store a non-destructive
             // render-time crop region instead of a baked bitmap.

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -34,6 +34,7 @@ import {
   useEditor,
   useEditorStore,
 } from "@/lib/editor/store"
+import { useVideoRegistry } from "@/lib/editor/video-registry"
 import {
   computeCropTarget,
   cropMediaObjectStyle,
@@ -189,6 +190,7 @@ function CanvasViewInner({
   } = useEditor()
   const scopeId = useCanvasScopeId()
   const isCanvasPreview = useCanvasPreviewMode()
+  const registeredVideos = useVideoRegistry((s) => s.videos)
   const bulkEditMode = useEditorStore((s) => s.bulkEditMode)
   const isPreviewMode = useEditorStore((s) => s.isPreviewMode)
   const bulkCanvasDragging = useEditorStore((s) => s.bulkCanvasDragging)
@@ -1329,6 +1331,13 @@ function CanvasViewInner({
           screenshotUrl={originalScreenshot ?? screenshot}
           initialRegion={mainCropRequest?.initialRegion}
           targetAspect={mainCropRequest?.aspect}
+          // Read at the render that opens the dialog, so the still preview is
+          // the frame the canvas is actually showing rather than the clip's
+          // first frame. Applies in Animate mode too — the playhead drives this
+          // same element there.
+          posterTimeSec={
+            scopeId ? (registeredVideos[scopeId]?.currentTime ?? null) : null
+          }
           onCrop={(cropped, region) => {
             // Video can't be re-encoded client-side — store a non-destructive
             // render-time crop region instead of a baked bitmap.

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -206,6 +206,14 @@ function CanvasViewInner({
   const canvasAnimation = useEditorStore(
     (s) => s.present.canvases.find((c) => c.id === scopeId)?.animation
   )
+  const canvasVideoClips = useEditorStore(
+    (s) => s.present.canvases.find((c) => c.id === scopeId)?.videoClips
+  )
+  // The element only; its `currentTime` is read lazily in the crop-poster
+  // getter below, never captured here.
+  const canvasVideoEl = useVideoRegistry((s) =>
+    scopeId ? (s.videos[scopeId] ?? null) : null
+  )
   const {
     bg: animateBgStack,
     filterStack: animateFilterStack,
@@ -339,30 +347,29 @@ function CanvasViewInner({
   // timeline→source mapping the player uses, or a trimmed clip would preview a
   // different frame than it plays.
   const getCropPosterTimeSec = React.useCallback((): number | null => {
-    const videoEl = scopeId
-      ? (useVideoRegistry.getState().videos[scopeId] ?? null)
-      : null
-    if (!videoEl) return null
-    const duration = Number.isFinite(videoEl.duration)
-      ? videoEl.duration
+    if (!canvasVideoEl) return null
+    const duration = Number.isFinite(canvasVideoEl.duration)
+      ? canvasVideoEl.duration
       : undefined
-    const state = useEditorStore.getState()
-    const canvas = state.present.canvases.find((c) => c.id === scopeId)
-    const openClipId = state.isAnimateMode
-      ? state.selectedAnimationClipId
-      : null
-    const openClip = openClipId
-      ? canvas?.animation?.clips.find((c) => c.id === openClipId)
-      : null
+    const openClip =
+      isAnimateMode && selectedAnimationClipId
+        ? canvasAnimation?.clips.find((c) => c.id === selectedAnimationClipId)
+        : null
     if (openClip) {
       const atMs = openClip.startMs + openClip.durationMs
-      const sec = sourceTimeAt(canvas?.videoClips, atMs, duration)
+      const sec = sourceTimeAt(canvasVideoClips, atMs, duration)
       // A keyframe over a gap in the video has no frame of its own; fall through
       // to the playhead rather than previewing one it never shows.
       if (sec != null) return sec
     }
-    return videoEl.currentTime
-  }, [scopeId])
+    return canvasVideoEl.currentTime
+  }, [
+    canvasVideoEl,
+    canvasVideoClips,
+    isAnimateMode,
+    selectedAnimationClipId,
+    canvasAnimation,
+  ])
   const isAuto = aspect.id === "auto" || aspect.w === 0 || aspect.h === 0
   const canUseNaturalCanvasAspect =
     isAuto && naturalDims && !inRowMode && frame.id === "none"

--- a/components/editor/crop-modal.tsx
+++ b/components/editor/crop-modal.tsx
@@ -36,12 +36,36 @@ async function urlToFile(url: string, filename: string): Promise<File> {
 }
 
 /**
+ * Where to seek for the crop dialog's still preview: the playhead the user is
+ * cropping against, clamped inside the clip. Only when there is no usable
+ * playhead does it fall back to a small nudge off zero — decoding at exactly 0
+ * yields a black/empty frame on some codecs, which is why the original code
+ * always seeked there, and why cropping six seconds in framed the wrong shot.
+ */
+export function posterSeekTime(atSec: number, duration: number): number {
+  const fallback = Math.min(0.1, duration / 2)
+  if (!Number.isFinite(atSec) || atSec <= 0) return fallback
+  if (!(duration > 0)) return atSec
+  // Never land ON the final boundary — seeking to exactly `duration` decodes
+  // past the last frame and paints black.
+  return Math.min(atSec, Math.max(0, duration - 0.01))
+}
+
+/**
  * Grab a still poster frame from a video src so react-image-crop (which is
  * image-only) has something to draw the crop handles over. The returned frame
  * is only used for handle placement — the video itself is never re-encoded; the
  * caller applies the resulting CropRegion at render time.
+ *
+ * `atSec` is the playhead the user is cropping against. It matters: framing a
+ * crop on frame 0 while the canvas shows six seconds in means placing the
+ * handles over content that isn't on screen.
  */
-async function videoPosterFile(url: string, filename: string): Promise<File> {
+async function videoPosterFile(
+  url: string,
+  filename: string,
+  atSec = 0
+): Promise<File> {
   const video = document.createElement("video")
   video.src = url
   video.muted = true
@@ -63,9 +87,12 @@ async function videoPosterFile(url: string, filename: string): Promise<File> {
       reject(new Error("video load failed"))
     }
     const onLoaded = () => {
-      // Seek slightly in to avoid a black/empty first frame on some codecs.
-      const target = Math.min(0.1, (video.duration || 0) / 2)
-      if (Number.isFinite(target) && target > 0 && video.currentTime === 0) {
+      const target = posterSeekTime(atSec, video.duration || 0)
+      if (
+        Number.isFinite(target) &&
+        target > 0 &&
+        video.currentTime !== target
+      ) {
         video.onseeked = () => {
           cleanup()
           resolve()
@@ -119,6 +146,7 @@ export function CropModal({
   screenshotUrl,
   initialRegion,
   targetAspect,
+  posterTimeSec,
   onCrop,
 }: {
   open: boolean
@@ -126,6 +154,8 @@ export function CropModal({
   screenshotUrl: string | null
   initialRegion?: CropRegion | null
   targetAspect?: number | null
+  /** Video only: the playhead the still preview should show. */
+  posterTimeSec?: number | null
   onCrop: (croppedBase64: string, region: CropRegion) => void
 }) {
   const safeTargetAspect =
@@ -178,13 +208,21 @@ export function CropModal({
     }
   }, [open, screenshotUrl, isVideo])
 
+  // Latched rather than a dependency of the poster effect below: the poster is
+  // the frame that was on screen when the dialog opened, and re-decoding it
+  // every time the playhead moves would fight the user's crop drag.
+  const posterTimeRef = React.useRef(0)
+  React.useEffect(() => {
+    posterTimeRef.current = posterTimeSec ?? 0
+  })
+
   React.useEffect(() => {
     if (!open || !screenshotUrl) return
     if (!isVideo && isDataUrl(screenshotUrl)) return
 
     let cancelled = false
     const loader = isVideo
-      ? videoPosterFile(screenshotUrl, "poster.png")
+      ? videoPosterFile(screenshotUrl, "poster.png", posterTimeRef.current)
       : urlToFile(screenshotUrl, "screenshot.png")
     void loader
       .then((file) => {

--- a/components/editor/crop-modal.tsx
+++ b/components/editor/crop-modal.tsx
@@ -146,7 +146,7 @@ export function CropModal({
   screenshotUrl,
   initialRegion,
   targetAspect,
-  posterTimeSec,
+  getPosterTimeSec,
   onCrop,
 }: {
   open: boolean
@@ -154,8 +154,12 @@ export function CropModal({
   screenshotUrl: string | null
   initialRegion?: CropRegion | null
   targetAspect?: number | null
-  /** Video only: the playhead the still preview should show. */
-  posterTimeSec?: number | null
+  /**
+   * Video only: the source-media time the still preview should show, read when
+   * the poster is decoded. A getter rather than a value because it comes from
+   * `video.currentTime`, which React never re-renders on.
+   */
+  getPosterTimeSec?: () => number | null
   onCrop: (croppedBase64: string, region: CropRegion) => void
 }) {
   const safeTargetAspect =
@@ -188,7 +192,13 @@ export function CropModal({
 
   const handleOpenChange = React.useCallback(
     (nextOpen: boolean) => {
-      if (!nextOpen) setAspectOverride(null)
+      if (!nextOpen) {
+        setAspectOverride(null)
+        // Drop the decoded still too. It is keyed only by URL, so keeping it
+        // would show the PREVIOUS open's frame the instant the dialog reopens —
+        // for a video that is a different moment in the clip, not a cache hit.
+        setLoadedFile(null)
+      }
       onOpenChange(nextOpen)
     },
     [onOpenChange]
@@ -208,12 +218,12 @@ export function CropModal({
     }
   }, [open, screenshotUrl, isVideo])
 
-  // Latched rather than a dependency of the poster effect below: the poster is
-  // the frame that was on screen when the dialog opened, and re-decoding it
-  // every time the playhead moves would fight the user's crop drag.
-  const posterTimeRef = React.useRef(0)
+  // Held in a ref so the poster effect can call it without listing it as a
+  // dependency: it is read once per open, and re-running the decode as the
+  // playhead moves would swap the still out from under a crop drag.
+  const getPosterTimeRef = React.useRef(getPosterTimeSec)
   React.useEffect(() => {
-    posterTimeRef.current = posterTimeSec ?? 0
+    getPosterTimeRef.current = getPosterTimeSec
   })
 
   React.useEffect(() => {
@@ -222,7 +232,11 @@ export function CropModal({
 
     let cancelled = false
     const loader = isVideo
-      ? videoPosterFile(screenshotUrl, "poster.png", posterTimeRef.current)
+      ? videoPosterFile(
+          screenshotUrl,
+          "poster.png",
+          getPosterTimeRef.current?.() ?? 0
+        )
       : urlToFile(screenshotUrl, "screenshot.png")
     void loader
       .then((file) => {

--- a/hooks/use-animation-player.ts
+++ b/hooks/use-animation-player.ts
@@ -4,6 +4,7 @@ import * as React from "react"
 
 import { useEditorStore } from "@/lib/editor/store"
 import { getVideoMutedPreferenceSync } from "@/lib/editor/video-mute-preference"
+import { sourceTimeAt, videoClipAtTime } from "@/lib/editor/video-timeline-map"
 import { useVideoRegistry } from "@/lib/editor/video-registry"
 
 type PlayerContextValue = {
@@ -67,18 +68,8 @@ export function AnimationPlayerProvider({
   }, [videoClips])
 
   const videoClipAt = React.useCallback(
-    (ms: number, mediaDurationMs?: number) => {
-      const clips = videoClipsRef.current ?? [
-        { id: "video-main", timelineStartMs: 0, startMs: 0, endMs: null },
-      ]
-      return clips.find(
-        (clip) =>
-          ms >= (clip.timelineStartMs ?? clip.startMs) &&
-          ms <
-            (clip.timelineStartMs ?? clip.startMs) +
-              ((clip.endMs ?? mediaDurationMs ?? Infinity) - clip.startMs)
-      )
-    },
+    (ms: number, mediaDurationMs?: number) =>
+      videoClipAtTime(videoClipsRef.current, ms, mediaDurationMs),
     []
   )
 
@@ -92,18 +83,16 @@ export function AnimationPlayerProvider({
     (ms: number) => {
       const el = getVideo()
       if (!el) return
+      const duration = Number.isFinite(el.duration) ? el.duration : undefined
       const clip = videoClipAt(
         ms,
-        Number.isFinite(el.duration) ? el.duration * 1000 : undefined
+        duration != null ? duration * 1000 : undefined
       )
       if (!clip) return
       el.muted = clip.muted ?? getVideoMutedPreferenceSync()
-      const sourceMs =
-        clip.startMs + (ms - (clip.timelineStartMs ?? clip.startMs))
-      const seconds = sourceMs / 1000
-      el.currentTime = Number.isFinite(el.duration)
-        ? Math.min(seconds, el.duration)
-        : seconds
+      const seconds = sourceTimeAt(videoClipsRef.current, ms, duration)
+      if (seconds == null) return
+      el.currentTime = seconds
     },
     [getVideo, videoClipAt]
   )

--- a/lib/editor/animation-playback.ts
+++ b/lib/editor/animation-playback.ts
@@ -7,7 +7,7 @@
 // turns that progress into concrete CSS override vars. Kept React-free so it's
 // testable and shared between live playback and (later) the exporter.
 
-import { clipProgressEase } from "./clip-easing"
+import { clipProgressEase, clipReleaseEase, clipReleaseMs } from "./clip-easing"
 import { hexToRgb } from "./color-utils"
 import { DEFAULT_CANVAS_BASE } from "./store/defaults"
 import type {
@@ -889,7 +889,8 @@ export function resolveAnimateOverlayStack(
  *  - before the first frame → the neutral `rest` value (reveal origin),
  *  - inside a frame → eased interpolation from the PREVIOUS frame's value (or
  *    `rest` for the first) → this frame's value,
- *  - in a gap after a frame, or past the last → hold that frame's value.
+ *  - in a gap after a frame, or past the last → hold that frame's value, or ease
+ *    it back to `rest` over `releaseMs` when the frame releases.
  * This is the single source of truth for continuity + hold across the timeline.
  */
 export function sampleKeyframes<V>(
@@ -900,6 +901,10 @@ export function sampleKeyframes<V>(
     /** Per-clip progress remap (curve + speed). Falls back to the historic
      * ease-out when a caller doesn't supply the owning clip's easing. */
     ease?: (rawT: number) => number
+    /** Ease back to `rest` over this many ms after the frame ends. 0 = hold. */
+    releaseMs?: number
+    /** Curve for that release. Falls back to the historic ease-out. */
+    releaseEase?: (rawT: number) => number
   }[],
   timeMs: number,
   rest: V,
@@ -907,12 +912,27 @@ export function sampleKeyframes<V>(
 ): V | null {
   if (frames.length === 0) return null
   const sorted = [...frames].sort((a, b) => a.startMs - b.startMs)
+
+  // What frame `i` reads as at a time past its own window: its pose, unwinding
+  // toward rest when it releases. Sampling it AT the next frame's start (rather
+  // than taking the pose flat) is what keeps a chain continuous — a frame that
+  // begins the instant the previous one ends still departs from the full pose,
+  // and one that begins mid-release departs from wherever the release got to.
+  const settledAt = (i: number, at: number): V => {
+    const f = sorted[i]
+    const release = f.releaseMs ?? 0
+    if (release <= 0) return f.value
+    const p = clamp01((at - (f.startMs + f.durationMs)) / release)
+    if (p <= 0) return f.value
+    return lerpValue(f.value, rest, (f.releaseEase ?? easeOut)(p))
+  }
+
   if (timeMs < sorted[0].startMs) return rest
   for (let i = 0; i < sorted.length; i++) {
     const f = sorted[i]
-    if (timeMs < f.startMs) return sorted[i - 1].value // gap → hold previous
+    if (timeMs < f.startMs) return settledAt(i - 1, timeMs) // gap
     if (timeMs <= f.startMs + f.durationMs) {
-      const from = i > 0 ? sorted[i - 1].value : rest
+      const from = i > 0 ? settledAt(i - 1, f.startMs) : rest
       const ease = f.ease ?? easeOut
       return lerpValue(
         from,
@@ -921,7 +941,7 @@ export function sampleKeyframes<V>(
       )
     }
   }
-  return sorted[sorted.length - 1].value // past the end → hold last
+  return settledAt(sorted.length - 1, timeMs) // past the end
 }
 
 /** True when `clip` animates the main screenshot (its own target or "all"). */
@@ -940,7 +960,8 @@ export function clipAffectsSlot(clip: AnimationClip, slotId: string): boolean {
  * Eased 0..1 progress toward the pose for a target's clips at `timeMs`:
  *  - before the first clip starts → 0 (neutral rest),
  *  - inside a clip → eased local progress,
- *  - in a gap after a clip, or past the last clip → 1 (holds the pose).
+ *  - in a gap after a clip, or past the last clip → 1 (holds the pose), or eased
+ *    back down toward 0 when that clip releases.
  * With no clips the target is never animated, so it sits at its full pose (1).
  */
 export function clipsProgressAt(
@@ -949,14 +970,23 @@ export function clipsProgressAt(
 ): number {
   if (clips.length === 0) return 1
   const sorted = [...clips].sort((a, b) => a.startMs - b.startMs)
+
+  const settledAt = (c: AnimationClip, at: number): number => {
+    const release = clipReleaseMs(c)
+    if (release <= 0) return 1
+    const p = clamp01((at - (c.startMs + c.durationMs)) / release)
+    return 1 - clipReleaseEase(c)(p)
+  }
+
   if (timeMs < sorted[0].startMs) return 0
-  for (const c of sorted) {
-    if (timeMs < c.startMs) return 1 // in a gap that follows an earlier clip
+  for (let i = 0; i < sorted.length; i++) {
+    const c = sorted[i]
+    if (timeMs < c.startMs) return settledAt(sorted[i - 1], timeMs) // gap
     if (timeMs <= c.startMs + c.durationMs) {
       return clipProgressEase(c)((timeMs - c.startMs) / c.durationMs)
     }
   }
-  return 1 // past every clip
+  return settledAt(sorted[sorted.length - 1], timeMs) // past every clip
 }
 
 /**

--- a/lib/editor/animation-playback.ts
+++ b/lib/editor/animation-playback.ts
@@ -243,6 +243,8 @@ export function lightingTargetMixAt(
     durationMs: number
     value: BackdropLighting
     ease?: (rawT: number) => number
+    releaseMs?: number
+    releaseEase?: (rawT: number) => number
   }[],
   timeMs: number,
   rest: BackdropLighting
@@ -266,6 +268,10 @@ export function lightingTargetMixAt(
         durationMs: f.durationMs,
         value: f.value.target === "inner" ? 1 : 0,
         ease: f.ease,
+        // Forwarded, or a released clip would slide its light back to the rest
+        // POSITION while the side it renders on stayed pinned to the pose.
+        releaseMs: f.releaseMs,
+        releaseEase: f.releaseEase,
       })),
       timeMs,
       restMix,
@@ -418,7 +424,8 @@ export function shadowBetween(from: Shadow, to: Shadow, p: number): Shadow {
  *  - a reveal from nothing → one shadow growing in from 0,
  *  - a retract to nothing → the old shadow easing OUT (keeping its own type so
  *    it fades rather than vanishing),
- *  - a gap / past the end → hold that keyframe's shadow.
+ *  - a gap / past the end → hold that keyframe's shadow, or blend it back to
+ *    `rest` over `releaseMs` when the frame releases.
  * Returns null when no keyframe animates the shadow (leave the committed value).
  */
 export function sampleShadowLayers(
@@ -427,40 +434,80 @@ export function sampleShadowLayers(
     durationMs: number
     value: Shadow
     ease?: (rawT: number) => number
+    /** Blend back to `rest` over this many ms after the frame ends. 0 = hold. */
+    releaseMs?: number
+    /** Curve for that release. Falls back to the historic ease-out. */
+    releaseEase?: (rawT: number) => number
   }[],
   timeMs: number,
   rest: Shadow
 ): Shadow[] | null {
   if (frames.length === 0) return null
   const sorted = [...frames].sort((a, b) => a.startMs - b.startMs)
+
+  /** How far frame `i` has released at `at` (0 = still on its pose). */
+  const releaseProgress = (i: number, at: number): number => {
+    const f = sorted[i]
+    const release = f.releaseMs ?? 0
+    if (release <= 0) return 0
+    const raw = clamp01((at - (f.startMs + f.durationMs)) / release)
+    return raw <= 0 ? 0 : (f.releaseEase ?? easeOut)(raw)
+  }
+
+  // What frame `i` renders at a time past its own window: its pose held, or run
+  // back out to rest under the same blend rules the reveal used — so a shadow
+  // recedes exactly the way it arrived, cross-blending when rest is a different
+  // visible type and fading on its own type when rest renders nothing.
+  const releasedLayers = (i: number, at: number): Shadow[] => {
+    const p = releaseProgress(i, at)
+    return p <= 0 ? [sorted[i].value] : layersBetween(sorted[i].value, rest, p)
+  }
+
+  // The single shadow a later frame departs FROM. Taking the OUTGOING layer
+  // keeps the pose's own type: blending straight to rest would adopt rest's
+  // type, and a rest of `none` would leave a shadow that renders nothing.
+  const settledValue = (i: number, at: number): Shadow =>
+    releasedLayers(i, at)[0]
+
   if (timeMs < sorted[0].startMs) return [rest]
   for (let i = 0; i < sorted.length; i++) {
     const f = sorted[i]
-    if (timeMs < f.startMs) return [sorted[i - 1].value] // gap → hold previous
+    // Gap: released frames keep blending toward rest instead of holding.
+    if (timeMs < f.startMs) return releasedLayers(i - 1, timeMs)
     if (timeMs <= f.startMs + f.durationMs) {
-      const from = i > 0 ? sorted[i - 1].value : rest
-      const to = f.value
+      const from = i > 0 ? settledValue(i - 1, f.startMs) : rest
       const ease = f.ease ?? easeOut
-      const p = ease(clamp01((timeMs - f.startMs) / f.durationMs))
-      const fromVisible = !shadowInvisible(from)
-      const toVisible = !shadowInvisible(to)
-      // Retract to nothing: fade the source out on its own type so it recedes
-      // the way it arrived rather than blinking off.
-      if (fromVisible && !toVisible) {
-        return [{ ...from, intensity: lerp(from.intensity, 0, p) }]
-      }
-      // Two different visible shadows → cross-blend (old OUT, new IN).
-      if (fromVisible && toVisible && from.type !== to.type) {
-        return [
-          { ...from, intensity: lerp(from.intensity, 0, p) },
-          { ...to, intensity: lerp(0, to.intensity, p) },
-        ]
-      }
-      // Same-type morph, reveal from nothing, or nothing→nothing: one layer.
-      return [shadowBetween(from, to, p)]
+      return layersBetween(
+        from,
+        f.value,
+        ease(clamp01((timeMs - f.startMs) / f.durationMs))
+      )
     }
   }
-  return [sorted[sorted.length - 1].value] // past the end → hold last
+  return releasedLayers(sorted.length - 1, timeMs)
+}
+
+/**
+ * The shadow layer(s) rendering a `from` → `to` blend at progress p. Shared by
+ * the reveal and the release so both directions cross-blend identically.
+ */
+function layersBetween(from: Shadow, to: Shadow, p: number): Shadow[] {
+  const fromVisible = !shadowInvisible(from)
+  const toVisible = !shadowInvisible(to)
+  // Retract to nothing: fade the source out on its own type so it recedes
+  // the way it arrived rather than blinking off.
+  if (fromVisible && !toVisible) {
+    return [{ ...from, intensity: lerp(from.intensity, 0, p) }]
+  }
+  // Two different visible shadows → cross-blend (old OUT, new IN).
+  if (fromVisible && toVisible && from.type !== to.type) {
+    return [
+      { ...from, intensity: lerp(from.intensity, 0, p) },
+      { ...to, intensity: lerp(0, to.intensity, p) },
+    ]
+  }
+  // Same-type morph, reveal from nothing, or nothing→nothing: one layer.
+  return [shadowBetween(from, to, p)]
 }
 
 export function backdropEffectsDiffer(

--- a/lib/editor/animation-playback.ts
+++ b/lib/editor/animation-playback.ts
@@ -463,25 +463,29 @@ export function sampleShadowLayers(
     return p <= 0 ? [sorted[i].value] : layersBetween(sorted[i].value, rest, p)
   }
 
-  // The single shadow a later frame departs FROM. Taking the OUTGOING layer
-  // keeps the pose's own type: blending straight to rest would adopt rest's
-  // type, and a rest of `none` would leave a shadow that renders nothing.
-  const settledValue = (i: number, at: number): Shadow =>
-    releasedLayers(i, at)[0]
-
   if (timeMs < sorted[0].startMs) return [rest]
   for (let i = 0; i < sorted.length; i++) {
     const f = sorted[i]
     // Gap: released frames keep blending toward rest instead of holding.
     if (timeMs < f.startMs) return releasedLayers(i - 1, timeMs)
     if (timeMs <= f.startMs + f.durationMs) {
-      const from = i > 0 ? settledValue(i - 1, f.startMs) : rest
-      const ease = f.ease ?? easeOut
-      return layersBetween(
-        from,
-        f.value,
-        ease(clamp01((timeMs - f.startMs) / f.durationMs))
+      // The WHOLE stack the previous frame was rendering at this frame's start,
+      // not just its outgoing layer: a release that is itself cross-blending
+      // toward a different-typed rest has two live layers, and dropping the
+      // incoming one pops it off at this frame's first tick.
+      const from = i > 0 ? releasedLayers(i - 1, f.startMs) : [rest]
+      const p = (f.ease ?? easeOut)(
+        clamp01((timeMs - f.startMs) / f.durationMs)
       )
+      // One layer keeps the same-type morph and reveal-from-nothing rules.
+      // Several can only fade out together while the new pose fades in — at
+      // p = 0 that renders the previous stack exactly, so nothing jumps.
+      return from.length === 1
+        ? layersBetween(from[0], f.value, p)
+        : [
+            ...from.map((s) => ({ ...s, intensity: lerp(s.intensity, 0, p) })),
+            { ...f.value, intensity: lerp(0, f.value.intensity, p) },
+          ]
     }
   }
   return releasedLayers(sorted.length - 1, timeMs)

--- a/lib/editor/apply-animation-frame.ts
+++ b/lib/editor/apply-animation-frame.ts
@@ -88,7 +88,11 @@ import {
   cropRegionRatio,
   cropViewBoxValue,
 } from "@/lib/editor/crop-utils"
-import { clipProgressEase } from "@/lib/editor/clip-easing"
+import {
+  clipProgressEase,
+  clipReleaseEase,
+  clipReleaseMs,
+} from "@/lib/editor/clip-easing"
 import { captureClipPose } from "@/lib/editor/store"
 import type {
   AnimationClip,
@@ -402,6 +406,8 @@ export function applyAnimationFrameAtTime({
           durationMs: c.durationMs,
           value: value(poseOf(c)),
           ease: clipProgressEase(c),
+          releaseMs: clipReleaseMs(c),
+          releaseEase: clipReleaseEase(c),
         }))
 
     const restFor = <V>(
@@ -519,6 +525,8 @@ export function applyAnimationFrameAtTime({
           durationMs: c.durationMs,
           value: pointFor(pz.screenshotPosition, pz.screenshotOffset),
           ease: clipProgressEase(c),
+          releaseMs: clipReleaseMs(c),
+          releaseEase: clipReleaseEase(c),
         }
       })
       const posRest =
@@ -866,6 +874,8 @@ export function applyAnimationFrameAtTime({
             durationMs: c.durationMs,
             value: { tilt: sp.tilt, rotation: sp.rotation },
             ease: clipProgressEase(c),
+            releaseMs: clipReleaseMs(c),
+            releaseEase: clipReleaseEase(c),
           }
         }),
       playheadMs,
@@ -895,6 +905,8 @@ export function applyAnimationFrameAtTime({
           durationMs: c.durationMs,
           value: slotPoseOf(c).scale,
           ease: clipProgressEase(c),
+          releaseMs: clipReleaseMs(c),
+          releaseEase: clipReleaseEase(c),
         })),
       playheadMs,
       100,
@@ -925,6 +937,8 @@ export function applyAnimationFrameAtTime({
               yPct: sp.yPct ?? slot.yPct,
             },
             ease: clipProgressEase(c),
+            releaseMs: clipReleaseMs(c),
+            releaseEase: clipReleaseEase(c),
           }
         }),
         playheadMs,
@@ -948,6 +962,8 @@ export function applyAnimationFrameAtTime({
           durationMs: c.durationMs,
           value: slotPoseOf(c).shadow ?? INVISIBLE_SHADOW,
           ease: clipProgressEase(c),
+          releaseMs: clipReleaseMs(c),
+          releaseEase: clipReleaseEase(c),
         })),
       playheadMs,
       INVISIBLE_SHADOW
@@ -989,6 +1005,8 @@ export function applyAnimationFrameAtTime({
           durationMs: c.durationMs,
           value: slotPoseOf(c).border ?? committedBorder,
           ease: clipProgressEase(c),
+          releaseMs: clipReleaseMs(c),
+          releaseEase: clipReleaseEase(c),
         })),
       playheadMs,
       slotRestFor("border", (sp) => sp?.border, INVISIBLE_BORDER),
@@ -1011,6 +1029,8 @@ export function applyAnimationFrameAtTime({
           durationMs: c.durationMs,
           value: slotPoseOf(c).borderRadius ?? committedRadius,
           ease: clipProgressEase(c),
+          releaseMs: clipReleaseMs(c),
+          releaseEase: clipReleaseEase(c),
         })),
       playheadMs,
       slotRestFor("borderRadius", (sp) => sp?.borderRadius, committedRadius),
@@ -1031,6 +1051,8 @@ export function applyAnimationFrameAtTime({
           durationMs: c.durationMs,
           value: slotPoseOf(c).padding ?? committedPadding,
           ease: clipProgressEase(c),
+          releaseMs: clipReleaseMs(c),
+          releaseEase: clipReleaseEase(c),
         })),
       playheadMs,
       slotRestFor("padding", (sp) => sp?.padding, committedPadding),
@@ -1051,6 +1073,8 @@ export function applyAnimationFrameAtTime({
         durationMs: c.durationMs,
         value: slotPoseOf(c).lighting ?? REST_LIGHTING,
         ease: clipProgressEase(c),
+        releaseMs: clipReleaseMs(c),
+        releaseEase: clipReleaseEase(c),
       }))
     if (slotLightingFrames.length > 0) {
       const restBase = slotRestFor(

--- a/lib/editor/clip-easing.ts
+++ b/lib/editor/clip-easing.ts
@@ -101,6 +101,36 @@ export function clipProgressEase(clip: {
 }
 
 /**
+ * Whether a clip releases back to its pre-clip state after its window instead of
+ * holding the pose. Undefined is off: clips authored before the release existed
+ * were composed around the hold.
+ */
+export function clipReturnsToDefault(clip: {
+  returnToDefault?: boolean
+}): boolean {
+  return clip.returnToDefault === true
+}
+
+/**
+ * How long the release takes, starting at the clip's end. It mirrors the active
+ * transition so the motion out is the motion in played backwards — a clip that
+ * settles in 400ms of a 5 s window also unwinds in 400ms.
+ */
+export function clipReleaseMs(clip: AnimationClip): number {
+  return clipReturnsToDefault(clip) ? effectiveActiveMs(clip) : 0
+}
+
+/**
+ * The curve the release rides. It is the clip's own curve WITHOUT the speed
+ * remap — speed already decided how long the release lasts, so folding it in
+ * again would compress the curve inside its own shortened window.
+ */
+export function clipReleaseEase(clip: AnimationClip): (rawT: number) => number {
+  const fn = EASING_FNS[clipEasingKind(clip)]
+  return (rawT) => fn(clamp01(rawT))
+}
+
+/**
  * The effective active duration (ms) a clip's transition actually plays over,
  * given its speed — the rest of the window holds the pose. Shown in the UI so
  * "finish in 1 s of a 5 s clip" reads directly.

--- a/lib/editor/clip-easing.ts
+++ b/lib/editor/clip-easing.ts
@@ -102,13 +102,14 @@ export function clipProgressEase(clip: {
 
 /**
  * Whether a clip releases back to its pre-clip state after its window instead of
- * holding the pose. Undefined is off: clips authored before the release existed
- * were composed around the hold.
+ * holding the pose. On unless a clip opts out, so a keyframe's effect never
+ * outlives the band that authored it — including in drafts saved before the
+ * release existed.
  */
 export function clipReturnsToDefault(clip: {
   returnToDefault?: boolean
 }): boolean {
-  return clip.returnToDefault === true
+  return clip.returnToDefault !== false
 }
 
 /**

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -459,6 +459,12 @@ export type AnimationClip = {
   baseline?: ClipBaseline
   easing?: ClipEasingKind
   speed?: number
+  /**
+   * Ease every owned effect back to the pre-clip state once the clip's window
+   * ends, instead of holding the pose for the rest of the timeline. Undefined
+   * reads as off so drafts saved before this existed keep holding.
+   */
+  returnToDefault?: boolean
 }
 
 export type CanvasAnimation = {

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -462,7 +462,7 @@ export type AnimationClip = {
   /**
    * Ease every owned effect back to the pre-clip state once the clip's window
    * ends, instead of holding the pose for the rest of the timeline. Undefined
-   * reads as off so drafts saved before this existed keep holding.
+   * reads as ON — set it to false to keep the pose.
    */
   returnToDefault?: boolean
 }

--- a/lib/editor/store.tsx
+++ b/lib/editor/store.tsx
@@ -2884,6 +2884,10 @@ export const useEditorStore = create<EditorStore>((set, get) => {
             baseline: snapshot,
             // A fresh keyframe owns nothing until you edit an effect on it.
             effects: [],
+            // Set explicitly rather than leaning on the undefined default: new
+            // clips unwind after their window, drafts saved before the release
+            // existed keep holding their pose.
+            returnToDefault: true,
           }
           return {
             animation: { ...animation, clips: [...animation.clips, clip] },

--- a/lib/editor/store.tsx
+++ b/lib/editor/store.tsx
@@ -2884,10 +2884,6 @@ export const useEditorStore = create<EditorStore>((set, get) => {
             baseline: snapshot,
             // A fresh keyframe owns nothing until you edit an effect on it.
             effects: [],
-            // Set explicitly rather than leaning on the undefined default: new
-            // clips unwind after their window, drafts saved before the release
-            // existed keep holding their pose.
-            returnToDefault: true,
           }
           return {
             animation: { ...animation, clips: [...animation.clips, clip] },

--- a/lib/editor/video-timeline-map.ts
+++ b/lib/editor/video-timeline-map.ts
@@ -1,0 +1,55 @@
+import type { VideoTimelineClip } from "./state-types"
+
+/**
+ * Timeline time → source-media time.
+ *
+ * A video clip can start anywhere on the timeline (`timelineStartMs`) and play
+ * from anywhere inside the source (`startMs`), so the two clocks only agree for
+ * an untrimmed clip parked at zero. Both the animate player (seeking the live
+ * <video> each frame) and the crop dialog (decoding a still poster) need this
+ * mapping, and they must agree or the crop handles land on a different frame
+ * than the canvas shows.
+ */
+
+/** The default timeline: one untrimmed clip covering the whole source. */
+const WHOLE_SOURCE: VideoTimelineClip[] = [
+  { id: "video-main", timelineStartMs: 0, startMs: 0, endMs: null },
+]
+
+/** The clip playing at timeline time `ms`, or undefined in a gap. */
+export function videoClipAtTime(
+  clips: readonly VideoTimelineClip[] | null | undefined,
+  ms: number,
+  mediaDurationMs?: number
+): VideoTimelineClip | undefined {
+  const list = clips && clips.length > 0 ? clips : WHOLE_SOURCE
+  return list.find(
+    (clip) =>
+      ms >= (clip.timelineStartMs ?? clip.startMs) &&
+      ms <
+        (clip.timelineStartMs ?? clip.startMs) +
+          ((clip.endMs ?? mediaDurationMs ?? Infinity) - clip.startMs)
+  )
+}
+
+/**
+ * The source-media SECONDS shown at timeline time `ms`, or null when no clip
+ * covers it. Clamped to `mediaDurationSec` when that is known.
+ */
+export function sourceTimeAt(
+  clips: readonly VideoTimelineClip[] | null | undefined,
+  ms: number,
+  mediaDurationSec?: number
+): number | null {
+  const mediaDurationMs =
+    mediaDurationSec != null && Number.isFinite(mediaDurationSec)
+      ? mediaDurationSec * 1000
+      : undefined
+  const clip = videoClipAtTime(clips, ms, mediaDurationMs)
+  if (!clip) return null
+  const sourceMs = clip.startMs + (ms - (clip.timelineStartMs ?? clip.startMs))
+  const seconds = sourceMs / 1000
+  return mediaDurationSec != null && Number.isFinite(mediaDurationSec)
+    ? Math.min(seconds, mediaDurationSec)
+    : seconds
+}

--- a/tests/components/editor/crop-modal-poster.test.ts
+++ b/tests/components/editor/crop-modal-poster.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+
+import { posterSeekTime } from "@/components/editor/crop-modal"
+
+/**
+ * The crop dialog's still preview used to always seek ~0.1s in, so cropping a
+ * video six seconds into the timeline framed the handles over the clip's FIRST
+ * frame — content that wasn't on screen. It now seeks to the playhead.
+ */
+describe("posterSeekTime", () => {
+  it("seeks to the playhead the user is cropping against", () => {
+    expect(posterSeekTime(6.09, 7.1)).toBeCloseTo(6.09, 5)
+  })
+
+  it("falls back to a nudge off zero when there is no playhead", () => {
+    // Decoding at exactly 0 gives a black frame on some codecs.
+    expect(posterSeekTime(0, 7.1)).toBeCloseTo(0.1, 5)
+  })
+
+  it("uses half the clip when it is shorter than the nudge", () => {
+    expect(posterSeekTime(0, 0.08)).toBeCloseTo(0.04, 5)
+  })
+
+  it("never lands on the final boundary, which decodes past the last frame", () => {
+    expect(posterSeekTime(7.1, 7.1)).toBeCloseTo(7.09, 5)
+    expect(posterSeekTime(99, 7.1)).toBeCloseTo(7.09, 5)
+  })
+
+  it("keeps the playhead when the duration is not known yet", () => {
+    expect(posterSeekTime(6.09, 0)).toBeCloseTo(6.09, 5)
+    expect(posterSeekTime(6.09, Number.NaN)).toBeCloseTo(6.09, 5)
+  })
+
+  it("ignores a non-finite or negative playhead", () => {
+    expect(posterSeekTime(Number.NaN, 7.1)).toBeCloseTo(0.1, 5)
+    expect(posterSeekTime(-3, 7.1)).toBeCloseTo(0.1, 5)
+  })
+})

--- a/tests/lib/editor/animation-crop-frame.test.ts
+++ b/tests/lib/editor/animation-crop-frame.test.ts
@@ -78,8 +78,22 @@ describe("animated crop → CSS vars", () => {
     expect(el.style.getPropertyValue(VIEW_BOX)).toBe("inset(10% 10% 10% 10%)")
   })
 
-  it("holds the last crop past the end of the clip", () => {
+  it("releases the crop back to the baseline rect after the clip", () => {
     const clips = [cropClip()]
+
+    applyAt(el, clips, 1000)
+    expect(el.style.getPropertyValue(VIEW_BOX)).toBe("inset(20% 20% 20% 20%)")
+
+    // The release mirrors the reveal, so halfway back out reads like halfway in.
+    applyAt(el, clips, 1500)
+    expect(el.style.getPropertyValue(VIEW_BOX)).toBe("inset(10% 10% 10% 10%)")
+
+    applyAt(el, clips, 9999)
+    expect(el.style.getPropertyValue(VIEW_BOX)).toBe("inset(0% 0% 0% 0%)")
+  })
+
+  it("holds the last crop past the end when the clip opts out", () => {
+    const clips = [cropClip({ returnToDefault: false })]
     applyAt(el, clips, 1000)
     const atEnd = el.style.getPropertyValue(VIEW_BOX)
 

--- a/tests/lib/editor/animation-playback.test.ts
+++ b/tests/lib/editor/animation-playback.test.ts
@@ -701,4 +701,36 @@ describe("sampleShadowLayers", () => {
       5
     )
   })
+
+  it("keeps both layers when a frame starts mid cross-blend release", () => {
+    // Pose `soft` releasing toward a visible `glow` rest is a two-layer stack.
+    // A frame starting mid-release must depart from BOTH, or the incoming glow
+    // pops off at its first tick.
+    const frames = [
+      frame(soft),
+      { startMs: 1500, durationMs: 1000, value: soft, ease: linear },
+    ]
+    const before = sampleShadowLayers([frames[0]], 1500, glow)!
+    const atStart = sampleShadowLayers(frames, 1500, glow)!
+
+    expect(before.map((s) => s.type)).toEqual(["soft", "glow"])
+    expect(atStart.map((s) => s.type)).toEqual(["soft", "glow", "soft"])
+    // The third layer is the new pose at intensity 0, so the rendered stack is
+    // unchanged at the boundary.
+    expect(atStart[0].intensity).toBeCloseTo(before[0].intensity, 5)
+    expect(atStart[1].intensity).toBeCloseTo(before[1].intensity, 5)
+    expect(atStart[2].intensity).toBeCloseTo(0, 5)
+  })
+
+  it("fades the residual layers out as the next frame eases in", () => {
+    const frames = [
+      frame(soft),
+      { startMs: 1500, durationMs: 1000, value: soft, ease: linear },
+    ]
+    // Halfway into the next frame: both residuals halved, new pose at half.
+    const mid = sampleShadowLayers(frames, 2000, glow)!
+    expect(mid[0].intensity).toBeCloseTo(20, 5) // soft residual was 40
+    expect(mid[1].intensity).toBeCloseTo(15, 5) // glow residual was 30
+    expect(mid[2].intensity).toBeCloseTo(40, 5) // new soft easing in to 80
+  })
 })

--- a/tests/lib/editor/animation-playback.test.ts
+++ b/tests/lib/editor/animation-playback.test.ts
@@ -452,3 +452,131 @@ describe("cropRegionBetween", () => {
     ).toEqual(to)
   })
 })
+
+describe("return to default (release)", () => {
+  const num = (from: number, to: number, p: number) => lerp(from, to, p)
+  const linear = (t: number) => t
+  // A frame that reaches 10 over [0,1000], then unwinds to rest across 1000ms.
+  const releasing = [
+    {
+      startMs: 0,
+      durationMs: 1000,
+      value: 10,
+      ease: linear,
+      releaseMs: 1000,
+      releaseEase: linear,
+    },
+  ]
+
+  it("sampleKeyframes still holds when a frame has no release", () => {
+    const holding = [{ startMs: 0, durationMs: 1000, value: 10, ease: linear }]
+    expect(sampleKeyframes(holding, 5000, 0, num)).toBe(10)
+    expect(
+      sampleKeyframes(
+        holding.map((f) => ({ ...f, releaseMs: 0 })),
+        5000,
+        0,
+        num
+      )
+    ).toBe(10)
+  })
+
+  it("sampleKeyframes sits on the pose the instant the window ends", () => {
+    expect(sampleKeyframes(releasing, 1000, 0, num)).toBeCloseTo(10, 5)
+  })
+
+  it("sampleKeyframes eases back toward rest across the release", () => {
+    expect(sampleKeyframes(releasing, 1500, 0, num)).toBeCloseTo(5, 5)
+    expect(sampleKeyframes(releasing, 1750, 0, num)).toBeCloseTo(2.5, 5)
+  })
+
+  it("sampleKeyframes lands exactly on rest and stays there", () => {
+    expect(sampleKeyframes(releasing, 2000, 0, num)).toBeCloseTo(0, 5)
+    expect(sampleKeyframes(releasing, 99000, 0, num)).toBeCloseTo(0, 5)
+  })
+
+  it("returns to a non-zero rest, not to zero", () => {
+    expect(sampleKeyframes(releasing, 2000, 4, num)).toBeCloseTo(4, 5)
+  })
+
+  it("releases into a gap rather than holding through it", () => {
+    const frames = [
+      ...releasing,
+      { startMs: 4000, durationMs: 1000, value: 20, ease: linear },
+    ]
+    expect(sampleKeyframes(frames, 1500, 0, num)).toBeCloseTo(5, 5)
+    expect(sampleKeyframes(frames, 3000, 0, num)).toBeCloseTo(0, 5)
+  })
+
+  it("a next frame butted against the release still departs from the full pose", () => {
+    // Chain continuity: B starts the instant A ends, so A has released nothing.
+    const frames = [
+      ...releasing,
+      { startMs: 1000, durationMs: 1000, value: 20, ease: linear },
+    ]
+    expect(sampleKeyframes(frames, 1000, 0, num)).toBeCloseTo(10, 5)
+    expect(sampleKeyframes(frames, 1500, 0, num)).toBeCloseTo(15, 5)
+  })
+
+  it("a next frame starting mid-release departs from the decayed value", () => {
+    // B starts at 1500 — half of A's release, so A reads 5, not 10.
+    const frames = [
+      ...releasing,
+      { startMs: 1500, durationMs: 1000, value: 20, ease: linear },
+    ]
+    expect(sampleKeyframes(frames, 1500, 0, num)).toBeCloseTo(5, 5)
+    expect(sampleKeyframes(frames, 2000, 0, num)).toBeCloseTo(12.5, 5)
+  })
+
+  it("clipsProgressAt unwinds to 0 after a releasing clip", () => {
+    const clips = [
+      clip({
+        id: "a",
+        startMs: 0,
+        durationMs: 1000,
+        easing: "linear",
+        returnToDefault: true,
+      }),
+    ]
+    expect(clipsProgressAt(clips, 1000)).toBeCloseTo(1, 5)
+    expect(clipsProgressAt(clips, 1500)).toBeCloseTo(0.5, 5)
+    expect(clipsProgressAt(clips, 2000)).toBeCloseTo(0, 5)
+    expect(clipsProgressAt(clips, 9000)).toBeCloseTo(0, 5)
+  })
+
+  it("clipsProgressAt unwinds in a gap that follows a releasing clip", () => {
+    const clips = [
+      clip({
+        id: "a",
+        startMs: 0,
+        durationMs: 1000,
+        easing: "linear",
+        returnToDefault: true,
+      }),
+      clip({ id: "b", startMs: 6000, durationMs: 1000 }),
+    ]
+    expect(clipsProgressAt(clips, 1500)).toBeCloseTo(0.5, 5)
+    expect(clipsProgressAt(clips, 4000)).toBeCloseTo(0, 5)
+  })
+
+  it("clipsProgressAt keeps holding for a clip that does not release", () => {
+    const clips = [clip({ id: "a", startMs: 0, durationMs: 1000 })]
+    expect(clipsProgressAt(clips, 9000)).toBe(1)
+  })
+
+  it("speed shortens the release window along with the transition", () => {
+    const clips = [
+      clip({
+        id: "a",
+        startMs: 0,
+        durationMs: 1000,
+        easing: "linear",
+        speed: 2,
+        returnToDefault: true,
+      }),
+    ]
+    // Active (and so release) is 500ms: fully unwound 500ms past the window.
+    expect(clipsProgressAt(clips, 1250)).toBeCloseTo(0.5, 5)
+    expect(clipsProgressAt(clips, 1500)).toBeCloseTo(0, 5)
+  })
+})

--- a/tests/lib/editor/animation-playback.test.ts
+++ b/tests/lib/editor/animation-playback.test.ts
@@ -18,6 +18,7 @@ import {
   lerp,
   resolveAnimateFilterStack,
   sampleKeyframes,
+  sampleShadowLayers,
   shadowsDiffer,
 } from "@/lib/editor/animation-playback"
 import type {
@@ -123,14 +124,27 @@ describe("clipsProgressAt", () => {
     expect(clipsProgressAt(clips, 1500)).toBeCloseTo(EASED_HALF, 5)
   })
 
-  it("holds the pose (1) after the clip and in trailing gaps", () => {
-    expect(clipsProgressAt(clips, 5000)).toBe(1)
+  it("holds the pose (1) after the clip when it opts out of releasing", () => {
+    const holding = [
+      clip({
+        id: "a",
+        startMs: 1000,
+        durationMs: 1000,
+        returnToDefault: false,
+      }),
+    ]
+    expect(clipsProgressAt(holding, 5000)).toBe(1)
   })
 
-  it("holds the pose (1) in a gap that follows an earlier clip", () => {
+  it("holds the pose (1) in a gap when both clips opt out", () => {
     const two = [
-      clip({ id: "a", startMs: 0, durationMs: 1000 }),
-      clip({ id: "b", startMs: 4000, durationMs: 1000 }),
+      clip({ id: "a", startMs: 0, durationMs: 1000, returnToDefault: false }),
+      clip({
+        id: "b",
+        startMs: 4000,
+        durationMs: 1000,
+        returnToDefault: false,
+      }),
     ]
     expect(clipsProgressAt(two, 2000)).toBe(1)
   })
@@ -559,9 +573,18 @@ describe("return to default (release)", () => {
     expect(clipsProgressAt(clips, 4000)).toBeCloseTo(0, 5)
   })
 
-  it("clipsProgressAt keeps holding for a clip that does not release", () => {
-    const clips = [clip({ id: "a", startMs: 0, durationMs: 1000 })]
+  it("clipsProgressAt keeps holding for a clip that opts out", () => {
+    const clips = [
+      clip({ id: "a", startMs: 0, durationMs: 1000, returnToDefault: false }),
+    ]
     expect(clipsProgressAt(clips, 9000)).toBe(1)
+  })
+
+  it("releases by default — an unflagged clip does not hold its pose", () => {
+    const clips = [
+      clip({ id: "a", startMs: 0, durationMs: 1000, easing: "linear" }),
+    ]
+    expect(clipsProgressAt(clips, 2000)).toBeCloseTo(0, 5)
   })
 
   it("speed shortens the release window along with the transition", () => {
@@ -578,5 +601,104 @@ describe("return to default (release)", () => {
     // Active (and so release) is 500ms: fully unwound 500ms past the window.
     expect(clipsProgressAt(clips, 1250)).toBeCloseTo(0.5, 5)
     expect(clipsProgressAt(clips, 1500)).toBeCloseTo(0, 5)
+  })
+})
+
+describe("sampleShadowLayers", () => {
+  const linear = (t: number) => t
+  const none: Shadow = {
+    type: "none",
+    intensity: 0,
+    color: "#000000",
+    lightSource: "center",
+  }
+  const soft: Shadow = {
+    type: "soft",
+    intensity: 80,
+    color: "#000000",
+    lightSource: "center",
+  }
+  const glow: Shadow = {
+    type: "glow",
+    intensity: 60,
+    color: "#ffffff",
+    lightSource: "center",
+  }
+  const frame = (value: Shadow, over: Record<string, unknown> = {}) => ({
+    startMs: 0,
+    durationMs: 1000,
+    value,
+    ease: linear,
+    releaseMs: 1000,
+    releaseEase: linear,
+    ...over,
+  })
+
+  it("returns null when no keyframe animates the shadow", () => {
+    expect(sampleShadowLayers([], 500, none)).toBeNull()
+  })
+
+  it("reveals from the rest shadow", () => {
+    expect(
+      sampleShadowLayers([frame(soft)], 0, none)![0].intensity
+    ).toBeCloseTo(0, 5)
+    expect(
+      sampleShadowLayers([frame(soft)], 500, none)![0].intensity
+    ).toBeCloseTo(40, 5)
+  })
+
+  it("holds the pose past the end when the frame opts out", () => {
+    const holding = [frame(soft, { releaseMs: 0 })]
+    expect(sampleShadowLayers(holding, 9000, none)).toEqual([soft])
+  })
+
+  it("fades back out to an invisible rest on its own type", () => {
+    // Retract semantics: it recedes as a `soft` shadow losing intensity rather
+    // than blinking off, mirroring how it revealed.
+    const mid = sampleShadowLayers([frame(soft)], 1500, none)!
+    expect(mid).toHaveLength(1)
+    expect(mid[0].type).toBe("soft")
+    expect(mid[0].intensity).toBeCloseTo(40, 5)
+
+    expect(sampleShadowLayers([frame(soft)], 2000, none)![0].intensity).toBe(0)
+  })
+
+  it("cross-blends back when rest is a different visible shadow", () => {
+    const mid = sampleShadowLayers([frame(soft)], 1500, glow)!
+    expect(mid.map((s) => s.type)).toEqual(["soft", "glow"])
+    expect(mid[0].intensity).toBeCloseTo(40, 5) // pose easing OUT
+    expect(mid[1].intensity).toBeCloseTo(30, 5) // rest easing back IN
+  })
+
+  it("sits exactly on the pose the instant the window ends", () => {
+    // lightSource normalizes to grid coords through the blend, so compare the
+    // fields the release actually drives.
+    const layers = sampleShadowLayers([frame(soft)], 1000, none)!
+    expect(layers).toHaveLength(1)
+    expect(layers[0].type).toBe(soft.type)
+    expect(layers[0].intensity).toBeCloseTo(soft.intensity, 5)
+  })
+
+  it("releases into a gap instead of holding through it", () => {
+    const frames = [
+      frame(soft),
+      { startMs: 4000, durationMs: 1000, value: glow, ease: linear },
+    ]
+    expect(sampleShadowLayers(frames, 1500, none)![0].intensity).toBeCloseTo(
+      40,
+      5
+    )
+    expect(sampleShadowLayers(frames, 3000, none)![0].intensity).toBe(0)
+  })
+
+  it("a next frame butted against the release departs from the full pose", () => {
+    const frames = [
+      frame(soft),
+      { startMs: 1000, durationMs: 1000, value: soft, ease: linear },
+    ]
+    expect(sampleShadowLayers(frames, 1000, none)![0].intensity).toBeCloseTo(
+      80,
+      5
+    )
   })
 })

--- a/tests/lib/editor/animation-release-frame.test.ts
+++ b/tests/lib/editor/animation-release-frame.test.ts
@@ -3,18 +3,82 @@ import { beforeEach, describe, expect, it } from "vitest"
 import { applyAnimationFrameAtTime } from "@/lib/editor/apply-animation-frame"
 import {
   backgroundLayerOpacityVar,
+  DEFAULT_BASELINE,
+  filterLayerOpacityVar,
   FULL_CROP_REGION,
+  OVERLAY_BASE_OPACITY_VAR,
+  overlayLayerOpacityVar,
+  PATTERN_BASE_OPACITY_VAR,
+  patternLayerOpacityVar,
+  PORTRAIT_BASE_OPACITY_VAR,
+  portraitLayerOpacityVar,
+  REST_LIGHTING,
 } from "@/lib/editor/animation-playback"
 import { captureClipPose, useEditorStore } from "@/lib/editor/store"
-import type { AnimationClip, CanvasState } from "@/lib/editor/state-types"
+import type {
+  AnimationClip,
+  AnimationEffect,
+  CanvasState,
+} from "@/lib/editor/state-types"
 
 /**
  * The release has to reach EVERY effect family, not just the ones sharing the
- * generic keyframe sampler — shadow and the layer crossfades each have their own
- * sampler, and each was a separate hold. This drives the real applicator and
- * asserts the vars unwind, so a new effect that forgets to forward the release
- * fails here rather than shipping as "this one animation doesn't come back".
+ * generic keyframe sampler: shadow has its own sampler, and the backdrop layers
+ * (background, filter, portrait, pattern, overlay) crossfade through their own
+ * opacity vars. Each of those was a separate hold, so this drives the real
+ * applicator over the whole union and asserts the frame at the end of the
+ * release is the frame at the clip's start — which is what "returns to default"
+ * means. An effect that forgets to forward the release fails here rather than
+ * shipping as "this one animation doesn't come back".
  */
+const ALL_EFFECTS: AnimationEffect[] = [
+  "position",
+  "zoom",
+  "tilt",
+  "padding",
+  "shadow",
+  "background",
+  "backdrop",
+  "canvasRadius",
+  "lighting",
+  "filter",
+  "portrait",
+  "pattern",
+  "overlay",
+  "border",
+  "borderRadius",
+  "crop",
+]
+
+/** Every var the clip below drives, across all of those sampling paths. */
+const VARS = [
+  "--crop-view-box",
+  "--canvas-ts-scale",
+  "--canvas-ts-rx",
+  "--canvas-ts-ry",
+  "--canvas-ts-rz",
+  "--editor-padding-preview",
+  "--canvas-bd-radius",
+  "--bd-fx-preview",
+  "--bd-noise-opacity",
+  "--editor-screenshot-radius",
+  "--editor-border-outline-preview",
+  "--editor-border-offset-preview",
+  "--editor-shadow-preview",
+  "--bd-light-op",
+  "--bd-light-img",
+  "--bd-light-op-in",
+  "--bd-light-img-in",
+  backgroundLayerOpacityVar("c1"),
+  filterLayerOpacityVar("c1"),
+  portraitLayerOpacityVar("c1"),
+  PORTRAIT_BASE_OPACITY_VAR,
+  patternLayerOpacityVar("c1"),
+  PATTERN_BASE_OPACITY_VAR,
+  overlayLayerOpacityVar("c1"),
+  OVERLAY_BASE_OPACITY_VAR,
+]
+
 const baseCanvas = (): CanvasState => {
   const s = useEditorStore.getState().present
   return s.canvases.find((c) => c.id === s.activeCanvasId)!
@@ -29,23 +93,22 @@ const applyAt = (el: HTMLElement, clips: AnimationClip[], timeMs: number) =>
     timeMs,
   })
 
+const readVars = (el: HTMLElement) =>
+  Object.fromEntries(VARS.map((v) => [v, el.style.getPropertyValue(v)]))
+
+/** A clip animating every effect from a neutral baseline to a loud pose. */
 const everythingClip = (over: Partial<AnimationClip> = {}): AnimationClip => {
   const base = captureClipPose(baseCanvas())
+  const lighting = base.lighting ?? REST_LIGHTING
+  const portrait = base.portrait ?? DEFAULT_BASELINE.portrait!
+  const pattern = base.pattern ?? DEFAULT_BASELINE.pattern!
+  const overlay = base.overlay ?? DEFAULT_BASELINE.overlay!
   return {
     id: "c1",
     startMs: 0,
     durationMs: 1000,
     easing: "linear",
-    effects: [
-      "crop",
-      "shadow",
-      "zoom",
-      "tilt",
-      "padding",
-      "canvasRadius",
-      "backdrop",
-      "background",
-    ],
+    effects: ALL_EFFECTS,
     baseline: {
       ...base,
       crop: FULL_CROP_REGION,
@@ -53,13 +116,21 @@ const everythingClip = (over: Partial<AnimationClip> = {}): AnimationClip => {
       canvasBorderRadius: 0,
       tilt: { rx: 0, ry: 0, rz: 0 },
       scale: 100,
+      screenshotOffset: { x: 0, y: 0 },
       shadow: {
         type: "none",
         intensity: 0,
         color: "#000000",
         lightSource: "center",
       },
-      backdropEffects: { ...base.backdropEffects, brightness: 100 },
+      backdropEffects: { ...base.backdropEffects, brightness: 100, noise: 0 },
+      border: { color: "#ffffff", width: 0, style: "solid", padding: 0 },
+      borderRadius: 0,
+      lighting: { ...lighting, intensity: 0 },
+      filter: "none",
+      portrait: { ...portrait, mode: "off" },
+      pattern: { ...pattern, ids: [] },
+      overlay: { ...overlay, opacity: 0 },
     },
     pose: {
       ...base,
@@ -68,28 +139,25 @@ const everythingClip = (over: Partial<AnimationClip> = {}): AnimationClip => {
       canvasBorderRadius: 40,
       tilt: { rx: 20, ry: 10, rz: 5 },
       scale: 150,
+      screenshotOffset: { x: 40, y: 30 },
       shadow: {
         type: "soft",
         intensity: 80,
         color: "#000000",
         lightSource: "center",
       },
-      backdropEffects: { ...base.backdropEffects, brightness: 150 },
+      backdropEffects: { ...base.backdropEffects, brightness: 150, noise: 40 },
+      border: { color: "#ff0000", width: 8, style: "solid", padding: 12 },
+      borderRadius: 24,
+      lighting: { ...lighting, intensity: 70 },
+      filter: "vivid",
+      portrait: { ...portrait, mode: "studio", intensity: 70 },
+      pattern: { ...pattern, ids: [1] },
+      overlay: { ...overlay, id: 3, opacity: 60 },
     },
     ...over,
   }
 }
-
-// Every var the clip above drives, and what each must read at rest.
-const VARS: [name: string, atRest: string][] = [
-  ["--crop-view-box", "inset(0% 0% 0% 0%)"],
-  ["--canvas-ts-scale", "1"],
-  ["--canvas-ts-rx", "0deg"],
-  ["--editor-padding-preview", "0.000%"],
-  ["--canvas-bd-radius", "0.000px"],
-  ["--bd-fx-preview", "brightness(1)"],
-  [backgroundLayerOpacityVar("c1"), "0"],
-]
 
 describe("release reaches every effect family", () => {
   let el: HTMLElement
@@ -100,65 +168,212 @@ describe("release reaches every effect family", () => {
     document.body.appendChild(el)
   })
 
-  it("unwinds every animated var back to rest after the clip", () => {
+  it("ends the release on exactly the frame the clip started from", () => {
     const clips = [everythingClip()]
 
+    applyAt(el, clips, 0)
+    const atStart = readVars(el)
+
     applyAt(el, clips, 1000)
-    const atPose = VARS.map(([name]) => el.style.getPropertyValue(name))
+    // Guard against a vacuous pass: the pose must actually differ from rest.
+    expect(readVars(el)).not.toEqual(atStart)
 
-    // Halfway through the release each var differs from the pose...
-    applyAt(el, clips, 1500)
-    const midRelease = VARS.map(([name]) => el.style.getPropertyValue(name))
-    expect(midRelease).not.toEqual(atPose)
-
-    // ...and by the end every one is back at rest and stays there.
     applyAt(el, clips, 2000)
-    for (const [name, atRest] of VARS) {
-      expect([name, el.style.getPropertyValue(name)]).toEqual([name, atRest])
-    }
+    expect(readVars(el)).toEqual(atStart)
+
     applyAt(el, clips, 99000)
-    for (const [name, atRest] of VARS) {
-      expect([name, el.style.getPropertyValue(name)]).toEqual([name, atRest])
-    }
+    expect(readVars(el)).toEqual(atStart)
   })
 
-  it("the release mirrors the reveal — same value in and out", () => {
+  it("mirrors the reveal — halfway out matches halfway in", () => {
     const clips = [everythingClip()]
 
     applyAt(el, clips, 500)
-    const halfIn = VARS.map(([name]) => el.style.getPropertyValue(name))
+    const halfIn = readVars(el)
 
     applyAt(el, clips, 1500)
-    const halfOut = VARS.map(([name]) => el.style.getPropertyValue(name))
+    expect(readVars(el)).toEqual(halfIn)
+  })
 
-    expect(halfOut).toEqual(halfIn)
+  it("every animated var moves during the release, none of them stall", () => {
+    const clips = [everythingClip()]
+
+    applyAt(el, clips, 1000)
+    const atPose = readVars(el)
+    applyAt(el, clips, 1500)
+    const midRelease = readVars(el)
+    applyAt(el, clips, 2000)
+    const atRest = readVars(el)
+
+    const moved: string[] = []
+    for (const name of VARS) {
+      // A var reading the same at the pose and at rest was never animated by
+      // this clip; every other one must have left the pose by mid-release.
+      if (atPose[name] === atRest[name]) continue
+      moved.push(name)
+      expect([name, midRelease[name]]).not.toEqual([name, atPose[name]])
+    }
+    // Not a vacuous pass: one representative var per sampling path, so a
+    // fixture that quietly stopped driving a family can't pass this file.
+    expect(moved).toEqual(
+      expect.arrayContaining([
+        "--canvas-ts-scale", // generic keyframe sampler
+        "--crop-view-box", // crop + its shell geometry
+        "--editor-shadow-preview", // shadow's own layer sampler
+        "--editor-border-outline-preview", // border
+        "--bd-fx-preview", // backdrop effects
+        "--bd-light-op-in", // lighting (inner side)
+        backgroundLayerOpacityVar("c1"), // the five layer crossfades
+        filterLayerOpacityVar("c1"),
+        portraitLayerOpacityVar("c1"),
+        patternLayerOpacityVar("c1"),
+        overlayLayerOpacityVar("c1"),
+      ])
+    )
   })
 
   it("the shadow recedes on its own type instead of blinking off", () => {
     const clips = [everythingClip()]
-    const scope = el
-
-    applyAt(el, clips, 1000)
-    const atPose = scope.style.getPropertyValue("--editor-shadow-preview")
 
     applyAt(el, clips, 1500)
-    const mid = scope.style.getPropertyValue("--editor-shadow-preview")
-    expect(mid).not.toBe(atPose)
+    const mid = el.style.getPropertyValue("--editor-shadow-preview")
     expect(mid).not.toBe("none")
+    expect(mid).not.toBe("")
 
     applyAt(el, clips, 2000)
-    expect(scope.style.getPropertyValue("--editor-shadow-preview")).toBe("none")
+    expect(el.style.getPropertyValue("--editor-shadow-preview")).toBe("none")
   })
 
-  it("a clip that opts out still holds every var at its pose", () => {
+  it("a clip that opts out holds instead of releasing", () => {
     const clips = [everythingClip({ returnToDefault: false })]
 
-    applyAt(el, clips, 1000)
-    const atPose = VARS.map(([name]) => el.style.getPropertyValue(name))
+    applyAt(el, clips, 0)
+    const atStart = readVars(el)
+
+    // Nothing moves once the window is over, and it never comes back to rest.
+    // (Compared past-the-end to past-the-end: the in-window frame writes the
+    // border colour as rgba() while the hold path passes the pose hex through,
+    // which is the same colour in a different notation.)
+    applyAt(el, clips, 2000)
+    const justAfter = readVars(el)
+    expect(justAfter).not.toEqual(atStart)
 
     applyAt(el, clips, 99000)
-    expect(VARS.map(([name]) => el.style.getPropertyValue(name))).toEqual(
-      atPose
+    expect(readVars(el)).toEqual(justAfter)
+  })
+})
+
+/**
+ * Extra screenshot slots are a second, parallel set of sampling sites (their own
+ * tilt/zoom/position/shadow/border/radius/padding/lighting frames). They were
+ * patched alongside the main ones, so they get the same end-to-end check.
+ */
+describe("release reaches slot-scoped effects", () => {
+  const SLOT_VARS = [
+    "--slot-ts-scale",
+    "--slot-ts-rx",
+    "--slot-ts-rot",
+    "--editor-shadow-preview",
+    "--editor-border-outline-preview",
+    "--editor-screenshot-radius",
+  ]
+
+  let el: HTMLElement
+  let slotEl: HTMLElement
+  let slotId: string
+
+  beforeEach(() => {
+    useEditorStore.getState().reset()
+    slotId = useEditorStore.getState().addScreenshotSlot()!
+    el = document.createElement("div")
+    slotEl = document.createElement("div")
+    slotEl.setAttribute("data-screenshot-slot-id", slotId)
+    el.appendChild(slotEl)
+    document.body.appendChild(el)
+  })
+
+  const slotClip = (over: Partial<AnimationClip> = {}): AnimationClip => {
+    const base = captureClipPose(baseCanvas())
+    const rest = {
+      tilt: { rx: 0, ry: 0, rz: 0 },
+      scale: 100,
+      rotation: 0,
+      shadow: {
+        type: "none" as const,
+        intensity: 0,
+        color: "#000000",
+        lightSource: "center",
+      },
+      border: {
+        color: "#ffffff",
+        width: 0,
+        style: "solid" as const,
+        padding: 0,
+      },
+      borderRadius: 0,
+    }
+    return {
+      id: "c1",
+      startMs: 0,
+      durationMs: 1000,
+      easing: "linear",
+      target: { scope: "slot", slotId },
+      effects: ["tilt", "zoom", "shadow", "border", "borderRadius"],
+      baseline: { ...base, slots: { [slotId]: rest } },
+      pose: {
+        ...base,
+        slots: {
+          [slotId]: {
+            tilt: { rx: 25, ry: 15, rz: 10 },
+            scale: 160,
+            rotation: 12,
+            shadow: {
+              type: "soft",
+              intensity: 80,
+              color: "#000000",
+              lightSource: "center",
+            },
+            border: {
+              color: "#ff0000",
+              width: 6,
+              style: "solid",
+              padding: 10,
+            },
+            borderRadius: 20,
+          },
+        },
+      },
+      ...over,
+    }
+  }
+
+  const readSlot = () =>
+    Object.fromEntries(
+      SLOT_VARS.map((v) => [v, slotEl.style.getPropertyValue(v)])
     )
+
+  it("unwinds a slot's vars back to the frame it started from", () => {
+    const clips = [slotClip()]
+
+    applyAt(el, clips, 0)
+    const atStart = readSlot()
+
+    applyAt(el, clips, 1000)
+    expect(readSlot()).not.toEqual(atStart)
+
+    applyAt(el, clips, 2000)
+    expect(readSlot()).toEqual(atStart)
+    applyAt(el, clips, 99000)
+    expect(readSlot()).toEqual(atStart)
+  })
+
+  it("mirrors the reveal on a slot too", () => {
+    const clips = [slotClip()]
+
+    applyAt(el, clips, 500)
+    const halfIn = readSlot()
+
+    applyAt(el, clips, 1500)
+    expect(readSlot()).toEqual(halfIn)
   })
 })

--- a/tests/lib/editor/animation-release-frame.test.ts
+++ b/tests/lib/editor/animation-release-frame.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { applyAnimationFrameAtTime } from "@/lib/editor/apply-animation-frame"
+import {
+  backgroundLayerOpacityVar,
+  FULL_CROP_REGION,
+} from "@/lib/editor/animation-playback"
+import { captureClipPose, useEditorStore } from "@/lib/editor/store"
+import type { AnimationClip, CanvasState } from "@/lib/editor/state-types"
+
+/**
+ * The release has to reach EVERY effect family, not just the ones sharing the
+ * generic keyframe sampler — shadow and the layer crossfades each have their own
+ * sampler, and each was a separate hold. This drives the real applicator and
+ * asserts the vars unwind, so a new effect that forgets to forward the release
+ * fails here rather than shipping as "this one animation doesn't come back".
+ */
+const baseCanvas = (): CanvasState => {
+  const s = useEditorStore.getState().present
+  return s.canvases.find((c) => c.id === s.activeCanvasId)!
+}
+
+const applyAt = (el: HTMLElement, clips: AnimationClip[], timeMs: number) =>
+  applyAnimationFrameAtTime({
+    canvasEl: el,
+    canvas: baseCanvas(),
+    globalAspect: { id: "auto", w: 16, h: 9 },
+    clips,
+    timeMs,
+  })
+
+const everythingClip = (over: Partial<AnimationClip> = {}): AnimationClip => {
+  const base = captureClipPose(baseCanvas())
+  return {
+    id: "c1",
+    startMs: 0,
+    durationMs: 1000,
+    easing: "linear",
+    effects: [
+      "crop",
+      "shadow",
+      "zoom",
+      "tilt",
+      "padding",
+      "canvasRadius",
+      "backdrop",
+      "background",
+    ],
+    baseline: {
+      ...base,
+      crop: FULL_CROP_REGION,
+      padding: 0,
+      canvasBorderRadius: 0,
+      tilt: { rx: 0, ry: 0, rz: 0 },
+      scale: 100,
+      shadow: {
+        type: "none",
+        intensity: 0,
+        color: "#000000",
+        lightSource: "center",
+      },
+      backdropEffects: { ...base.backdropEffects, brightness: 100 },
+    },
+    pose: {
+      ...base,
+      crop: { x: 20, y: 20, width: 60, height: 60 },
+      padding: 120,
+      canvasBorderRadius: 40,
+      tilt: { rx: 20, ry: 10, rz: 5 },
+      scale: 150,
+      shadow: {
+        type: "soft",
+        intensity: 80,
+        color: "#000000",
+        lightSource: "center",
+      },
+      backdropEffects: { ...base.backdropEffects, brightness: 150 },
+    },
+    ...over,
+  }
+}
+
+// Every var the clip above drives, and what each must read at rest.
+const VARS: [name: string, atRest: string][] = [
+  ["--crop-view-box", "inset(0% 0% 0% 0%)"],
+  ["--canvas-ts-scale", "1"],
+  ["--canvas-ts-rx", "0deg"],
+  ["--editor-padding-preview", "0.000%"],
+  ["--canvas-bd-radius", "0.000px"],
+  ["--bd-fx-preview", "brightness(1)"],
+  [backgroundLayerOpacityVar("c1"), "0"],
+]
+
+describe("release reaches every effect family", () => {
+  let el: HTMLElement
+
+  beforeEach(() => {
+    useEditorStore.getState().reset()
+    el = document.createElement("div")
+    document.body.appendChild(el)
+  })
+
+  it("unwinds every animated var back to rest after the clip", () => {
+    const clips = [everythingClip()]
+
+    applyAt(el, clips, 1000)
+    const atPose = VARS.map(([name]) => el.style.getPropertyValue(name))
+
+    // Halfway through the release each var differs from the pose...
+    applyAt(el, clips, 1500)
+    const midRelease = VARS.map(([name]) => el.style.getPropertyValue(name))
+    expect(midRelease).not.toEqual(atPose)
+
+    // ...and by the end every one is back at rest and stays there.
+    applyAt(el, clips, 2000)
+    for (const [name, atRest] of VARS) {
+      expect([name, el.style.getPropertyValue(name)]).toEqual([name, atRest])
+    }
+    applyAt(el, clips, 99000)
+    for (const [name, atRest] of VARS) {
+      expect([name, el.style.getPropertyValue(name)]).toEqual([name, atRest])
+    }
+  })
+
+  it("the release mirrors the reveal — same value in and out", () => {
+    const clips = [everythingClip()]
+
+    applyAt(el, clips, 500)
+    const halfIn = VARS.map(([name]) => el.style.getPropertyValue(name))
+
+    applyAt(el, clips, 1500)
+    const halfOut = VARS.map(([name]) => el.style.getPropertyValue(name))
+
+    expect(halfOut).toEqual(halfIn)
+  })
+
+  it("the shadow recedes on its own type instead of blinking off", () => {
+    const clips = [everythingClip()]
+    const scope = el
+
+    applyAt(el, clips, 1000)
+    const atPose = scope.style.getPropertyValue("--editor-shadow-preview")
+
+    applyAt(el, clips, 1500)
+    const mid = scope.style.getPropertyValue("--editor-shadow-preview")
+    expect(mid).not.toBe(atPose)
+    expect(mid).not.toBe("none")
+
+    applyAt(el, clips, 2000)
+    expect(scope.style.getPropertyValue("--editor-shadow-preview")).toBe("none")
+  })
+
+  it("a clip that opts out still holds every var at its pose", () => {
+    const clips = [everythingClip({ returnToDefault: false })]
+
+    applyAt(el, clips, 1000)
+    const atPose = VARS.map(([name]) => el.style.getPropertyValue(name))
+
+    applyAt(el, clips, 99000)
+    expect(VARS.map(([name]) => el.style.getPropertyValue(name))).toEqual(
+      atPose
+    )
+  })
+})

--- a/tests/lib/editor/clip-easing.test.ts
+++ b/tests/lib/editor/clip-easing.test.ts
@@ -5,6 +5,9 @@ import {
   CLIP_EASING_LABELS,
   clipEasingKind,
   clipProgressEase,
+  clipReleaseEase,
+  clipReleaseMs,
+  clipReturnsToDefault,
   clipSpeed,
   DEFAULT_CLIP_EASING,
   DEFAULT_CLIP_SPEED,
@@ -162,5 +165,60 @@ describe("easingDotAt", () => {
     const end = easingDotAt("linear", 1, size, pad)
     expect(end.x).toBeCloseTo(size - pad, 6)
     expect(end.y).toBeCloseTo(pad, 6)
+  })
+})
+
+describe("clipReturnsToDefault", () => {
+  it("is off when unset, so clips saved before the release keep holding", () => {
+    expect(clipReturnsToDefault(clip())).toBe(false)
+  })
+
+  it("passes an explicit choice through", () => {
+    expect(clipReturnsToDefault(clip({ returnToDefault: true }))).toBe(true)
+    expect(clipReturnsToDefault(clip({ returnToDefault: false }))).toBe(false)
+  })
+})
+
+describe("clipReleaseMs", () => {
+  it("is 0 when the clip holds its pose", () => {
+    expect(clipReleaseMs(clip())).toBe(0)
+    expect(clipReleaseMs(clip({ returnToDefault: false }))).toBe(0)
+  })
+
+  it("mirrors the clip's window when it releases at full speed", () => {
+    expect(
+      clipReleaseMs(clip({ durationMs: 1200, returnToDefault: true }))
+    ).toBe(1200)
+  })
+
+  it("mirrors the ACTIVE duration, so speed shortens the release too", () => {
+    const fast = clip({ durationMs: 5000, speed: 5, returnToDefault: true })
+    expect(clipReleaseMs(fast)).toBe(effectiveActiveMs(fast))
+    expect(clipReleaseMs(fast)).toBe(1000)
+  })
+})
+
+describe("clipReleaseEase", () => {
+  it("pins the endpoints so the release starts at the pose and lands on rest", () => {
+    const ease = clipReleaseEase(clip({ easing: "linear" }))
+    expect(ease(0)).toBeCloseTo(0, 6)
+    expect(ease(1)).toBeCloseTo(1, 6)
+  })
+
+  it("uses the clip's own curve", () => {
+    expect(clipReleaseEase(clip({ easing: "linear" }))(0.5)).toBeCloseTo(0.5, 6)
+    expect(clipReleaseEase(clip({ easing: "out" }))(0.5)).toBeCloseTo(0.875, 6)
+  })
+
+  it("drops the speed remap — speed already shortened the release window", () => {
+    const fast = clip({ easing: "linear", speed: 4 })
+    expect(clipProgressEase(fast)(0.5)).toBeCloseTo(1, 6)
+    expect(clipReleaseEase(fast)(0.5)).toBeCloseTo(0.5, 6)
+  })
+
+  it("clamps progress outside 0..1", () => {
+    const ease = clipReleaseEase(clip({ easing: "linear" }))
+    expect(ease(-1)).toBeCloseTo(0, 6)
+    expect(ease(2)).toBeCloseTo(1, 6)
   })
 })

--- a/tests/lib/editor/clip-easing.test.ts
+++ b/tests/lib/editor/clip-easing.test.ts
@@ -169,8 +169,9 @@ describe("easingDotAt", () => {
 })
 
 describe("clipReturnsToDefault", () => {
-  it("is off when unset, so clips saved before the release keep holding", () => {
-    expect(clipReturnsToDefault(clip())).toBe(false)
+  it("is ON when unset, so every clip releases unless it opts out", () => {
+    // Drafts saved before the release existed carry no flag; they release too.
+    expect(clipReturnsToDefault(clip())).toBe(true)
   })
 
   it("passes an explicit choice through", () => {
@@ -180,19 +181,16 @@ describe("clipReturnsToDefault", () => {
 })
 
 describe("clipReleaseMs", () => {
-  it("is 0 when the clip holds its pose", () => {
-    expect(clipReleaseMs(clip())).toBe(0)
+  it("is 0 only when the clip opts out of releasing", () => {
     expect(clipReleaseMs(clip({ returnToDefault: false }))).toBe(0)
   })
 
   it("mirrors the clip's window when it releases at full speed", () => {
-    expect(
-      clipReleaseMs(clip({ durationMs: 1200, returnToDefault: true }))
-    ).toBe(1200)
+    expect(clipReleaseMs(clip({ durationMs: 1200 }))).toBe(1200)
   })
 
   it("mirrors the ACTIVE duration, so speed shortens the release too", () => {
-    const fast = clip({ durationMs: 5000, speed: 5, returnToDefault: true })
+    const fast = clip({ durationMs: 5000, speed: 5 })
     expect(clipReleaseMs(fast)).toBe(effectiveActiveMs(fast))
     expect(clipReleaseMs(fast)).toBe(1000)
   })

--- a/tests/lib/editor/store/clip-return-to-default.test.ts
+++ b/tests/lib/editor/store/clip-return-to-default.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { useEditorStore } from "@/lib/editor/store"
+
+const store = useEditorStore
+
+const activeCanvas = () => {
+  const s = store.getState().present
+  return s.canvases.find((c) => c.id === s.activeCanvasId)!
+}
+const clips = () => activeCanvas().animation!.clips
+const clipById = (id: string) => clips().find((c) => c.id === id)!
+
+describe("addAnimationClip returnToDefault", () => {
+  beforeEach(() => store.getState().reset())
+
+  it("marks new clips as returning to default explicitly", () => {
+    const id = store.getState().addAnimationClip()
+    // Explicit `true`, not undefined: undefined is the legacy hold, so relying
+    // on the default would silently change how old drafts play.
+    expect(clipById(id).returnToDefault).toBe(true)
+  })
+
+  it("lets a clip be switched back to holding its pose", () => {
+    const id = store.getState().addAnimationClip()
+    store.getState().updateAnimationClip(id, { returnToDefault: false })
+    expect(clipById(id).returnToDefault).toBe(false)
+  })
+
+  it("carries the choice onto both halves of a split", () => {
+    const id = store.getState().addAnimationClip()
+    const source = clipById(id)
+    const newId = store
+      .getState()
+      .splitAnimationClip(id, source.startMs + source.durationMs / 2)
+    expect(newId).not.toBeNull()
+    expect(clipById(id).returnToDefault).toBe(true)
+    expect(clipById(newId!).returnToDefault).toBe(true)
+  })
+})

--- a/tests/lib/editor/store/clip-return-to-default.test.ts
+++ b/tests/lib/editor/store/clip-return-to-default.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest"
 
+import { clipReturnsToDefault } from "@/lib/editor/clip-easing"
 import { useEditorStore } from "@/lib/editor/store"
 
 const store = useEditorStore
@@ -14,11 +15,9 @@ const clipById = (id: string) => clips().find((c) => c.id === id)!
 describe("addAnimationClip returnToDefault", () => {
   beforeEach(() => store.getState().reset())
 
-  it("marks new clips as returning to default explicitly", () => {
+  it("returns new clips to default without needing a stored flag", () => {
     const id = store.getState().addAnimationClip()
-    // Explicit `true`, not undefined: undefined is the legacy hold, so relying
-    // on the default would silently change how old drafts play.
-    expect(clipById(id).returnToDefault).toBe(true)
+    expect(clipReturnsToDefault(clipById(id))).toBe(true)
   })
 
   it("lets a clip be switched back to holding its pose", () => {
@@ -27,14 +26,15 @@ describe("addAnimationClip returnToDefault", () => {
     expect(clipById(id).returnToDefault).toBe(false)
   })
 
-  it("carries the choice onto both halves of a split", () => {
+  it("carries an opt-out onto both halves of a split", () => {
     const id = store.getState().addAnimationClip()
+    store.getState().updateAnimationClip(id, { returnToDefault: false })
     const source = clipById(id)
     const newId = store
       .getState()
       .splitAnimationClip(id, source.startMs + source.durationMs / 2)
     expect(newId).not.toBeNull()
-    expect(clipById(id).returnToDefault).toBe(true)
-    expect(clipById(newId!).returnToDefault).toBe(true)
+    expect(clipReturnsToDefault(clipById(id))).toBe(false)
+    expect(clipReturnsToDefault(clipById(newId!))).toBe(false)
   })
 })

--- a/tests/lib/editor/video-timeline-map.test.ts
+++ b/tests/lib/editor/video-timeline-map.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest"
+
+import { sourceTimeAt, videoClipAtTime } from "@/lib/editor/video-timeline-map"
+import type { VideoTimelineClip } from "@/lib/editor/state-types"
+
+/**
+ * Timeline time and source time only agree for an untrimmed clip parked at
+ * zero. The animate player and the crop dialog both map between them, and they
+ * have to agree — otherwise the crop handles land on a different frame than the
+ * canvas plays.
+ */
+const clip = (over: Partial<VideoTimelineClip> = {}): VideoTimelineClip => ({
+  id: "v1",
+  timelineStartMs: 0,
+  startMs: 0,
+  endMs: null,
+  ...over,
+})
+
+describe("videoClipAtTime", () => {
+  it("treats a missing timeline as one untrimmed clip over the source", () => {
+    expect(videoClipAtTime(null, 6090, 7100)?.id).toBe("video-main")
+    expect(videoClipAtTime([], 6090, 7100)?.id).toBe("video-main")
+  })
+
+  it("finds the clip covering the time", () => {
+    const clips = [
+      clip({ id: "a", timelineStartMs: 0, startMs: 0, endMs: 2000 }),
+      clip({ id: "b", timelineStartMs: 2000, startMs: 5000, endMs: 7000 }),
+    ]
+    expect(videoClipAtTime(clips, 500)?.id).toBe("a")
+    expect(videoClipAtTime(clips, 2500)?.id).toBe("b")
+  })
+
+  it("returns undefined in a gap between clips", () => {
+    const clips = [
+      clip({ id: "a", timelineStartMs: 0, startMs: 0, endMs: 1000 }),
+      clip({ id: "b", timelineStartMs: 5000, startMs: 0, endMs: 1000 }),
+    ]
+    expect(videoClipAtTime(clips, 3000)).toBeUndefined()
+  })
+
+  it("is half-open — a clip's own end belongs to the next clip", () => {
+    const clips = [
+      clip({ id: "a", timelineStartMs: 0, startMs: 0, endMs: 2000 }),
+      clip({ id: "b", timelineStartMs: 2000, startMs: 0, endMs: 2000 }),
+    ]
+    expect(videoClipAtTime(clips, 2000)?.id).toBe("b")
+  })
+})
+
+describe("sourceTimeAt", () => {
+  it("passes the time straight through for an untrimmed clip at zero", () => {
+    expect(sourceTimeAt(null, 6090, 7.1)).toBeCloseTo(6.09, 5)
+  })
+
+  it("offsets by the clip's trim — the whole point of the mapping", () => {
+    // Plays source 5s..7s while sitting at 2s..4s on the timeline, so timeline
+    // 3s is source 6s.
+    const clips = [clip({ timelineStartMs: 2000, startMs: 5000, endMs: 7000 })]
+    expect(sourceTimeAt(clips, 3000, 7.1)).toBeCloseTo(6, 5)
+  })
+
+  it("returns null in a gap, so callers can fall back", () => {
+    const clips = [clip({ timelineStartMs: 0, startMs: 0, endMs: 1000 })]
+    expect(sourceTimeAt(clips, 4000, 7.1)).toBeNull()
+  })
+
+  it("has no source time past the end of the media", () => {
+    expect(sourceTimeAt(null, 999_000, 7.1)).toBeNull()
+  })
+
+  it("clamps when a clip's end overruns the real media duration", () => {
+    // Stale/optimistic endMs (metadata said longer than the file really is).
+    const clips = [clip({ timelineStartMs: 0, startMs: 0, endMs: 60_000 })]
+    expect(sourceTimeAt(clips, 8000, 7.1)).toBeCloseTo(7.1, 5)
+  })
+
+  it("leaves the time unclamped when the duration is not known yet", () => {
+    expect(sourceTimeAt(null, 6090)).toBeCloseTo(6.09, 5)
+    expect(sourceTimeAt(null, 6090, Number.NaN)).toBeCloseTo(6.09, 5)
+  })
+})


### PR DESCRIPTION
Two related pieces of Animate-mode work: animation clips can now unwind back to their pre-clip state after their window, and the video crop dialog previews the frame you are actually looking at.

## Clips return to default

A clip held its pose for the rest of the timeline once the playhead passed it, so a keyframe's effect outlived the band that authored it. Clips now **release**: after the window ends, every owned effect eases back to the pre-clip state over a window mirroring the active transition (so `speed` shortens both directions), riding the clip's own easing curve.

- Off per clip via a **Return to default** toggle in the Transition popover.
- `returnToDefault: undefined` reads as **on**, so existing timelines release too — this changes playback for already-saved drafts, deliberately.
- The release runs *past* the clip band, so a timeline whose last clip ends at 7s keeps moving until the unwind finishes.

The interesting part is chain continuity. A later clip reads the previous clip's value **sampled at its own start**, not flat: a clip butted against the previous one still departs from the full pose, and one starting mid-release departs from wherever the unwind got to. Nothing jumps.

### It had to reach every effect, not just most

The first pass only covered effects sharing the generic keyframe sampler. Two families have their own and kept holding:

- **`sampleShadowLayers`** — shadow cross-blends stacked layers, so it samples separately. It now runs the pose back out under the same blend rules the reveal used: cross-blending when rest is a different visible type, fading on its own type when rest renders nothing. Taking the *outgoing* layer as the value a later frame departs from matters — blending straight to rest adopts rest's type, and a rest of `none` left a shadow rendering nothing.
- **`lightingTargetMixAt`** — dropped the release fields when re-mapping its frames, so a released clip would slide its light back to the rest position while the side it rendered on stayed pinned to the pose.

`tests/lib/editor/animation-release-frame.test.ts` drives the real applicator across the whole `AnimationEffect` union (typed as the union, so a new member is a compile error) and asserts the frame at the end of the release **is** the frame at the clip's start — which is what "returns to default" means, and doesn't encode incidental notation like the border colour arriving as `rgba()` through the blend but as the pose hex through the hold. It fails loudly if a var doesn't move, which is how the lighting assertions turned out to be watching the outer side of an inner-target light. Slots get the same check.

## Crop previews the right frame

The crop dialog builds a still poster because `react-image-crop` is image-only, and that poster always seeked ~0.1s in. Cropping a video parked six seconds down the timeline drew the handles over content that wasn't on screen.

Three bugs, in order:

1. **Hardcoded seek.** Now seeks to the playhead. One mechanism covers normal and Animate mode — the video control bar and the animate player both drive the same registered `<video>`.
2. **Selecting a clip doesn't move the playhead**, so authoring a crop for a keyframe at 00:05 previewed whatever the playhead sat on. With a keyframe open, the dialog now previews the frame its pose lands on (the end of its window). With none open, the playhead still wins.
3. **`useMemo` cached the time.** `currentTime` is not React state, so no dep changed as the video played and the memo served what it read when the element registered — 0. It now passes a **getter**, called when the still is decoded, which removes the class of bug rather than the instance.

Also drops the decoded still on close: it was keyed only by URL, so reopening served the previous open's frame instantly — for a video that is a different moment in the clip, not a cache hit.

The timeline→source mapping is extracted to `lib/editor/video-timeline-map.ts` and shared with the animate player. A trimmed clip plays source 5s at timeline 2s; a preview that skipped the offset would frame a different shot than the clip plays. A keyframe over a gap in the video falls back to the playhead rather than previewing a frame it never shows.

## Testing

1014 tests pass (`pnpm test`), `pnpm typecheck` and lint clean.

Existing animation tests that asserted hold semantics were updated to opt out explicitly — those edits are the back-compat surface worth reviewing.

**Not verified in the running app.** The unit tests cover the pure seek math and the frame applicator; both crop bugs lived in the React wiring around them, which nothing here exercises. Worth a manual pass: scrub to ~4s, open crop, confirm the still matches the canvas — then again with a keyframe selected.

## Known gaps

- **Slot crops** keep the old first-frame behaviour. Extra screenshot slots aren't in the video registry, so they have neither a playhead nor a keyframe to read.
- **Release length** mirrors the clip's active duration and isn't separately adjustable. If a 7s clip unwinding over 7s feels slow in practice, a release-duration control is a small follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Return to default”** option to transition controls.
  * Animations now support a **release/unwind phase** that eases effects back after the active window (or holds when disabled).
  * Crop dialog poster frames now reflect the **current playhead**, including trimmed clip and gap handling.
* **Bug Fixes**
  * Improved deterministic poster seeking to avoid end-boundary/empty frames and reduced preview flicker on reopen.
  * Refined video timeline ↔ source-time syncing for more accurate playback/preview.
* **Tests**
  * Added extensive coverage for return-to-default/release behavior, poster seeking, and timeline-to-video time mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds clip release transitions and frame-aware video crop previews. The main changes are:

- Clips unwind to their pre-clip state after their active window.
- Shadow layers and lighting targets remain continuous during release.
- Crop posters use the current playhead or selected keyframe time.
- Playback and crop previews share trimmed-video timeline mapping.
- Transition controls include a per-clip return-to-default toggle.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The updated shadow sampler preserves both layers from an active cross-type release.
- The next keyframe starts from the complete rendered shadow state without a boundary pop.
- Tests cover the boundary and the residual-layer fade during the next transition.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/editor/animation-playback.ts | Adds release sampling and preserves all shadow layers when another keyframe starts during a cross-type release. |
| lib/editor/apply-animation-frame.ts | Applies release timing across animated effects and renders complete shadow-layer arrays. |
| lib/editor/clip-easing.ts | Defines the default release behavior, release duration, and release easing. |
| components/editor/canvas/canvas-view.tsx | Provides crop previews with the selected keyframe or current video playhead time. |
| components/editor/crop-modal.tsx | Decodes video posters at the requested source time and clears stale posters when the dialog closes. |
| lib/editor/video-timeline-map.ts | Centralizes timeline-to-source mapping for trimmed video clips and timeline gaps. |
| tests/lib/editor/animation-playback.test.ts | Covers shadow-layer continuity at keyframe boundaries and during the incoming transition. |

<sub>Reviews (2): Last reviewed commit: ["fix: keep both layers when a frame start..."](https://github.com/shivabhattacharjee/tokokino/commit/278608daf68aec8948e711e927a191d4fd52723f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46031921)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/sideprojects/github/ShivaBhattacharjee/tokokino/-/custom-context?memory=7a22f059-86c3-428b-88f5-f28e5fb51882))
- Context used - agents.md ([source](https://app.greptile.com/sideprojects/github/ShivaBhattacharjee/tokokino/-/custom-context?memory=0b3651fa-1db4-4837-8570-4aaf8d2a4cc2))

<!-- /greptile_comment -->