### PR TITLE
fix: resolve CodeQL code-scanning alerts (#1, #5, #6)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,6 +10,9 @@ concurrency:
   group: checks-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Format, lint, typecheck, test, build

--- a/components/editor/text-element-parts/use-text-element-interactions.ts
+++ b/components/editor/text-element-parts/use-text-element-interactions.ts
@@ -743,7 +743,7 @@ export function useTextElementInteractions({
   const commitContent = React.useCallback(() => {
     const node = editorRef.current
     if (!node) return
-    const next = node.innerText.replace(/ /g, " ")
+    const next = node.innerText.replace(/\u00A0/g, " ")
     updateText(text.id, { content: next || " " })
     setEditingRequested(false)
   }, [text.id, updateText])

--- a/lib/editor/fonts.ts
+++ b/lib/editor/fonts.ts
@@ -425,7 +425,7 @@ function toFontId(label: string, category: FontCategory) {
 
 function makeCss(label: string, category: FontCategory) {
   if (label === "Doto") return "var(--font-doto), 'Doto', sans-serif"
-  const quoted = `'${label.replace(/'/g, "\\'")}'`
+  const quoted = `'${label.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`
   if (category === "serif") return `${quoted}, serif`
   if (category === "mono") return `${quoted}, ui-monospace, monospace`
   if (category === "script") return `${quoted}, cursive`


### PR DESCRIPTION
Resolves three open CodeQL code-scanning alerts.

## Changes

### #1 — Missing workflow permissions (`actions/missing-workflow-permissions`)
`.github/workflows/checks.yml` had no `permissions` block, so the `checks` job inherited the default `GITHUB_TOKEN` scope (potentially read-write). The job only checks out code and runs format/lint/typecheck/test/build, so it now declares least privilege:

```yaml
permissions:
  contents: read
```

### #6 — Replacement of a substring with itself (`js/identity-replacement`)
`components/editor/text-element-parts/use-text-element-interactions.ts` had `node.innerText.replace(/ /g, " ")` — both characters were regular spaces, making it a genuine no-op. The intent was to normalize the non-breaking spaces that `contenteditable`/`innerText` emit, so it now targets ` `:

```ts
const next = node.innerText.replace(/ /g, " ")
```

### #5 — Incomplete string escaping (`js/incomplete-sanitization`)
`lib/editor/fonts.ts` escaped single quotes but not backslashes when building the CSS font-family literal. Font labels all come from curated hardcoded arrays (no quotes/backslashes, nothing user-controlled), so this is not exploitable, but the two-line change silences the alert and is correct:

```ts
const quoted = `'${label.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`
```

## Validation
- `pnpm typecheck` passes
- lint-staged (Prettier + ESLint) ran clean on commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text editor content now correctly converts non-breaking spaces to regular spaces when saved.
  * Font names containing backslashes are safely represented in generated styles.

* **Security**
  * Automated checks now use read-only access to repository contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves three CodeQL alerts in CI, text editing, and font CSS generation. The main changes are:

- Restrict the checks workflow token to read-only repository access.
- Normalize non-breaking spaces when committing editable text.
- Escape backslashes in quoted CSS font-family values.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after considering whether pasted non-breaking spaces must be preserved.

- The CI permission matches the current workflow steps.
- The CSS escaping order is correct and leaves existing catalog values unchanged.
- Text commits can change an intentional non-breaking space into a wrapping space.

components/editor/text-element-parts/use-text-element-interactions.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/checks.yml | Adds read-only repository permissions; the current workflow has no GitHub write operation. |
| components/editor/text-element-parts/use-text-element-interactions.ts | Normalizes browser-generated non-breaking spaces but also changes intentional non-breaking spaces in edited content. |
| lib/editor/fonts.ts | Correctly escapes backslashes before single quotes in generated CSS font-family strings. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acomponents%2Feditor%2Ftext-element-parts%2Fuse-text-element-interactions.ts%3A746%0A**Intentional%20Non-Breaking%20Spaces%20Are%20Lost**%0A%0AWhen%20edited%20text%20contains%20an%20intentional%20U%2B00A0%20character%2C%20such%20as%20one%20pasted%20to%20keep%20two%20words%20together%2C%20this%20global%20replacement%20stores%20it%20as%20a%20regular%20space%20on%20blur%20or%20keyboard%20commit.%20The%20saved%20text%20can%20then%20wrap%20where%20the%20user%20explicitly%20prevented%20a%20line%20break.%0A%0A&repo=shivabhattacharjee%2Ftokokino&pr=30&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/editor/text-element-parts/use-text-element-interactions.ts:746
**Intentional Non-Breaking Spaces Are Lost**

When edited text contains an intentional U+00A0 character, such as one pasted to keep two words together, this global replacement stores it as a regular space on blur or keyboard commit. The saved text can then wrap where the user explicitly prevented a line break.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve CodeQL code-scanning alerts"](https://github.com/shivabhattacharjee/tokokino/commit/fa955b712449d3ad7a14cc00b07f4734615c216e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46259466)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/sideprojects/github/ShivaBhattacharjee/tokokino/-/custom-context?memory=7a22f059-86c3-428b-88f5-f28e5fb51882))
- Context used - agents.md ([source](https://app.greptile.com/sideprojects/github/ShivaBhattacharjee/tokokino/-/custom-context?memory=0b3651fa-1db4-4837-8570-4aaf8d2a4cc2))

<!-- /greptile_comment -->