### PR TITLE
Drive preset previews from live canvas state and CSS vars

### DIFF
--- a/app/api/presets/route.ts
+++ b/app/api/presets/route.ts
@@ -3,7 +3,11 @@ import { NextResponse } from "next/server"
 import { requireSession } from "@/lib/api-auth"
 import { enforceRateLimit } from "@/lib/rate-limit"
 import { createCustomPreset, listCustomPresets } from "@/lib/preset-db"
-import { MAX_PRESET_BYTES, createPresetBodySchema } from "@/lib/schemas/preset"
+import {
+  MAX_PRESET_BYTES,
+  createPresetBodySchema,
+  presetListQuerySchema,
+} from "@/lib/schemas/preset"
 
 export const runtime = "nodejs"
 
@@ -11,7 +15,12 @@ export async function GET(request: Request) {
   const auth = await requireSession(request)
   if (!auth.ok) return auth.response
 
-  const presets = await listCustomPresets(auth.session.user.id)
+  const url = new URL(request.url)
+  const { sort } = presetListQuerySchema.parse({
+    sort: url.searchParams.get("sort") ?? undefined,
+  })
+
+  const presets = await listCustomPresets(auth.session.user.id, { sort })
   return NextResponse.json({
     presets: presets.map((preset) => ({
       id: preset.id,

--- a/components/editor/annotation-shape/element.tsx
+++ b/components/editor/annotation-shape/element.tsx
@@ -261,8 +261,13 @@ export function AnnotationShapeElement({
         xPct: drag.nextXPct,
         yPct: drag.nextYPct,
       })
+      // Skip if the shape was grabbed again before the frame ran — the new
+      // drag owns the vars now.
       const roots = livePreviewRoots(canvasScopeId)
-      requestAnimationFrame(() => clearElementLivePosition(roots, shape.id))
+      requestAnimationFrame(() => {
+        if (dragRef.current) return
+        clearElementLivePosition(roots, shape.id)
+      })
     }
     onCenterGuideChange?.({ x: false, y: false })
   }

--- a/components/editor/annotation-shape/element.tsx
+++ b/components/editor/annotation-shape/element.tsx
@@ -4,7 +4,17 @@ import * as React from "react"
 import { createPortal } from "react-dom"
 import { RiRefreshLine } from "@remixicon/react"
 
-import { type AnnotationShape, useEditor } from "@/lib/editor/store"
+import {
+  type AnnotationShape,
+  useEditor,
+  useEditorStore,
+} from "@/lib/editor/store"
+import {
+  clearElementLivePosition,
+  elementPositionVars,
+  livePreviewRoots,
+  setElementLivePosition,
+} from "@/lib/editor/live-preview-roots"
 import { cn } from "@/lib/utils"
 import {
   bulkToolbarScale,
@@ -96,6 +106,13 @@ export function AnnotationShapeElement({
   } = useEditor()
   const isSelected = selectedAnnotationShapeId === shape.id
   const dashArray = lineDashArray(shape.lineStyle)
+  const positionVars = elementPositionVars(shape.id)
+  const activeCanvasId = useEditorStore((s) => s.present.activeCanvasId)
+  const activeCanvasIdRef = React.useRef(activeCanvasId)
+  React.useEffect(() => {
+    activeCanvasIdRef.current = activeCanvasId
+  })
+
   const elRef = React.useRef<HTMLDivElement>(null)
   const selectionChromeRef = React.useRef<HTMLDivElement>(null)
   const dragRef = React.useRef<DragState | null>(null)
@@ -224,12 +241,17 @@ export function AnnotationShapeElement({
     drag.nextXPct = nextX
     drag.nextYPct = nextY
     drag.moved = true
+    // Broadcast from the canvas roots so the preset thumbnails' copy of this
+    // shape tracks the drag. The selection chrome is canvas-only UI and never
+    // renders in a preview, so it keeps its direct inline write.
+    setElementLivePosition(
+      livePreviewRoots(activeCanvasIdRef.current),
+      shape.id,
+      nextX,
+      nextY
+    )
     const el = elRef.current
-    if (el) {
-      el.style.left = `${nextX}%`
-      el.style.top = `${nextY}%`
-      setToolbarRect(el.getBoundingClientRect())
-    }
+    if (el) setToolbarRect(el.getBoundingClientRect())
     const chrome = selectionChromeRef.current
     if (chrome) {
       chrome.style.left = `${nextX}%`
@@ -247,6 +269,8 @@ export function AnnotationShapeElement({
         xPct: drag.nextXPct,
         yPct: drag.nextYPct,
       })
+      const roots = livePreviewRoots(activeCanvasIdRef.current)
+      requestAnimationFrame(() => clearElementLivePosition(roots, shape.id))
     }
     onCenterGuideChange?.({ x: false, y: false })
   }
@@ -495,8 +519,8 @@ export function AnnotationShapeElement({
         data-annotation-shape-id={shape.id}
         data-export-stack="foreground"
         style={{
-          left: `var(--editor-position-x, ${shape.xPct}%)`,
-          top: `var(--editor-position-y, ${shape.yPct}%)`,
+          left: `var(${positionVars.x}, var(--editor-position-x, ${shape.xPct}%))`,
+          top: `var(${positionVars.y}, var(--editor-position-y, ${shape.yPct}%))`,
           width: isStep ? STEP_SIZE : `${shape.widthPct}%`,
           height: isStep ? STEP_SIZE : `${shape.heightPct}%`,
           transform: `translate(-50%, -50%) rotate(${rotation}deg)`,

--- a/components/editor/annotation-shape/element.tsx
+++ b/components/editor/annotation-shape/element.tsx
@@ -4,11 +4,7 @@ import * as React from "react"
 import { createPortal } from "react-dom"
 import { RiRefreshLine } from "@remixicon/react"
 
-import {
-  type AnnotationShape,
-  useEditor,
-  useEditorStore,
-} from "@/lib/editor/store"
+import { type AnnotationShape, useEditor } from "@/lib/editor/store"
 import {
   clearElementLivePosition,
   elementPositionVars,
@@ -94,6 +90,7 @@ export function AnnotationShapeElement({
   previewMode?: boolean
 }) {
   const {
+    id: canvasScopeId,
     selectedAnnotationShapeId,
     setSelectedAnnotationShapeId,
     setSelectedTextId,
@@ -107,11 +104,6 @@ export function AnnotationShapeElement({
   const isSelected = selectedAnnotationShapeId === shape.id
   const dashArray = lineDashArray(shape.lineStyle)
   const positionVars = elementPositionVars(shape.id)
-  const activeCanvasId = useEditorStore((s) => s.present.activeCanvasId)
-  const activeCanvasIdRef = React.useRef(activeCanvasId)
-  React.useEffect(() => {
-    activeCanvasIdRef.current = activeCanvasId
-  })
 
   const elRef = React.useRef<HTMLDivElement>(null)
   const selectionChromeRef = React.useRef<HTMLDivElement>(null)
@@ -245,7 +237,7 @@ export function AnnotationShapeElement({
     // shape tracks the drag. The selection chrome is canvas-only UI and never
     // renders in a preview, so it keeps its direct inline write.
     setElementLivePosition(
-      livePreviewRoots(activeCanvasIdRef.current),
+      livePreviewRoots(canvasScopeId),
       shape.id,
       nextX,
       nextY
@@ -269,7 +261,7 @@ export function AnnotationShapeElement({
         xPct: drag.nextXPct,
         yPct: drag.nextYPct,
       })
-      const roots = livePreviewRoots(activeCanvasIdRef.current)
+      const roots = livePreviewRoots(canvasScopeId)
       requestAnimationFrame(() => clearElementLivePosition(roots, shape.id))
     }
     onCenterGuideChange?.({ x: false, y: false })

--- a/components/editor/asset-element.tsx
+++ b/components/editor/asset-element.tsx
@@ -31,7 +31,6 @@ import {
   type AssetFilter,
   assetFilterCss,
   useEditor,
-  useEditorStore,
 } from "@/lib/editor/store"
 import {
   clearElementLivePosition,
@@ -88,6 +87,7 @@ export function AssetElementView({
   previewMode?: boolean
 }) {
   const {
+    id: canvasScopeId,
     selectedAssetId,
     setSelectedAssetId,
     setSelectedTextId,
@@ -101,11 +101,6 @@ export function AssetElementView({
   const isSelected = selectedAssetId === asset.id
 
   const positionVars = elementPositionVars(asset.id)
-  const activeCanvasId = useEditorStore((s) => s.present.activeCanvasId)
-  const activeCanvasIdRef = React.useRef(activeCanvasId)
-  React.useEffect(() => {
-    activeCanvasIdRef.current = activeCanvasId
-  })
 
   const elRef = React.useRef<HTMLDivElement>(null)
   const imgRef = React.useRef<HTMLImageElement>(null)
@@ -212,7 +207,7 @@ export function AssetElementView({
     // Broadcasting them from the canvas roots (rather than this element's own
     // inline style) also carries the drag into the preset thumbnails' copy.
     setElementLivePosition(
-      livePreviewRoots(activeCanvasIdRef.current),
+      livePreviewRoots(canvasScopeId),
       asset.id,
       nextX,
       nextY
@@ -231,7 +226,7 @@ export function AssetElementView({
       })
       // Clear a frame later so the committed value takes over from the var
       // without a one-frame jump back to where the drag started.
-      const roots = livePreviewRoots(activeCanvasIdRef.current)
+      const roots = livePreviewRoots(canvasScopeId)
       requestAnimationFrame(() => clearElementLivePosition(roots, asset.id))
     }
     dragRef.current = null

--- a/components/editor/asset-element.tsx
+++ b/components/editor/asset-element.tsx
@@ -31,7 +31,14 @@ import {
   type AssetFilter,
   assetFilterCss,
   useEditor,
+  useEditorStore,
 } from "@/lib/editor/store"
+import {
+  clearElementLivePosition,
+  elementPositionVars,
+  livePreviewRoots,
+  setElementLivePosition,
+} from "@/lib/editor/live-preview-roots"
 import { useFloatingToolbarRect } from "@/hooks/use-floating-toolbar-rect"
 import { readImageFileAsDataUrl } from "@/lib/editor/image-resize"
 import { cn } from "@/lib/utils"
@@ -92,6 +99,13 @@ export function AssetElementView({
     bulkViewportZoom,
   } = useEditor()
   const isSelected = selectedAssetId === asset.id
+
+  const positionVars = elementPositionVars(asset.id)
+  const activeCanvasId = useEditorStore((s) => s.present.activeCanvasId)
+  const activeCanvasIdRef = React.useRef(activeCanvasId)
+  React.useEffect(() => {
+    activeCanvasIdRef.current = activeCanvasId
+  })
 
   const elRef = React.useRef<HTMLDivElement>(null)
   const imgRef = React.useRef<HTMLImageElement>(null)
@@ -194,13 +208,17 @@ export function AssetElementView({
     drag.lastXPct = nextX
     drag.lastYPct = nextY
     drag.moved = true
-    // Mutate DOM directly to avoid re-rendering the entire editor on every pointermove
+    // Drive CSS vars instead of re-rendering the editor on every pointermove.
+    // Broadcasting them from the canvas roots (rather than this element's own
+    // inline style) also carries the drag into the preset thumbnails' copy.
+    setElementLivePosition(
+      livePreviewRoots(activeCanvasIdRef.current),
+      asset.id,
+      nextX,
+      nextY
+    )
     const el = elRef.current
-    if (el) {
-      el.style.left = `${nextX}%`
-      el.style.top = `${nextY}%`
-      setToolbarRect(el.getBoundingClientRect())
-    }
+    if (el) setToolbarRect(el.getBoundingClientRect())
   }
 
   const endDrag = (e: React.PointerEvent<Element>) => {
@@ -211,6 +229,10 @@ export function AssetElementView({
         xPct: drag.lastXPct,
         yPct: drag.lastYPct,
       })
+      // Clear a frame later so the committed value takes over from the var
+      // without a one-frame jump back to where the drag started.
+      const roots = livePreviewRoots(activeCanvasIdRef.current)
+      requestAnimationFrame(() => clearElementLivePosition(roots, asset.id))
     }
     dragRef.current = null
     setIsDragging(false)
@@ -353,8 +375,8 @@ export function AssetElementView({
           isSelected ? "cursor-grabbing" : "cursor-grab"
         )}
         style={{
-          left: `var(--editor-position-x, ${asset.xPct}%)`,
-          top: `var(--editor-position-y, ${asset.yPct}%)`,
+          left: `var(${positionVars.x}, var(--editor-position-x, ${asset.xPct}%))`,
+          top: `var(${positionVars.y}, var(--editor-position-y, ${asset.yPct}%))`,
           width: `${asset.widthPct}%`,
           height: heightStyle,
           transform: `translate(-50%, -50%) rotate(${asset.rotation}deg) scaleX(${asset.flipX ? -1 : 1}) scaleY(${asset.flipY ? -1 : 1})`,

--- a/components/editor/asset-element.tsx
+++ b/components/editor/asset-element.tsx
@@ -219,17 +219,21 @@ export function AssetElementView({
   const endDrag = (e: React.PointerEvent<Element>) => {
     const drag = dragRef.current
     if (!drag || drag.pointerId !== e.pointerId) return
+    dragRef.current = null
     if (drag.moved) {
       updateAsset(asset.id, {
         xPct: drag.lastXPct,
         yPct: drag.lastYPct,
       })
       // Clear a frame later so the committed value takes over from the var
-      // without a one-frame jump back to where the drag started.
+      // without a one-frame jump back to where the drag started. Skip if the
+      // asset was grabbed again meanwhile — the new drag owns the vars now.
       const roots = livePreviewRoots(canvasScopeId)
-      requestAnimationFrame(() => clearElementLivePosition(roots, asset.id))
+      requestAnimationFrame(() => {
+        if (dragRef.current) return
+        clearElementLivePosition(roots, asset.id)
+      })
     }
-    dragRef.current = null
     setIsDragging(false)
   }
 

--- a/components/editor/canvas/annotation-layer.tsx
+++ b/components/editor/canvas/annotation-layer.tsx
@@ -13,6 +13,8 @@ type AnnotationLayerProps = {
   annotationMaskId: string
   isAnnotating: boolean
   cursorClass: string
+  /** When set, shows a circular eraser brush preview matching stroke width. */
+  eraserBrushSize?: number | null
   onPointerDown: (e: React.PointerEvent<SVGSVGElement>) => void
   onPointerMove: (e: React.PointerEvent<SVGSVGElement>) => void
   onPointerUp: (e: React.PointerEvent<SVGSVGElement>) => void
@@ -26,12 +28,20 @@ export function AnnotationLayer({
   annotationMaskId,
   isAnnotating,
   cursorClass,
+  eraserBrushSize = null,
   onPointerDown,
   onPointerMove,
   onPointerUp,
   onClick,
   onDoubleClick,
 }: AnnotationLayerProps) {
+  const [eraserBrushPos, setEraserBrushPos] = React.useState<{
+    x: number
+    y: number
+  } | null>(null)
+  const showEraserBrush =
+    isAnnotating && eraserBrushSize != null && eraserBrushSize > 0
+
   const eraserStrokes = React.useMemo(() => {
     const strokes: AnnotationStroke[] = []
     for (const stroke of annotations) {
@@ -46,6 +56,27 @@ export function AnnotationLayer({
     }
     return strokes
   }, [annotations])
+
+  const updateEraserBrushPos = React.useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      if (!showEraserBrush) {
+        setEraserBrushPos(null)
+        return
+      }
+      const svg = e.currentTarget
+      const rect = svg.getBoundingClientRect()
+      if (!rect.width || !rect.height) return
+      setEraserBrushPos({
+        x: ((e.clientX - rect.left) / rect.width) * svg.clientWidth,
+        y: ((e.clientY - rect.top) / rect.height) * svg.clientHeight,
+      })
+    },
+    [showEraserBrush]
+  )
+
+  React.useEffect(() => {
+    if (!showEraserBrush) setEraserBrushPos(null)
+  }, [showEraserBrush])
 
   return (
     <>
@@ -115,13 +146,36 @@ export function AnnotationLayer({
             ? `pointer-events-auto ${cursorClass}`
             : "pointer-events-none"
         )}
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
+        onPointerDown={(e) => {
+          updateEraserBrushPos(e)
+          onPointerDown(e)
+        }}
+        onPointerMove={(e) => {
+          updateEraserBrushPos(e)
+          onPointerMove(e)
+        }}
         onPointerUp={onPointerUp}
         onPointerCancel={onPointerUp}
+        onPointerLeave={() => setEraserBrushPos(null)}
         onClick={onClick}
         onDoubleClick={onDoubleClick}
       />
+
+      {showEraserBrush && eraserBrushPos ? (
+        <div
+          aria-hidden
+          data-export-hidden="true"
+          data-annotation-eraser-brush="true"
+          className="pointer-events-none absolute z-[1001] rounded-full border border-white shadow-[0_0_0_1px_rgba(0,0,0,0.75)]"
+          style={{
+            left: eraserBrushPos.x,
+            top: eraserBrushPos.y,
+            width: eraserBrushSize,
+            height: eraserBrushSize,
+            transform: "translate(-50%, -50%)",
+          }}
+        />
+      ) : null}
     </>
   )
 }

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -80,6 +80,7 @@ import {
   setMainScreenshotBarePreviewPx,
   setMainScreenshotPositionPreview,
 } from "@/components/editor/position-preview-vars"
+import { livePreviewRoots } from "@/lib/editor/live-preview-roots"
 import { MainScreenshotRowItem } from "./main-screenshot-row-item"
 import { ScreenshotBare } from "./screenshot-bare"
 import {
@@ -639,8 +640,11 @@ function CanvasViewInner({
   // mouse-up. Uses the same preview helpers the position pad / player write.
   const previewLiveMainOffset = React.useCallback(
     (offset: { x: number; y: number }) => {
-      const canvasEl = canvasRef.current
-      if (!canvasEl) return
+      // Every live-preview root, so dragging the screenshot moves it in the
+      // preset thumbnails too. In a preview subtree this resolves to nothing,
+      // but previews are inert so the handler never runs there anyway.
+      const canvasEl = livePreviewRoots(scopeId)
+      if (canvasEl.length === 0) return
 
       // Multi-row / framed / tweet: container is % positioned. Bare single: px.
       if (inRowMode || frame.id !== "none" || tweet) {
@@ -704,7 +708,7 @@ function CanvasViewInner({
     updateCenterGuides,
     setScreenshotPositionDragging,
     onLiveOffsetPreview: previewLiveMainOffset,
-    getPreviewCanvasElement: () => canvasRef.current,
+    getPreviewCanvasElement: () => livePreviewRoots(scopeId),
   })
   const effectiveOffset = liveOffset ?? screenshotOffset
   const screenshotLeft =

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -678,6 +678,7 @@ function CanvasViewInner({
       frame,
       inRowMode,
       positionedStyle,
+      scopeId,
       screenshotPosition,
       screenshotSlots,
       tweet,

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -112,6 +112,9 @@ type CanvasViewProps = {
   onActivate: () => void
   previewMode?: boolean
   canvasOverride?: Partial<CanvasState> | null
+  /** Preview only: canvas to read store state from, when it differs from
+   * `canvasId` (which stays synthetic to keep the preview DOM-isolated). */
+  sourceCanvasId?: string | null
 }
 
 type SlotCropRequest = CropTarget & {
@@ -230,7 +233,10 @@ function CanvasViewInner({
     pattern: backdrop.pattern,
     overlay,
   })
-  useBackgroundDownscale(background, scopeId)
+  // Previews share the live canvas' background, which the real canvas already
+  // downscales — running it again per preview only duplicates the work against
+  // a canvas id that doesn't exist in the store.
+  useBackgroundDownscale(background, isCanvasPreview ? null : scopeId)
 
   const canvasRef = React.useRef<HTMLDivElement>(null)
   const generatedAnnotationMaskId = React.useId()
@@ -1337,6 +1343,11 @@ function CanvasViewInner({
             annotationMaskId={annotationMaskId}
             isAnnotating={isAnnotating}
             cursorClass={annotationCursor}
+            eraserBrushSize={
+              isAnnotating && annotation.mode === "eraser"
+                ? annotation.strokeWidth
+                : null
+            }
             onPointerDown={startAnnotation}
             onPointerMove={moveAnnotation}
             onPointerUp={stopAnnotation}
@@ -1434,7 +1445,10 @@ export function CanvasView(props: CanvasViewProps) {
   return (
     <CanvasScope id={props.canvasId}>
       {props.previewMode ? (
-        <CanvasPreviewScope override={props.canvasOverride ?? null}>
+        <CanvasPreviewScope
+          override={props.canvasOverride ?? null}
+          sourceCanvasId={props.sourceCanvasId ?? null}
+        >
           {inner}
         </CanvasPreviewScope>
       ) : (

--- a/components/editor/canvas/use-annotation-interactions.ts
+++ b/components/editor/canvas/use-annotation-interactions.ts
@@ -529,7 +529,7 @@ export function useAnnotationInteractions({
   const isAnnotating = activeTool === "arrow"
   const annotationCursor =
     annotation.mode === "eraser"
-      ? "cursor-cell"
+      ? "cursor-none"
       : annotation.mode === "pen" ||
           annotation.mode === "highlight" ||
           annotation.mode === "blur" ||

--- a/components/editor/canvas/use-screenshot-drag.ts
+++ b/components/editor/canvas/use-screenshot-drag.ts
@@ -83,7 +83,9 @@ export function useScreenshotDrag({
    */
   onLiveOffsetPreview?: (offset: Offset) => void
   /** Canvas root used to clear position preview vars after a drag commits. */
-  getPreviewCanvasElement?: () => HTMLElement | null
+  /** Every live-preview root to clear vars from — the canvas plus any
+   * preset thumbnail mirroring it. */
+  getPreviewCanvasElement?: () => HTMLElement[]
 }) {
   const [isScreenshotDragging, setIsScreenshotDragging] = React.useState(false)
   const [liveOffset, setLiveOffset] = React.useState<Offset | null>(null)
@@ -174,7 +176,7 @@ export function useScreenshotDrag({
   const endDrag = (normalize: boolean) => {
     setIsScreenshotDragging(false)
     updateCenterGuides({ x: false, y: false })
-    const canvasEl = getPreviewCanvas?.() ?? null
+    const canvasEl = getPreviewCanvas?.() ?? []
     try {
       commitLiveOffset(normalize)
     } finally {
@@ -182,7 +184,7 @@ export function useScreenshotDrag({
       // over (outside Animate mode nothing else clears them; inside, hold the
       // dragging flag until after the clear paints so AnimationLayer doesn't
       // re-sample the pre-drag pose for a frame).
-      clearPositionPreviewVarsAfterPaint([canvasEl])
+      clearPositionPreviewVarsAfterPaint(canvasEl)
       afterPositionPreviewCleared(() => setDraggingFlag?.(false))
     }
   }

--- a/components/editor/inspector/backdrop-section.tsx
+++ b/components/editor/inspector/backdrop-section.tsx
@@ -11,6 +11,10 @@ import {
   useActiveCanvasId,
   useEditorStore,
 } from "@/lib/editor/store"
+import {
+  livePreviewRoots,
+  setLivePreviewVar,
+} from "@/lib/editor/live-preview-roots"
 import { useScreenshotStyleTarget } from "@/lib/editor/screenshot-style-target"
 import { cn } from "@/lib/utils"
 
@@ -61,22 +65,15 @@ export function BackdropSection({
   } = backdrop
   const activeLighting = selectedSlot?.lighting ?? lighting
 
-  // Live-preview CSS vars on the active canvas: dragging sliders writes to
-  // these vars directly so the canvas updates without re-rendering the store
-  // until the user releases the slider. See tilt-section.tsx for the same
-  // pattern applied to tilt/scale.
-  const getCanvasEl = React.useCallback((): HTMLElement | null => {
-    if (typeof document === "undefined" || !activeCanvasId) return null
-    return document.querySelector(`[data-canvas-id="${activeCanvasId}"]`)
-  }, [activeCanvasId])
+  // Live-preview CSS vars on the active canvas and every preset thumbnail
+  // mirroring it: dragging sliders writes to these vars directly so both
+  // update without re-rendering the store until the user releases the slider.
+  // See tilt-section.tsx for the same pattern applied to tilt/scale.
   const setPreviewVar = React.useCallback(
     (name: string, value: string | null) => {
-      const el = getCanvasEl()
-      if (!el) return
-      if (value === null) el.style.removeProperty(name)
-      else el.style.setProperty(name, value)
+      setLivePreviewVar(livePreviewRoots(activeCanvasId), name, value)
     },
-    [getCanvasEl]
+    [activeCanvasId]
   )
   const clearPreviewVarAfterPaint = React.useCallback(
     (name: string) => {

--- a/components/editor/inspector/padding-section.tsx
+++ b/components/editor/inspector/padding-section.tsx
@@ -9,6 +9,10 @@ import {
   useActiveCanvasId,
   useEditorStore,
 } from "@/lib/editor/store"
+import {
+  livePreviewRoots,
+  setLivePreviewVar,
+} from "@/lib/editor/live-preview-roots"
 import { useScreenshotStyleTarget } from "@/lib/editor/screenshot-style-target"
 import { cn } from "@/lib/utils"
 
@@ -25,36 +29,28 @@ export function PaddingSection() {
   )
   const [draftPadding, setDraftPadding] = React.useState<number | null>(null)
   const displayedPadding = draftPadding ?? padding
-  const getPreviewScopeEl = React.useCallback((): HTMLElement | null => {
-    if (typeof document === "undefined" || !activeCanvasId) return null
-    const canvasEl = document.querySelector<HTMLElement>(
-      `[data-canvas-id="${activeCanvasId}"]`
-    )
-    if (!canvasEl) return null
-    if (target === "all") return canvasEl
+  const getPreviewScopeEls = React.useCallback((): HTMLElement[] => {
+    const roots = livePreviewRoots(activeCanvasId)
+    if (target === "all") return roots
 
     const scopeId = target === "slot" ? selectedSlot?.id : "canvas"
-    if (!scopeId) return canvasEl
-    return (
-      canvasEl.querySelector<HTMLElement>(
-        `[data-editor-shadow-preview-scope="${scopeId}"]`
-      ) ?? canvasEl
+    if (!scopeId) return roots
+    return roots.map(
+      (root) =>
+        root.querySelector<HTMLElement>(
+          `[data-editor-shadow-preview-scope="${CSS.escape(scopeId)}"]`
+        ) ?? root
     )
   }, [activeCanvasId, selectedSlot?.id, target])
   const setPreviewPadding = React.useCallback(
     (value: number | null) => {
-      const el = getPreviewScopeEl()
-      if (!el) return
-      if (value === null) {
-        el.style.removeProperty(PADDING_PREVIEW_VAR)
-        return
-      }
-      el.style.setProperty(
+      setLivePreviewVar(
+        getPreviewScopeEls(),
         PADDING_PREVIEW_VAR,
-        `${Math.max(0, Math.min(240, value)) / 12}%`
+        value === null ? null : `${Math.max(0, Math.min(240, value)) / 12}%`
       )
     },
-    [getPreviewScopeEl]
+    [getPreviewScopeEls]
   )
   const clearPreviewPaddingAfterPaint = React.useCallback(() => {
     if (typeof requestAnimationFrame === "undefined") return

--- a/components/editor/inspector/position-section.tsx
+++ b/components/editor/inspector/position-section.tsx
@@ -282,12 +282,12 @@ export function PositionSection() {
       setMainScreenshotPositionPreview(canvasElement, safePoint)
     },
     [
+      activeCanvasId,
       editor.aspect,
       editor.frame,
       editor.screenshotOffset,
       editor.screenshotPosition,
       editor.screenshotSlots,
-      getActiveCanvasElement,
       getSelectedSlotElement,
       hasMainScreenshotBox,
       isAllTarget,

--- a/components/editor/inspector/position-section.tsx
+++ b/components/editor/inspector/position-section.tsx
@@ -224,8 +224,10 @@ export function PositionSection() {
         xPct: clampPercent(point.xPct),
         yPct: clampPercent(point.yPct),
       }
-      const canvasElement = getActiveCanvasElement()
-      if (!canvasElement) return
+      // Main-screenshot position vars live on the root, so passing every
+      // live-preview root drives the preset thumbnails along with the canvas.
+      const canvasElement = livePreviewRoots(activeCanvasId)
+      if (canvasElement.length === 0) return
 
       if (selectedSlot) {
         setElementPositionPreview(getSelectedSlotElement(), safePoint)

--- a/components/editor/inspector/position-section.tsx
+++ b/components/editor/inspector/position-section.tsx
@@ -18,6 +18,7 @@ import {
   allScreenshotGroupCenter,
   screenshotSlotGroupCenter,
 } from "@/components/editor/floating-toolbar-parts/geometry"
+import { livePreviewRoots } from "@/lib/editor/live-preview-roots"
 import { useEditor, useEditorStore } from "@/lib/editor/store"
 
 import {
@@ -421,33 +422,41 @@ export function PositionSection() {
   // + every slot; otherwise only the main/canvas moves.
   const zoom = selectedSlot ? selectedSlot.scale : editor.scale
 
+  // Preset thumbnails inherit the canvas zoom (`planSinglePreset` takes scale
+  // straight off the canvas), so they are driven alongside it — otherwise they
+  // sit at the old zoom until the slider is released.
   const getZoomTargets = React.useCallback((): Array<{
     el: HTMLElement
     scaleVar: string
   }> => {
+    const roots = livePreviewRoots(activeCanvasId)
+    if (roots.length === 0) return []
+
+    const slotIn = (root: HTMLElement, slotId: string) =>
+      root.querySelector<HTMLElement>(
+        `[data-screenshot-slot-id="${CSS.escape(slotId)}"]`
+      )
+
     if (selectedSlot) {
-      const el = getSelectedSlotElement()
-      return el ? [{ el, scaleVar: SLOT_SCALE_VAR }] : []
+      return roots.flatMap((root) => {
+        const el = slotIn(root, selectedSlot.id)
+        return el ? [{ el, scaleVar: SLOT_SCALE_VAR }] : []
+      })
     }
-    const canvasEl = getActiveCanvasElement()
-    if (!canvasEl) return []
-    if (!isAllTarget) return [{ el: canvasEl, scaleVar: CANVAS_SCALE_VAR }]
-    const targets: Array<{ el: HTMLElement; scaleVar: string }> = [
-      { el: canvasEl, scaleVar: CANVAS_SCALE_VAR },
-    ]
-    for (const slot of editor.screenshotSlots) {
-      const el = querySlotElement(slot.id)
-      if (el) targets.push({ el, scaleVar: SLOT_SCALE_VAR })
-    }
-    return targets
-  }, [
-    editor.screenshotSlots,
-    getActiveCanvasElement,
-    getSelectedSlotElement,
-    isAllTarget,
-    querySlotElement,
-    selectedSlot,
-  ])
+    if (!isAllTarget)
+      return roots.map((el) => ({ el, scaleVar: CANVAS_SCALE_VAR }))
+
+    return roots.flatMap((root) => {
+      const targets: Array<{ el: HTMLElement; scaleVar: string }> = [
+        { el: root, scaleVar: CANVAS_SCALE_VAR },
+      ]
+      for (const slot of editor.screenshotSlots) {
+        const el = slotIn(root, slot.id)
+        if (el) targets.push({ el, scaleVar: SLOT_SCALE_VAR })
+      }
+      return targets
+    })
+  }, [activeCanvasId, editor.screenshotSlots, isAllTarget, selectedSlot])
 
   const previewScale = React.useCallback(
     (next: number) => {

--- a/components/editor/inspector/shadow-section.tsx
+++ b/components/editor/inspector/shadow-section.tsx
@@ -4,6 +4,10 @@ import * as React from "react"
 
 import { ColorPickerPopover } from "@/components/editor/color-picker-popover"
 import { EffectSlider } from "@/components/editor/inspector/effect-slider"
+import {
+  livePreviewRoots,
+  setLivePreviewVar,
+} from "@/lib/editor/live-preview-roots"
 import { useScreenshotStyleTarget } from "@/lib/editor/screenshot-style-target"
 import {
   useActiveCanvasField,
@@ -327,31 +331,25 @@ export function ShadowSection() {
     ? (selectedSlot.shadow ?? canvasShadow)
     : canvasShadow
 
-  const getPreviewScopeEl = React.useCallback((): HTMLElement | null => {
-    if (typeof document === "undefined" || !activeCanvasId) return null
-    const canvasEl = document.querySelector<HTMLElement>(
-      `[data-canvas-id="${activeCanvasId}"]`
-    )
-    if (!canvasEl) return null
-    if (target === "all") return canvasEl
+  const getPreviewScopeEls = React.useCallback((): HTMLElement[] => {
+    const roots = livePreviewRoots(activeCanvasId)
+    if (target === "all") return roots
 
     const scopeId = target === "slot" ? selectedSlot?.id : "canvas"
-    if (!scopeId) return canvasEl
-    return (
-      canvasEl.querySelector<HTMLElement>(
-        `[data-editor-shadow-preview-scope="${scopeId}"]`
-      ) ?? canvasEl
+    if (!scopeId) return roots
+    return roots.map(
+      (root) =>
+        root.querySelector<HTMLElement>(
+          `[data-editor-shadow-preview-scope="${CSS.escape(scopeId)}"]`
+        ) ?? root
     )
   }, [activeCanvasId, selectedSlot?.id, target])
 
   const setPreviewVar = React.useCallback(
     (name: string, value: string | null) => {
-      const el = getPreviewScopeEl()
-      if (!el) return
-      if (value === null) el.style.removeProperty(name)
-      else el.style.setProperty(name, value)
+      setLivePreviewVar(getPreviewScopeEls(), name, value)
     },
-    [getPreviewScopeEl]
+    [getPreviewScopeEls]
   )
 
   const clearPreviewVarsAfterPaint = React.useCallback(() => {

--- a/components/editor/inspector/tilt-section.tsx
+++ b/components/editor/inspector/tilt-section.tsx
@@ -110,19 +110,22 @@ export function TiltSection() {
 
   // Resolve the live-preview DOM target on demand so we don't cache a stale
   // node across selection changes or canvas remounts.
+  // Tilt is deliberately not fanned out to the preset thumbnails: each one
+  // pins the tilt its preset represents. Slot lookups stay scoped inside the
+  // canvas so a thumbnail's slot — which carries the same slot id — can't be
+  // matched first by a document-wide query.
   const getTargetEls = React.useCallback((): LivePreviewTarget[] => {
-    if (typeof document === "undefined") return []
+    if (typeof document === "undefined" || !activeCanvasId) return []
+    const canvasEl = document.querySelector<HTMLElement>(
+      `[data-canvas-id="${CSS.escape(activeCanvasId)}"]`
+    )
+    if (!canvasEl) return []
     if (selectedSlot) {
-      const el = document.querySelector<HTMLElement>(
-        `[data-screenshot-slot-id="${selectedSlot.id}"]`
+      const el = canvasEl.querySelector<HTMLElement>(
+        `[data-screenshot-slot-id="${CSS.escape(selectedSlot.id)}"]`
       )
       return el ? [{ el, kind: "slot" }] : []
     }
-    if (!activeCanvasId) return []
-    const canvasEl = document.querySelector<HTMLElement>(
-      `[data-canvas-id="${activeCanvasId}"]`
-    )
-    if (!canvasEl) return []
     if (target !== "all") return [{ el: canvasEl, kind: "canvas" }]
 
     const slotTargets = Array.from(

--- a/components/editor/position-preview-vars.ts
+++ b/components/editor/position-preview-vars.ts
@@ -47,22 +47,28 @@ export function setElementPositionPreview(
  * boxes and the main selection outline detached from its image.
  */
 export function setMainScreenshotPositionPreview(
-  canvasElement: HTMLElement | null | undefined,
+  canvasElement: HTMLElement | null | undefined | Array<HTMLElement | null | undefined>,
   point: PositionSwipePoint
 ) {
-  if (!canvasElement) return
-  canvasElement.style.setProperty(MAIN_POSITION_X_VAR, `${point.xPct}%`)
-  canvasElement.style.setProperty(MAIN_POSITION_Y_VAR, `${point.yPct}%`)
-  canvasElement.style.setProperty(
-    MAIN_ANCHOR_X_VAR,
-    frameAnchorTravel(point.xPct, "x")
-  )
-  canvasElement.style.setProperty(
-    MAIN_ANCHOR_Y_VAR,
-    frameAnchorTravel(point.yPct, "y")
-  )
-  canvasElement.style.setProperty(MAIN_OFFSET_X_VAR, "0px")
-  canvasElement.style.setProperty(MAIN_OFFSET_Y_VAR, "0px")
+  // Accepts a list so callers can pass every live-preview root and drive the
+  // preset thumbnails alongside the canvas — these vars all live on the root,
+  // so no per-element lookup is needed.
+  for (const el of toElements(canvasElement)) {
+    el.style.setProperty(MAIN_POSITION_X_VAR, `${point.xPct}%`)
+    el.style.setProperty(MAIN_POSITION_Y_VAR, `${point.yPct}%`)
+    el.style.setProperty(MAIN_ANCHOR_X_VAR, frameAnchorTravel(point.xPct, "x"))
+    el.style.setProperty(MAIN_ANCHOR_Y_VAR, frameAnchorTravel(point.yPct, "y"))
+    el.style.setProperty(MAIN_OFFSET_X_VAR, "0px")
+    el.style.setProperty(MAIN_OFFSET_Y_VAR, "0px")
+  }
+}
+
+function toElements(
+  input: HTMLElement | null | undefined | Array<HTMLElement | null | undefined>
+): HTMLElement[] {
+  if (!input) return []
+  if (Array.isArray(input)) return input.filter((el): el is HTMLElement => !!el)
+  return [input]
 }
 
 /**
@@ -73,13 +79,14 @@ export function setMainScreenshotPositionPreview(
  * make it jump on release.
  */
 export function setMainScreenshotBarePreviewPx(
-  canvasElement: HTMLElement | null | undefined,
+  canvasElement: HTMLElement | null | undefined | Array<HTMLElement | null | undefined>,
   leftPx: number,
   topPx: number
 ) {
-  if (!canvasElement) return
-  canvasElement.style.setProperty(MAIN_BARE_LEFT_VAR, `${leftPx}px`)
-  canvasElement.style.setProperty(MAIN_BARE_TOP_VAR, `${topPx}px`)
+  for (const el of toElements(canvasElement)) {
+    el.style.setProperty(MAIN_BARE_LEFT_VAR, `${leftPx}px`)
+    el.style.setProperty(MAIN_BARE_TOP_VAR, `${topPx}px`)
+  }
 }
 
 export function clearPositionPreviewVars(

--- a/components/editor/position-preview-vars.ts
+++ b/components/editor/position-preview-vars.ts
@@ -47,7 +47,11 @@ export function setElementPositionPreview(
  * boxes and the main selection outline detached from its image.
  */
 export function setMainScreenshotPositionPreview(
-  canvasElement: HTMLElement | null | undefined | Array<HTMLElement | null | undefined>,
+  canvasElement:
+    | HTMLElement
+    | null
+    | undefined
+    | Array<HTMLElement | null | undefined>,
   point: PositionSwipePoint
 ) {
   // Accepts a list so callers can pass every live-preview root and drive the
@@ -79,7 +83,11 @@ function toElements(
  * make it jump on release.
  */
 export function setMainScreenshotBarePreviewPx(
-  canvasElement: HTMLElement | null | undefined | Array<HTMLElement | null | undefined>,
+  canvasElement:
+    | HTMLElement
+    | null
+    | undefined
+    | Array<HTMLElement | null | undefined>,
   leftPx: number,
   topPx: number
 ) {

--- a/components/editor/present-presets-section.tsx
+++ b/components/editor/present-presets-section.tsx
@@ -21,7 +21,14 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-import { RiFileCopyLine } from "@remixicon/react"
+import { RiFileCopyLine, RiSortAsc, RiSortDesc } from "@remixicon/react"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import type { PresetSort } from "@/lib/schemas/preset"
 import { toast } from "sonner"
 import {
   useActiveCanvasField,
@@ -45,6 +52,46 @@ import {
 } from "./present-presets-section/tabs"
 
 const ENABLE_DEBUG_PRESETS = env.NEXT_PUBLIC_ENABLE_DEBUG_PRESETS
+
+const SORT_LABELS: Record<PresetSort, string> = {
+  latest: "Newest first",
+  oldest: "Oldest first",
+}
+
+/** Bare icon toggle — no border or background, and a fixed box so showing it
+ * on the Custom tab can't change the heading row's height. */
+function CustomPresetSortToggle({
+  sort,
+  disabled,
+  onChange,
+}: {
+  sort: PresetSort
+  disabled: boolean
+  onChange: (next: PresetSort) => void
+}) {
+  const next: PresetSort = sort === "latest" ? "oldest" : "latest"
+  const Icon = sort === "latest" ? RiSortDesc : RiSortAsc
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange(next)}
+            aria-label={`Sorted by ${SORT_LABELS[sort].toLowerCase()}. Switch to ${SORT_LABELS[next].toLowerCase()}.`}
+            className="-my-1 inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-1 focus-visible:ring-primary/50 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45"
+          >
+            <Icon className="size-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6}>
+          {SORT_LABELS[sort]}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
 
 export function PresentPresetsSection({
   flat = false,
@@ -105,6 +152,7 @@ export function PresentPresetsSection({
     (s) => s.setActiveSinglePresetId
   )
   const customPresets = useEditorStore((s) => s.customPresets)
+  const customPresetsSort = useEditorStore((s) => s.customPresetsSort)
   const customPresetsLoaded = useEditorStore((s) => s.customPresetsLoaded)
   const customPresetsLoading = useEditorStore((s) => s.customPresetsLoading)
   const setCustomPresets = useEditorStore((s) => s.setCustomPresets)
@@ -164,6 +212,7 @@ export function PresentPresetsSection({
       ? bulkPresetUiByCanvasId[activeCanvasId]
       : null
   const displayTab = bulkEditMode ? (bulkPresetUi?.tab ?? tab) : tab
+  const isCustomTab = displayTab === "custom"
   const displayActiveLayoutPresetId = bulkEditMode
     ? (bulkPresetUi?.activeLayoutPresetId ?? null)
     : activeLayoutPresetId
@@ -208,6 +257,14 @@ export function PresentPresetsSection({
     // and briefly leave a partial list on screen).
     loadCustomPresets(userId)
   }, [userId, isAuthPending, loadCustomPresets, clearCustomPresets])
+
+  const handleSortChange = React.useCallback(
+    (next: PresetSort) => {
+      if (!userId || next === customPresetsSort) return
+      loadCustomPresets(userId, next)
+    },
+    [customPresetsSort, loadCustomPresets, userId]
+  )
 
   const handleDeleteCustomPreset = React.useCallback(
     async (id: string) => {
@@ -552,12 +609,19 @@ export function PresentPresetsSection({
         </AlertDialogContent>
       </AlertDialog>
       <div className="shrink-0 px-4 pb-3">
-        {(showPresetHeading || ENABLE_DEBUG_PRESETS) && (
+        {(showPresetHeading || ENABLE_DEBUG_PRESETS || isCustomTab) && (
           <div className="mb-2 flex items-center justify-between gap-2">
             {showPresetHeading ? (
               <p className="text-[13px] font-medium text-foreground">Presets</p>
             ) : (
               <span aria-hidden />
+            )}
+            {isCustomTab && (
+              <CustomPresetSortToggle
+                sort={customPresetsSort}
+                disabled={!userId}
+                onChange={handleSortChange}
+              />
             )}
             {ENABLE_DEBUG_PRESETS && (
               <button

--- a/components/editor/present-presets-section/cards.tsx
+++ b/components/editor/present-presets-section/cards.tsx
@@ -45,11 +45,13 @@ import {
 import { ShimmerBox } from "@/components/ui/shimmer-image"
 import { PRESET_NAME_MAX_LENGTH } from "@/lib/schemas/preset"
 import { remoteImagePreviewUrl } from "@/lib/editor/image-resize"
+import { LIVE_PREVIEW_ROOT_ATTR } from "@/lib/editor/live-preview-roots"
 import { isVideoSrc } from "@/lib/editor/media-type"
 import { isUnsplashImageUrl } from "@/lib/editor/unsplash"
 import {
   planLayoutPreset,
-  planSinglePreset,
+  planSinglePresetSlotRow,
+  type SinglePresetSlotRow,
 } from "@/lib/editor/preset-application"
 import { resolveMainOffsetPx } from "@/lib/editor/preset-geometry"
 import {
@@ -69,6 +71,10 @@ import type {
 import { cn } from "@/lib/utils"
 
 import type { PresetTab } from "./tabs"
+
+type SinglePresetSlotLayout = SinglePresetSlotRow & {
+  slots: ScreenshotSlot[]
+}
 
 const MOBILE_PRESET_CARD_WIDTH = 172
 /** Shell padding + label row below the aspect-ratio preview. */
@@ -122,6 +128,15 @@ export function PresetCardsBody({
   onDeleteCustom: (id: string) => void | Promise<void>
   onRenameCustom: (id: string, name: string) => void | Promise<void>
 }) {
+  // Every single preset shares this row math, so run it once for the rail.
+  // `null` when there are no extra slots — the common case, and the one where
+  // a single-preset preview needs no state override at all.
+  const singleSlotLayout = React.useMemo<SinglePresetSlotLayout | null>(() => {
+    if (canvas.screenshotSlots.length === 0) return null
+    const row = planSinglePresetSlotRow(canvas, aspect)
+    return { ...row, slots: canvas.screenshotSlots }
+  }, [aspect, canvas])
+
   return (
     <>
       {displayTab === "single" && (
@@ -130,7 +145,8 @@ export function PresetCardsBody({
             <PresetCardSlot key={preset.id} horizontal={horizontal}>
               <SinglePresetCard
                 preset={preset}
-                canvas={canvas}
+                slotLayout={singleSlotLayout}
+                sourceCanvasId={canvas.id}
                 aspect={aspect}
                 horizontal={horizontal}
                 active={activeSinglePresetId === preset.id}
@@ -746,14 +762,17 @@ const PresetCardShell = React.memo(function PresetCardShell({
 
 const SinglePresetCard = React.memo(function SinglePresetCard({
   preset,
-  canvas,
+  slotLayout,
+  sourceCanvasId,
   aspect,
   horizontal = false,
   active,
   onApply,
 }: {
   preset: PresentPreset
-  canvas: CanvasState
+  /** Row-layout geometry for the extra slots, or null when there are none. */
+  slotLayout: SinglePresetSlotLayout | null
+  sourceCanvasId: string | null
   aspect: AspectState
   horizontal?: boolean
   active: boolean
@@ -768,30 +787,34 @@ const SinglePresetCard = React.memo(function SinglePresetCard({
     () => onApply(preset),
     [onApply, preset]
   )
-  const virtualCanvas = React.useMemo<CanvasState>(() => {
-    const plan = planSinglePreset(preset, canvas, aspect)
+  // A single preset differs from the live canvas by its tilt and — when extra
+  // slots exist — their row placement. `planSinglePreset` takes scale,
+  // position and offset straight off the canvas, and everything else (styling,
+  // text, assets, annotations) is untouched. So the preview subscribes to the
+  // real canvas and overrides only those two fields, instead of cloning a
+  // whole `CanvasState` per card on every edit. `preset.tilt` is a module
+  // constant, so with no extra slots this override never changes identity and
+  // a padding or background edit re-renders nothing here.
+  const override = React.useMemo<Partial<CanvasState>>(() => {
+    if (!slotLayout) return { tilt: preset.tilt }
     return {
-      ...canvas,
-      background: previewSafeBackground(canvas.background),
-      tilt: plan.canvasTilt,
-      scale: plan.canvasScale,
-      screenshotPosition: plan.screenshotPosition,
-      screenshotOffset: plan.screenshotOffset,
-      screenshotSlots: canvas.screenshotSlots.map((slot, i) => {
-        const patch = plan.slots[i]
-        if (!patch) return slot
+      tilt: preset.tilt,
+      screenshotSlots: slotLayout.slots.map((slot, i) => {
+        const placement = slotLayout.placements[i]
+        if (!placement) return slot
         return {
           ...slot,
-          xPct: patch.xPct,
-          yPct: patch.yPct,
-          widthPct: patch.widthPct ?? slot.widthPct,
-          rotation: patch.rotation,
-          tilt: patch.tilt,
-          scale: patch.scale,
+          xPct: placement.xPct,
+          yPct: 50,
+          widthPct: placement.widthPct ?? slot.widthPct,
+          rotation: 0,
+          tilt: preset.tilt,
+          scale: slotLayout.scale,
         }
       }),
     }
-  }, [aspect, canvas, preset])
+  }, [preset.tilt, slotLayout])
+
   return (
     <PresetCardShell
       active={active}
@@ -804,7 +827,8 @@ const SinglePresetCard = React.memo(function SinglePresetCard({
     >
       <CanvasPresetPreview
         aspect={aspect}
-        virtualCanvas={virtualCanvas}
+        virtualCanvas={override}
+        sourceCanvasId={sourceCanvasId}
         previewId={`_preset_preview_single_${preset.id}`}
       />
     </PresetCardShell>
@@ -921,10 +945,14 @@ const PRESET_PREVIEW_WIDTH = BASE_CANVAS_WIDTH
 const CanvasPresetPreview = React.memo(function CanvasPresetPreview({
   aspect,
   virtualCanvas,
+  sourceCanvasId = null,
   previewId,
 }: {
   aspect: AspectState
-  virtualCanvas: CanvasState
+  virtualCanvas: Partial<CanvasState> | null
+  /** Canvas to read live state from; omitted when `virtualCanvas` is a full
+   * standalone state (custom presets). */
+  sourceCanvasId?: string | null
   previewId: string
 }) {
   const previewRef = React.useRef<HTMLDivElement>(null)
@@ -935,11 +963,17 @@ const CanvasPresetPreview = React.memo(function CanvasPresetPreview({
   const previewScale = useContainScale(previewRef, stageWidth, stageHeight)
   return (
     <div ref={previewRef} className="pointer-events-none absolute inset-0">
+      {/* Tagging the stage as a live-preview root lets slider drags write vars
+          like padding, shadow and zoom onto it, so the thumbnail tracks the
+          drag instead of waiting for the commit. Tilt is deliberately not
+          fanned out this way — each thumbnail pins the tilt of the preset it
+          represents. */}
       <div
         className="absolute top-1/2 left-1/2 origin-center"
-        style={{
-          transform: `translate(-50%, -50%) scale(${previewScale})`,
-        }}
+        style={{ transform: `translate(-50%, -50%) scale(${previewScale})` }}
+        {...(sourceCanvasId
+          ? { [LIVE_PREVIEW_ROOT_ATTR]: sourceCanvasId }
+          : null)}
       >
         <CanvasView
           canvasId={previewId}
@@ -949,6 +983,7 @@ const CanvasPresetPreview = React.memo(function CanvasPresetPreview({
           effectiveScale={previewScale}
           onActivate={() => undefined}
           previewMode
+          sourceCanvasId={sourceCanvasId}
           canvasOverride={virtualCanvas}
         />
       </div>

--- a/components/editor/text-element-parts/types.ts
+++ b/components/editor/text-element-parts/types.ts
@@ -20,6 +20,11 @@ export type DragState = {
   moved: boolean
   snapXActive: boolean
   snapYActive: boolean
+  /** Last previewed position. The drag publishes CSS vars rather than writing
+   * the element's inline style, so the commit reads the value from here
+   * instead of parsing it back off the element. */
+  lastXPct: number
+  lastYPct: number
 }
 
 export type RotateState = {

--- a/components/editor/text-element-parts/use-text-element-interactions.ts
+++ b/components/editor/text-element-parts/use-text-element-interactions.ts
@@ -11,7 +11,6 @@ import {
   type TextElement,
   pickContrastColorAtPosition,
   useEditor,
-  useEditorStore,
 } from "@/lib/editor/store"
 import { useFloatingToolbarRect } from "@/hooks/use-floating-toolbar-rect"
 
@@ -39,6 +38,7 @@ export function useTextElementInteractions({
   onCenterGuideChange,
 }: Pick<TextElementViewProps, "text" | "canvasRef" | "onCenterGuideChange">) {
   const {
+    id: canvasScopeId,
     canvasZoom,
     selectedTextId,
     setSelectedTextId,
@@ -89,15 +89,14 @@ export function useTextElementInteractions({
   const bulkEditModeRef = React.useRef(bulkEditMode)
   const bulkViewportZoomRef = React.useRef(bulkViewportZoom)
   const onCenterGuideChangeRef = React.useRef(onCenterGuideChange)
-  const activeCanvasId = useEditorStore((s) => s.present.activeCanvasId)
-  const activeCanvasIdRef = React.useRef(activeCanvasId)
+  const canvasScopeIdRef = React.useRef(canvasScopeId)
   React.useEffect(() => {
     textRef.current = text
     canvasZoomRef.current = canvasZoom
     bulkEditModeRef.current = bulkEditMode
     bulkViewportZoomRef.current = bulkViewportZoom
     onCenterGuideChangeRef.current = onCenterGuideChange
-    activeCanvasIdRef.current = activeCanvasId
+    canvasScopeIdRef.current = canvasScopeId
   })
 
   const pointerScale = React.useCallback(() => {
@@ -380,7 +379,7 @@ export function useTextElementInteractions({
       // Broadcast rather than writing this element's inline style, so the
       // preset thumbnails' copy of this text follows the drag too.
       setElementLivePosition(
-        livePreviewRoots(activeCanvasIdRef.current),
+        livePreviewRoots(canvasScopeIdRef.current),
         textRef.current.id,
         clampedX,
         clampedY
@@ -447,7 +446,7 @@ export function useTextElementInteractions({
       // Clear a frame after the commit paints, so the committed xPct/yPct
       // takes over from the var without a one-frame jump back to the old spot.
       const textId = textRef.current.id
-      const roots = livePreviewRoots(activeCanvasIdRef.current)
+      const roots = livePreviewRoots(canvasScopeIdRef.current)
       if (typeof requestAnimationFrame === "undefined") {
         clearElementLivePosition(roots, textId)
       } else {

--- a/components/editor/text-element-parts/use-text-element-interactions.ts
+++ b/components/editor/text-element-parts/use-text-element-interactions.ts
@@ -443,17 +443,23 @@ export function useTextElementInteractions({
           }
         }
       }
+      dragRef.current = null
       // Clear a frame after the commit paints, so the committed xPct/yPct
       // takes over from the var without a one-frame jump back to the old spot.
+      // Skip if the text was grabbed again in the meantime — the new drag owns
+      // the vars now and clearing them would strand it at the committed spot.
       const textId = textRef.current.id
       const roots = livePreviewRoots(canvasScopeIdRef.current)
-      if (typeof requestAnimationFrame === "undefined") {
+      const clearIfIdle = () => {
+        if (dragRef.current) return
         clearElementLivePosition(roots, textId)
+      }
+      if (typeof requestAnimationFrame === "undefined") {
+        clearIfIdle()
       } else {
-        requestAnimationFrame(() => clearElementLivePosition(roots, textId))
+        requestAnimationFrame(clearIfIdle)
       }
 
-      dragRef.current = null
       setIsDragging(false)
       onCenterGuideChangeRef.current?.({ x: false, y: false })
     },

--- a/components/editor/text-element-parts/use-text-element-interactions.ts
+++ b/components/editor/text-element-parts/use-text-element-interactions.ts
@@ -3,9 +3,15 @@
 import * as React from "react"
 
 import {
+  clearElementLivePosition,
+  livePreviewRoots,
+  setElementLivePosition,
+} from "@/lib/editor/live-preview-roots"
+import {
   type TextElement,
   pickContrastColorAtPosition,
   useEditor,
+  useEditorStore,
 } from "@/lib/editor/store"
 import { useFloatingToolbarRect } from "@/hooks/use-floating-toolbar-rect"
 
@@ -83,12 +89,15 @@ export function useTextElementInteractions({
   const bulkEditModeRef = React.useRef(bulkEditMode)
   const bulkViewportZoomRef = React.useRef(bulkViewportZoom)
   const onCenterGuideChangeRef = React.useRef(onCenterGuideChange)
+  const activeCanvasId = useEditorStore((s) => s.present.activeCanvasId)
+  const activeCanvasIdRef = React.useRef(activeCanvasId)
   React.useEffect(() => {
     textRef.current = text
     canvasZoomRef.current = canvasZoom
     bulkEditModeRef.current = bulkEditMode
     bulkViewportZoomRef.current = bulkViewportZoom
     onCenterGuideChangeRef.current = onCenterGuideChange
+    activeCanvasIdRef.current = activeCanvasId
   })
 
   const pointerScale = React.useCallback(() => {
@@ -288,6 +297,8 @@ export function useTextElementInteractions({
         moved: false,
         snapXActive: false,
         snapYActive: false,
+        lastXPct: t.xPct,
+        lastYPct: t.yPct,
       }
     },
     [canvasRef, setSelectedAnnotationShapeId, setSelectedTextId]
@@ -363,13 +374,20 @@ export function useTextElementInteractions({
 
       const clampedX = clamp(nextX, -20, 120)
       const clampedY = clamp(nextY, -20, 120)
+      drag.lastXPct = clampedX
+      drag.lastYPct = clampedY
+
+      // Broadcast rather than writing this element's inline style, so the
+      // preset thumbnails' copy of this text follows the drag too.
+      setElementLivePosition(
+        livePreviewRoots(activeCanvasIdRef.current),
+        textRef.current.id,
+        clampedX,
+        clampedY
+      )
 
       const el = elRef.current
-      if (el) {
-        el.style.left = `${clampedX}%`
-        el.style.top = `${clampedY}%`
-        setToolbarRect(el.getBoundingClientRect())
-      }
+      if (el) setToolbarRect(el.getBoundingClientRect())
     },
     [setToolbarRect, updateResizeLens]
   )
@@ -403,8 +421,8 @@ export function useTextElementInteractions({
       if (drag.moved) {
         const el = elRef.current
         if (el) {
-          const x = parseFloat(el.style.left)
-          const y = parseFloat(el.style.top)
+          const x = drag.lastXPct
+          const y = drag.lastYPct
           const t = textRef.current
           updateText(t.id, {
             xPct: clamp(x, -20, 120),
@@ -426,6 +444,16 @@ export function useTextElementInteractions({
           }
         }
       }
+      // Clear a frame after the commit paints, so the committed xPct/yPct
+      // takes over from the var without a one-frame jump back to the old spot.
+      const textId = textRef.current.id
+      const roots = livePreviewRoots(activeCanvasIdRef.current)
+      if (typeof requestAnimationFrame === "undefined") {
+        clearElementLivePosition(roots, textId)
+      } else {
+        requestAnimationFrame(() => clearElementLivePosition(roots, textId))
+      }
+
       dragRef.current = null
       setIsDragging(false)
       onCenterGuideChangeRef.current?.({ x: false, y: false })

--- a/components/editor/text-element.tsx
+++ b/components/editor/text-element.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { elementPositionVars } from "@/lib/editor/live-preview-roots"
 import { cn } from "@/lib/utils"
 
 import { TextElementFloatingToolbar } from "./text-element-parts/floating-toolbar"
@@ -47,6 +48,7 @@ export function TextElementView({
     toolbarRect,
   } = useTextElementInteractions({ text, canvasRef, onCenterGuideChange })
 
+  const positionVars = elementPositionVars(text.id)
   const showBorder = isSelected || (text.borderColor && text.borderWidth > 0)
   const borderColor = text.borderColor
     ? text.borderColor
@@ -81,8 +83,12 @@ export function TextElementView({
           !isEditing && "touch-none"
         )}
         style={{
-          left: `var(--editor-position-x, ${text.xPct}%)`,
-          top: `var(--editor-position-y, ${text.yPct}%)`,
+          // Per-id var first so a drag can be broadcast from the canvas root
+          // and reach the preset thumbnails' copy of this text; the generic
+          // element-scoped var stays as the fallback for the writers that
+          // still target a single element directly.
+          left: `var(${positionVars.x}, var(--editor-position-x, ${text.xPct}%))`,
+          top: `var(${positionVars.y}, var(--editor-position-y, ${text.yPct}%))`,
           transform: `translate(-50%, -50%) rotate(${text.rotation}deg)`,
           transition:
             !isDragging && shouldAnimatePositionMove

--- a/lib/editor/live-preview-roots.ts
+++ b/lib/editor/live-preview-roots.ts
@@ -1,0 +1,93 @@
+/**
+ * Resolves every DOM root that should receive live-preview CSS vars while a
+ * slider or drag is in flight.
+ *
+ * Sliders write vars like `--editor-padding-preview` instead of dispatching to
+ * the store on every tick, so the canvas repaints without a React render until
+ * the value is committed. Those writes used to target the canvas element alone,
+ * which left the preset thumbnails frozen mid-drag: they mirror the same canvas
+ * but mount under a synthetic `data-canvas-id`, so the selector never reached
+ * them and they only caught up on release.
+ *
+ * Preset preview stages tag themselves with {@link LIVE_PREVIEW_ROOT_ATTR} set
+ * to the canvas they mirror. Writing the same vars to every root keeps the
+ * thumbnails in step with the canvas for free — the vars inherit down each
+ * preview subtree exactly as they do in the real canvas.
+ *
+ * A preview that pins a var itself (a preset thumbnail pins its own tilt) sets
+ * it on its own stage element, so the inherited value from a canvas-level drag
+ * loses to it. That is the intended precedence: dragging canvas tilt must not
+ * retilt the thumbnails, but dragging padding must repad them.
+ */
+
+export const LIVE_PREVIEW_ROOT_ATTR = "data-live-preview-root"
+
+export function livePreviewRoots(
+  activeCanvasId: string | null | undefined
+): HTMLElement[] {
+  if (typeof document === "undefined" || !activeCanvasId) return []
+  const id = CSS.escape(activeCanvasId)
+  const canvasEl = document.querySelector<HTMLElement>(
+    `[data-canvas-id="${id}"]`
+  )
+  const previewRoots = Array.from(
+    document.querySelectorAll<HTMLElement>(
+      `[${LIVE_PREVIEW_ROOT_ATTR}="${id}"]`
+    )
+  )
+  return canvasEl ? [canvasEl, ...previewRoots] : previewRoots
+}
+
+/** Set or remove a var across every live-preview root. */
+export function setLivePreviewVar(
+  roots: HTMLElement[],
+  name: string,
+  value: string | null
+) {
+  for (const root of roots) {
+    if (value === null) root.style.removeProperty(name)
+    else root.style.setProperty(name, value)
+  }
+}
+
+/**
+ * Per-element position vars, keyed by the element's own id.
+ *
+ * Dragging a text, asset or annotation layer used to write straight to the
+ * dragged element's inline style. That can't reach the preset thumbnails: they
+ * render their own copy of the element, and preview subtrees deliberately strip
+ * identifying attributes like `data-screenshot-slot-id`, so there is nothing to
+ * look the copy up by.
+ *
+ * Putting the id in the var *name* sidesteps that entirely. The var is written
+ * once on each root and inherits down to whichever element reads it, so the
+ * canvas and every thumbnail follow the drag without any of them having to be
+ * found individually. Element ids are UUIDs or `t-<ts>-<rand>`, both of which
+ * are valid custom-property idents.
+ */
+export function elementPositionVars(elementId: string) {
+  return {
+    x: `--tk-el-${elementId}-x`,
+    y: `--tk-el-${elementId}-y`,
+  }
+}
+
+export function setElementLivePosition(
+  roots: HTMLElement[],
+  elementId: string,
+  xPct: number,
+  yPct: number
+) {
+  const { x, y } = elementPositionVars(elementId)
+  setLivePreviewVar(roots, x, `${xPct}%`)
+  setLivePreviewVar(roots, y, `${yPct}%`)
+}
+
+export function clearElementLivePosition(
+  roots: HTMLElement[],
+  elementId: string
+) {
+  const { x, y } = elementPositionVars(elementId)
+  setLivePreviewVar(roots, x, null)
+  setLivePreviewVar(roots, y, null)
+}

--- a/lib/editor/preset-application.ts
+++ b/lib/editor/preset-application.ts
@@ -42,16 +42,18 @@ export type PresetPlan = {
 
 const aspectRatio = (aspect: AspectState) => (aspect.w || 16) / (aspect.h || 10)
 
-export function planSinglePreset(
-  preset: PresentPreset,
+/** The preset-independent half of {@link planSinglePreset}: where the extra
+ * slots sit in the natural row, and the scale they inherit. Every single preset
+ * shares this, so the preview rail computes it once instead of per card. */
+export type SinglePresetSlotRow = {
+  placements: Array<{ xPct: number; widthPct: number }>
+  scale: number
+}
+
+export function planSinglePresetSlotRow(
   canvas: CanvasState,
   aspect: AspectState
-): PresetPlan {
-  // Single presets are tilt/position presets — they follow the canvas' current
-  // zoom rather than forcing a fixed scale. This keeps the preset thumbnails
-  // (and applying a preset) in sync with the Zoom / Scale sliders, and stays
-  // idempotent under repeated application and aspect changes.
-  const scale = canvas.scale
+): SinglePresetSlotRow {
   const naturalLayout = computeRowLayout(
     [
       { id: "__main__", frame: canvas.frame },
@@ -63,14 +65,34 @@ export function planSinglePreset(
     aspectRatio(aspect)
   )
   return {
+    // Single presets are tilt/position presets — they follow the canvas'
+    // current zoom rather than forcing a fixed scale. This keeps the preset
+    // thumbnails (and applying a preset) in sync with the Zoom / Scale
+    // sliders, and stays idempotent under repeated application and aspect
+    // changes.
+    scale: canvas.scale,
+    placements: canvas.screenshotSlots.map((slot, i) => ({
+      xPct: naturalLayout[i + 1]?.xPct ?? slot.xPct,
+      widthPct: naturalLayout[i + 1]?.widthPct ?? slot.widthPct,
+    })),
+  }
+}
+
+export function planSinglePreset(
+  preset: PresentPreset,
+  canvas: CanvasState,
+  aspect: AspectState
+): PresetPlan {
+  const { placements, scale } = planSinglePresetSlotRow(canvas, aspect)
+  return {
     canvasTilt: preset.tilt,
     canvasScale: scale,
     screenshotPosition: canvas.screenshotPosition,
     screenshotOffset: canvas.screenshotOffset,
-    slots: canvas.screenshotSlots.map((slot, i) => ({
-      xPct: naturalLayout[i + 1]?.xPct ?? slot.xPct,
+    slots: placements.map((placement) => ({
+      xPct: placement.xPct,
       yPct: 50,
-      widthPct: naturalLayout[i + 1]?.widthPct ?? slot.widthPct,
+      widthPct: placement.widthPct,
       rotation: 0,
       tilt: preset.tilt,
       scale,

--- a/lib/editor/store.tsx
+++ b/lib/editor/store.tsx
@@ -17,6 +17,7 @@ import { isVideoSrc } from "./media-type"
 import { LAYOUT_PRESETS, PRESENT_PRESETS } from "./present-presets"
 import { screenshotPositionAnchor } from "./presets"
 import type { TweetCardSettings } from "./tweet-settings"
+import type { PresetSort } from "@/lib/schemas/preset"
 import {
   resolveActivePresetGeometry,
   resolveMainOffsetPx,
@@ -779,7 +780,7 @@ export type EditorActions = {
    * Fetch the signed-in user's custom presets once. Dedupes in-flight calls so
    * multiple mounted Preset sections (desktop + iPad sidebars) share one request.
    */
-  loadCustomPresets: (userId: string) => void
+  loadCustomPresets: (userId: string, sort?: PresetSort) => void
   addCustomPreset: (preset: CustomPresetSummary) => void
   updateCustomPreset: (id: string, patch: Partial<CustomPresetSummary>) => void
   removeCustomPreset: (id: string) => void
@@ -1089,6 +1090,8 @@ export type EditorStore = {
   customPresetsLoading: boolean
   /** User id the current `customPresets` list was fetched for. */
   customPresetsForUserId: string | null
+  /** Sort the current `customPresets` list was fetched with. */
+  customPresetsSort: PresetSort
   currentDraft: CurrentDraftInfo | null
 } & EditorActions
 
@@ -1362,6 +1365,7 @@ export const useEditorStore = create<EditorStore>((set, get) => {
     customPresetsLoaded: false,
     customPresetsLoading: false,
     customPresetsForUserId: null,
+    customPresetsSort: "latest",
     currentDraft: null,
 
     setActiveTool: (t) => commit({ activeTool: t }, null),
@@ -1381,21 +1385,34 @@ export const useEditorStore = create<EditorStore>((set, get) => {
         customPresetsForUserId: null,
       })
     },
-    loadCustomPresets: (userId) => {
+    loadCustomPresets: (userId, sort) => {
       const state = get()
-      if (state.customPresetsLoaded && state.customPresetsForUserId === userId)
+      const nextSort = sort ?? state.customPresetsSort
+      const sortChanged = nextSort !== state.customPresetsSort
+      if (
+        state.customPresetsLoaded &&
+        state.customPresetsForUserId === userId &&
+        !sortChanged
+      )
         return
       // Dedupe concurrent mounts only for the SAME account. A load for a
       // different user supersedes the in-flight request instead of being
       // blocked by it — its late response is dropped by the token check.
-      if (state.customPresetsLoading && customPresetsInFlightUserId === userId)
+      // A sort change also supersedes: the in-flight list is ordered wrong.
+      if (
+        state.customPresetsLoading &&
+        customPresetsInFlightUserId === userId &&
+        !sortChanged
+      )
         return
       const token = ++customPresetsRequestToken
       customPresetsInFlightUserId = userId
       set({
         customPresetsLoading: true,
+        customPresetsSort: nextSort,
         // Account switch: never show the previous account's presets while the
-        // new list loads.
+        // new list loads. A sort change keeps the current list on screen and
+        // reorders it in place when the response lands.
         ...(state.customPresetsForUserId !== null &&
         state.customPresetsForUserId !== userId
           ? {
@@ -1405,7 +1422,7 @@ export const useEditorStore = create<EditorStore>((set, get) => {
             }
           : {}),
       })
-      void fetch("/api/presets", { credentials: "include" })
+      void fetch(`/api/presets?sort=${nextSort}`, { credentials: "include" })
         .then(async (res) => {
           if (!res.ok) return [] as CustomPresetSummary[]
           const body: { presets: CustomPresetSummary[] } = await res.json()
@@ -1436,7 +1453,13 @@ export const useEditorStore = create<EditorStore>((set, get) => {
     },
     addCustomPreset: (preset) =>
       set((state) => ({
-        customPresets: [preset, ...state.customPresets],
+        // A new preset is the newest, so it belongs at whichever end the
+        // active sort puts newest — otherwise saving under "Oldest" drops it
+        // at the top, where a refetch would not have put it.
+        customPresets:
+          state.customPresetsSort === "oldest"
+            ? [...state.customPresets, preset]
+            : [preset, ...state.customPresets],
         customPresetsLoaded: true,
       })),
     updateCustomPreset: (id, patch) =>

--- a/lib/editor/store.tsx
+++ b/lib/editor/store.tsx
@@ -1424,7 +1424,7 @@ export const useEditorStore = create<EditorStore>((set, get) => {
       })
       void fetch(`/api/presets?sort=${nextSort}`, { credentials: "include" })
         .then(async (res) => {
-          if (!res.ok) return [] as CustomPresetSummary[]
+          if (!res.ok) throw new Error(`Preset load failed: ${res.status}`)
           const body: { presets: CustomPresetSummary[] } = await res.json()
           return body.presets
         })
@@ -1443,12 +1443,17 @@ export const useEditorStore = create<EditorStore>((set, get) => {
           console.warn("Could not load custom presets", err)
           if (token !== customPresetsRequestToken) return
           customPresetsInFlightUserId = null
-          set({
-            customPresets: [],
+          // Keep whatever list is on screen: a failed re-sort must not erase
+          // presets that loaded fine. Roll the sort back so the picker matches
+          // the order actually displayed.
+          set((current) => ({
+            customPresetsSort: current.customPresetsLoaded
+              ? state.customPresetsSort
+              : nextSort,
             customPresetsLoaded: true,
             customPresetsLoading: false,
             customPresetsForUserId: userId,
-          })
+          }))
         })
     },
     addCustomPreset: (preset) =>

--- a/lib/editor/store/use-editor.tsx
+++ b/lib/editor/store/use-editor.tsx
@@ -17,24 +17,42 @@ const CanvasOverrideContext = React.createContext<Partial<CanvasState> | null>(
 
 const CanvasPreviewModeContext = React.createContext<boolean>(false)
 
+/**
+ * The canvas whose store state a preview subtree reads. Previews mount under a
+ * synthetic `CanvasScope` id so their `data-canvas-id` can't be picked up by
+ * export or the live-preview var writers, which both `querySelector` on it.
+ * That synthetic id also used to decide which canvas they *read*, forcing every
+ * preview to carry a full `CanvasState` override. Splitting the two lets a
+ * preview stay DOM-isolated while subscribing to the real canvas directly.
+ */
+const CanvasSourceIdContext = React.createContext<string | null>(null)
+
 export function CanvasPreviewScope({
   override,
+  sourceCanvasId = null,
   children,
 }: {
   override: Partial<CanvasState> | null
+  sourceCanvasId?: string | null
   children: React.ReactNode
 }) {
   return (
     <CanvasPreviewModeContext.Provider value={true}>
-      <CanvasOverrideContext.Provider value={override}>
-        {children}
-      </CanvasOverrideContext.Provider>
+      <CanvasSourceIdContext.Provider value={sourceCanvasId}>
+        <CanvasOverrideContext.Provider value={override}>
+          {children}
+        </CanvasOverrideContext.Provider>
+      </CanvasSourceIdContext.Provider>
     </CanvasPreviewModeContext.Provider>
   )
 }
 
 export function useCanvasPreviewMode() {
   return React.useContext(CanvasPreviewModeContext)
+}
+
+export function useCanvasSourceId() {
+  return React.useContext(CanvasSourceIdContext)
 }
 
 export function CanvasScope({
@@ -84,6 +102,7 @@ export function useActiveCanvasField<T>(
   selector: (canvas: CanvasState) => T
 ): T {
   const scopeId = React.useContext(CanvasIdContext)
+  const sourceId = React.useContext(CanvasSourceIdContext)
   const override = React.useContext(CanvasOverrideContext)
 
   const overrideRef = React.useRef(override)
@@ -103,7 +122,7 @@ export function useActiveCanvasField<T>(
 
   const stableSelector = React.useCallback(
     (s: EditorStore) => {
-      const id = scopeId ?? s.present.activeCanvasId
+      const id = sourceId ?? scopeId ?? s.present.activeCanvasId
       const base =
         s.present.canvases.find((c) => c.id === id) ??
         s.present.canvases[0] ??
@@ -123,7 +142,7 @@ export function useActiveCanvasField<T>(
       }
       return selectorRef.current(canvas)
     },
-    [scopeId]
+    [scopeId, sourceId]
   )
 
   // Wrap with useShallow so selectors returning a new object literal (e.g.

--- a/lib/preset-db.ts
+++ b/lib/preset-db.ts
@@ -1,6 +1,6 @@
 import "server-only"
 
-import { and, desc, eq } from "drizzle-orm"
+import { and, asc, desc, eq } from "drizzle-orm"
 
 import {
   customPresets,
@@ -8,6 +8,7 @@ import {
   type StoredPresetGeometry,
 } from "@/lib/db/schema"
 import { fromD1Date, getDb, toD1Date } from "@/lib/d1"
+import type { PresetSort } from "@/lib/schemas/preset"
 
 export type { CustomPresetType, StoredPresetGeometry } from "@/lib/db/schema"
 
@@ -46,12 +47,20 @@ function rowToPreset(row: CustomPresetRow): CustomPresetRecord {
   }
 }
 
-export async function listCustomPresets(userId: string) {
+export async function listCustomPresets(
+  userId: string,
+  opts: { sort?: PresetSort } = {}
+) {
+  const order =
+    opts.sort === "oldest"
+      ? asc(customPresets.createdAt)
+      : desc(customPresets.createdAt)
+
   const rows = await getDb()
     .select()
     .from(customPresets)
     .where(eq(customPresets.userId, userId))
-    .orderBy(desc(customPresets.createdAt))
+    .orderBy(order)
 
   return rows.map(rowToPreset)
 }

--- a/lib/schemas/preset.ts
+++ b/lib/schemas/preset.ts
@@ -63,6 +63,17 @@ export const presetGeometrySchema = z
   })
   .loose()
 
+/**
+ * Query params for `GET /api/presets`. Mirrors `draftListQuerySchema`: an
+ * unrecognised or missing `sort` falls back to the default rather than
+ * erroring, so a stale client can never 400 the list.
+ */
+export const presetListQuerySchema = z.object({
+  sort: z.enum(["latest", "oldest"]).catch("latest"),
+})
+
+export type PresetSort = z.infer<typeof presetListQuerySchema>["sort"]
+
 /** Request body for `POST /api/presets`. */
 export const createPresetBodySchema = z.object({
   name: z.string().trim().min(1).max(PRESET_NAME_MAX_LENGTH),

--- a/tests/components/editor/annotation-layer.test.tsx
+++ b/tests/components/editor/annotation-layer.test.tsx
@@ -1,6 +1,6 @@
 import { createRef } from "react"
-import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
 
 import { AnnotationLayer } from "@/components/editor/canvas/annotation-layer"
 import type { AnnotationStroke } from "@/lib/editor/store"
@@ -87,5 +87,49 @@ describe("AnnotationLayer", () => {
     expect(screen.getByLabelText("Annotation layer")).toHaveClass(
       "pointer-events-none"
     )
+  })
+
+  it("shows a sized eraser brush preview under the pointer", () => {
+    const { container } = render(
+      <AnnotationLayer
+        layerRef={createRef<SVGSVGElement>()}
+        annotations={[]}
+        annotationMaskId="mask"
+        isAnnotating
+        cursorClass="cursor-none"
+        eraserBrushSize={11}
+        onPointerDown={() => {}}
+        onPointerMove={() => {}}
+        onPointerUp={() => {}}
+        onClick={() => {}}
+        onDoubleClick={() => {}}
+      />
+    )
+    const layer = screen.getByLabelText("Annotation layer")
+    Object.defineProperty(layer, "clientWidth", {
+      configurable: true,
+      value: 200,
+    })
+    Object.defineProperty(layer, "clientHeight", {
+      configurable: true,
+      value: 100,
+    })
+    vi.spyOn(layer, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 100,
+      width: 200,
+      height: 100,
+      toJSON: () => ({}),
+    })
+    fireEvent.pointerMove(layer, { clientX: 40, clientY: 60 })
+    const brush = container.querySelector(
+      "[data-annotation-eraser-brush='true']"
+    )
+    expect(brush).toBeTruthy()
+    expect(brush).toHaveStyle({ width: "11px", height: "11px" })
   })
 })


### PR DESCRIPTION
## Why

Preset preview cards rebuilt a full `CanvasState` override on every canvas change, so any edit — a padding tick, a text drag, an annotation stroke — re-rendered every card's entire `CanvasView` tree. They also never saw the live-preview CSS vars that sliders and drags write, because those target `[data-canvas-id]` and previews mount under a synthetic id. The result was the worst of both: expensive re-renders, and thumbnails that still lagged until commit.

A preview's job is to render the canvas with the preset's geometry applied. It should not be a cloned copy of canvas state.

## What changed

**Previews read the real canvas.** `CanvasPreviewScope` gains a `sourceCanvasId`, splitting the canvas a preview *reads* from the synthetic id it *renders under*. The synthetic id stays so export and the var writers can't match a preset card by `querySelector`.

The key simplification falls out of `planSinglePreset`: it already takes scale, position and offset straight off the canvas. So a single preset differs from the live canvas by **its tilt**, plus slot row placement when extra slots exist — nothing else. Those cards now override `{ tilt }` alone, a stable identity (`preset.tilt` is a module constant), so styling edits re-render nothing in the rail. Row layout is computed once for the rail instead of once per card.

**Live vars reach the thumbnails.** New `lib/editor/live-preview-roots.ts` resolves the canvas element plus every preview stage, and slider vars fan out to all of them.

Per-element drags needed a different approach: text, asset and annotation-shape drags wrote to their own element's inline style, and a preview renders a separate element instance that preview subtrees deliberately strip identifying attributes from. Putting the element id in the *var name* (`--tk-el-{id}-x`) sidesteps the lookup entirely — the var is written once per root and inherits down to whichever element reads it.

**Custom preset sorting.** `GET /api/presets` takes `?sort=latest|oldest`, following the `/api/drafts` convention: a zod enum with `.catch()` so an unrecognised value falls back rather than 400ing a stale client. A bare icon toggle sits on the Custom tab.

**Eraser brush cursor.** The annotation eraser now draws a circle matching its stroke width under the pointer, so its reach is visible before you erase.

## Now live in preset thumbnails during a drag

Padding, shadow, all 10 backdrop effects, canvas radius, overlay opacity, pattern intensity, zoom, main screenshot position, and text / asset / annotation-shape moves.

Border, background, overlay, filters, portrait and frame were already live — they dispatch on change rather than on commit. This PR makes them cheap, not live.

## Deliberately still commit-only

- **Tilt** — each card pins the tilt of the preset it represents; fanning canvas tilt out would overwrite exactly what the thumbnail exists to show.
- **Resize and rotation** — these also write width/height/fontSize inline. A half-updated thumbnail is worse than a consistently-lagging one, so they were left whole.
- **Slot position drag** — `setElementPositionPreview` writes a generic var on the element itself, and previews strip `data-screenshot-slot-id`. Fixable with the same per-id var treatment.
- **Freehand stroke drawing** — commits on pointer-up and mutates the SVG `d` attribute mid-draw, which doesn't fit a CSS var.

## Notes for review

- `useBackgroundDownscale` was running per preview against a canvas id absent from the store. Latent before; reading live state made it fire reliably, so it's now guarded on preview mode.
- `loadCustomPresets` has a dedupe guard that would have silently swallowed every sort change — it now treats a changed sort as a reason to refetch and supersedes an in-flight request.
- `addCustomPreset` prepended unconditionally, which put a newly saved preset at the top under "Oldest" — where a refetch would never have placed it.
- Preset previews now share the canvas' already-downscaled background instead of loading a separate 400px URL, so it's one decode across the canvas and all cards.
- Sort is in-memory and resets to Newest on reload; this store has no persist middleware for those fields. Easy to change if it should stick.

## Testing

`pnpm typecheck`, `pnpm build:next`, and the full vitest suite (1017 tests) all pass; eslint is clean.

The element tests caught a real bug mid-review: the drag handlers initially subscribed via `useEditorStore`, which those tests don't mock. Fixed by reading the scoped canvas id from `useEditor` — no extra subscription, and it targets the canvas the element belongs to rather than the active one, which is what bulk edit needs.

**Not verified in a browser.** Everything above is from reading code and running the suite; the drag paths and the sort round-trip against real D1 data deserve a manual pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes preset previews follow live canvas state while reducing unnecessary renders. The main changes are:

- Reads preview data from the source canvas while keeping synthetic preview IDs.
- Propagates live CSS variables to canvas and preset-preview roots.
- Mirrors text, asset, annotation, and screenshot movement during drags.
- Adds newest and oldest sorting for custom presets.
- Adds a stroke-width eraser cursor preview.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge based on the remaining review scope.

- No additional blocking issue qualifies for a new follow-up comment.
- The updated sort request path rejects failed HTTP responses and preserves an existing preset list.



<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/editor/store.tsx | Adds sort-aware custom-preset loading, request supersession, failure handling, and insertion ordering. |
| lib/editor/live-preview-roots.ts | Adds shared DOM-root resolution and CSS-variable helpers for live canvas previews. |
| components/editor/present-presets-section/cards.tsx | Moves single-preset previews to source-canvas state with small geometry overrides. |
| app/api/presets/route.ts | Parses the preset sort query and forwards it to the user-scoped database query. |
| lib/preset-db.ts | Supports ascending and descending custom-preset ordering by creation time. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `components/editor/text-element-parts/use-text-element-interactions.ts`, line 1209-1212 ([link](https://github.com/shivabhattacharjee/tokokino/blob/3ce169bdf1598e43803f9c860b80c2712c4aaee1/components/editor/text-element-parts/use-text-element-interactions.ts#L1209-L1212)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Old Cleanup Clears New Drag**

   If the same text is released and grabbed again before this animation-frame callback runs, the new drag writes fresh position variables and this callback from the previous drag removes them. The text then jumps to its last committed position until the next pointer move; the equivalent asset and annotation-shape cleanup paths have the same race.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: components/editor/text-element-parts/use-text-element-interactions.ts
   Line: 1209-1212

   Comment:
   **Old Cleanup Clears New Drag**

   If the same text is released and grabbed again before this animation-frame callback runs, the new drag writes fresh position variables and this callback from the previous drag removes them. The text then jumps to its last committed position until the next pointer move; the equivalent asset and annotation-shape cleanup paths have the same race.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20components%2Feditor%2Ftext-element-parts%2Fuse-text-element-interactions.ts%0ALine%3A%201209-1212%0A%0AComment%3A%0A**Old%20Cleanup%20Clears%20New%20Drag**%0A%0AIf%20the%20same%20text%20is%20released%20and%20grabbed%20again%20before%20this%20animation-frame%20callback%20runs%2C%20the%20new%20drag%20writes%20fresh%20position%20variables%20and%20this%20callback%20from%20the%20previous%20drag%20removes%20them.%20The%20text%20then%20jumps%20to%20its%20last%20committed%20position%20until%20the%20next%20pointer%20move%3B%20the%20equivalent%20asset%20and%20annotation-shape%20cleanup%20paths%20have%20the%20same%20race.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=shivabhattacharjee%2Ftokokino&pr=28&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: keep loaded presets when a custom p..."](https://github.com/shivabhattacharjee/tokokino/commit/b81d9717da57d375ce7e5c645b8e5d9f2d733ffc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46051871)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/sideprojects/github/ShivaBhattacharjee/tokokino/-/custom-context?memory=7a22f059-86c3-428b-88f5-f28e5fb51882))
- Context used - agents.md ([source](https://app.greptile.com/sideprojects/github/ShivaBhattacharjee/tokokino/-/custom-context?memory=0b3651fa-1db4-4837-8570-4aaf8d2a4cc2))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sorting for custom presets (newest/oldest).
  * Added a visible circular eraser brush preview while annotating.
  * Improved live previews during dragging and slider/panels interactions across both the main canvas and preset previews.
* **Bug Fixes**
  * Improved drag behavior to prevent brief visual snapping when committing positions.
  * Eraser mode now uses a more suitable cursor.
* **Tests**
  * Added coverage for the eraser brush preview rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->