### PR TITLE
Account settings: session management + queue-backed deletion

### DIFF
--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -1,0 +1,188 @@
+import { NextResponse } from "next/server"
+import { z } from "zod/v4"
+
+import {
+  requestAccountDeletion,
+  retryPendingAccountCleanups,
+} from "@/lib/account-management"
+import { requireSession } from "@/lib/api-auth"
+import { getAuth } from "@/lib/auth"
+import { getD1Database } from "@/lib/d1"
+import { enforceRateLimit } from "@/lib/rate-limit"
+
+export const runtime = "nodejs"
+
+const sessionActionSchema = z
+  .object({
+    action: z.enum(["revoke", "revoke-all"]),
+    sessionId: z.string().min(1).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.action === "revoke" && !value.sessionId) {
+      ctx.addIssue({ code: "custom", message: "A session is required" })
+    }
+  })
+
+const deleteAccountSchema = z.object({ confirmation: z.literal("DELETE") })
+
+type CloudflareRequest = Request & {
+  cf?: { city?: string; region?: string; country?: string }
+}
+
+function sessionLocation(request: Request) {
+  const cf = (request as CloudflareRequest).cf
+  if (!cf) return null
+  const parts = [cf.city, cf.region || cf.country].filter(Boolean)
+  return parts.length > 0 ? parts.join(", ") : null
+}
+
+function deviceName(userAgent: string | null | undefined) {
+  const agent = userAgent ?? ""
+  const browser = /edg\//i.test(agent)
+    ? "Edge"
+    : /firefox\//i.test(agent)
+      ? "Firefox"
+      : /chrome\//i.test(agent)
+        ? "Chrome"
+        : /safari\//i.test(agent)
+          ? "Safari"
+          : "Browser"
+  const platform = /iphone/i.test(agent)
+    ? "iPhone"
+    : /ipad/i.test(agent)
+      ? "iPad"
+      : /android/i.test(agent)
+        ? "Android"
+        : /macintosh|mac os/i.test(agent)
+          ? "macOS"
+          : /windows/i.test(agent)
+            ? "Windows"
+            : /linux/i.test(agent)
+              ? "Linux"
+              : "Unknown device"
+  return `${browser} on ${platform}`
+}
+
+export async function GET(request: Request) {
+  const auth = await requireSession(request)
+  if (!auth.ok) return auth.response
+  const current = auth.session
+
+  const limited = await enforceRateLimit({
+    limiter: "WRITE_RATE_LIMITER",
+    scope: "account-sessions",
+    id: current.user.id,
+  })
+  if (limited) return limited
+
+  void retryPendingAccountCleanups()
+
+  const location = sessionLocation(request)
+  if (location) {
+    await getD1Database()
+      .prepare(
+        "INSERT INTO session_locations (session_id, location, updated_at) VALUES (?, ?, ?) ON CONFLICT(session_id) DO UPDATE SET location = excluded.location, updated_at = excluded.updated_at"
+      )
+      .bind(current.session.id, location, new Date().toISOString())
+      .run()
+  }
+
+  const sessions = await getAuth().api.listSessions({
+    headers: request.headers,
+  })
+  const locations = await Promise.all(
+    sessions.map(async (session) => {
+      const row = await getD1Database()
+        .prepare("SELECT location FROM session_locations WHERE session_id = ?")
+        .bind(session.id)
+        .first<{ location: string }>()
+      return [session.id, row?.location ?? "Location unavailable"] as const
+    })
+  )
+  const locationBySession = new Map(locations)
+
+  return NextResponse.json({
+    sessions: sessions
+      .map((session) => ({
+        id: session.id,
+        device: deviceName(session.userAgent),
+        location: locationBySession.get(session.id) ?? "Location unavailable",
+        lastActive: session.updatedAt.toISOString(),
+        current: session.id === current.session.id,
+      }))
+      .sort((a, b) => Number(b.current) - Number(a.current)),
+  })
+}
+
+export async function POST(request: Request) {
+  const auth = await requireSession(request)
+  if (!auth.ok) return auth.response
+  const current = auth.session
+
+  const limited = await enforceRateLimit({
+    limiter: "WRITE_RATE_LIMITER",
+    scope: "account-session-revoke",
+    id: current.user.id,
+  })
+  if (limited) return limited
+
+  const input = sessionActionSchema.safeParse(
+    await request.json().catch(() => null)
+  )
+  if (!input.success) {
+    return NextResponse.json(
+      { error: "Invalid session action" },
+      { status: 400 }
+    )
+  }
+
+  if (input.data.action === "revoke-all") {
+    await getAuth().api.revokeSessions({ headers: request.headers })
+    return NextResponse.json({ ok: true, current: true })
+  }
+
+  const sessions = await getAuth().api.listSessions({
+    headers: request.headers,
+  })
+  const target = sessions.find((session) => session.id === input.data.sessionId)
+  if (!target)
+    return NextResponse.json({ error: "Session not found" }, { status: 404 })
+
+  await getAuth().api.revokeSession({
+    headers: request.headers,
+    body: { token: target.token },
+  })
+  return NextResponse.json({
+    ok: true,
+    current: target.id === current.session.id,
+  })
+}
+
+export async function DELETE(request: Request) {
+  const auth = await requireSession(request)
+  if (!auth.ok) return auth.response
+  const current = auth.session
+
+  const limited = await enforceRateLimit({
+    limiter: "WRITE_RATE_LIMITER",
+    scope: "account-delete",
+    id: current.user.id,
+  })
+  if (limited) return limited
+
+  const input = deleteAccountSchema.safeParse(
+    await request.json().catch(() => null)
+  )
+  if (!input.success) {
+    return NextResponse.json(
+      { error: "Type DELETE to permanently delete your account" },
+      { status: 400 }
+    )
+  }
+
+  // Sign the user out everywhere, then hand the heavy deletion to the queue.
+  // Re-login is blocked by the account-deletion gate in `lib/auth.ts`.
+  await getAuth().api.revokeSessions({ headers: request.headers })
+  await requestAccountDeletion(current.user.id)
+  return NextResponse.json({ ok: true, status: "pending" })
+}

--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -75,7 +75,11 @@ export async function GET(request: Request) {
   })
   if (limited) return limited
 
-  void retryPendingAccountCleanups()
+  // Fire-and-forget so the route stays non-blocking, but attach a handler so a
+  // failure in the initial query can't surface as an unhandled rejection.
+  void retryPendingAccountCleanups().catch((error) => {
+    console.error("Could not retry pending account cleanups", error)
+  })
 
   const location = sessionLocation(request)
   if (location) {
@@ -90,16 +94,19 @@ export async function GET(request: Request) {
   const sessions = await getAuth().api.listSessions({
     headers: request.headers,
   })
-  const locations = await Promise.all(
-    sessions.map(async (session) => {
-      const row = await getD1Database()
-        .prepare("SELECT location FROM session_locations WHERE session_id = ?")
-        .bind(session.id)
-        .first<{ location: string }>()
-      return [session.id, row?.location ?? "Location unavailable"] as const
-    })
-  )
-  const locationBySession = new Map(locations)
+  const locationBySession = new Map<string, string>()
+  if (sessions.length > 0) {
+    const placeholders = sessions.map(() => "?").join(", ")
+    const rows = await getD1Database()
+      .prepare(
+        `SELECT session_id, location FROM session_locations WHERE session_id IN (${placeholders})`
+      )
+      .bind(...sessions.map((session) => session.id))
+      .all<{ session_id: string; location: string }>()
+    for (const row of rows.results ?? []) {
+      locationBySession.set(row.session_id, row.location)
+    }
+  }
 
   return NextResponse.json({
     sessions: sessions

--- a/app/api/internal/account-deletion/reconcile/route.ts
+++ b/app/api/internal/account-deletion/reconcile/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server"
 
-import { reconcileStaleAccountDeletions } from "@/lib/account-management"
+import {
+  reconcileStaleAccountDeletions,
+  retryPendingAccountCleanups,
+} from "@/lib/account-management"
 import { env } from "@/lib/env"
 
 export const runtime = "nodejs"
@@ -8,7 +11,9 @@ export const runtime = "nodejs"
 /**
  * Internal endpoint driven by the cron `scheduled` handler in `worker.ts`.
  * Retries deletion flags that have gone stale so a dropped or dead-lettered
- * job cannot lock an account out forever. Guarded by the server-only secret.
+ * job cannot lock an account out forever, and drains the durable R2 cleanup
+ * outbox so a deleted user's orphaned objects are removed without depending on
+ * other account traffic. Guarded by the server-only secret.
  */
 export async function POST(request: Request) {
   const secret = env.BETTER_AUTH_SECRET
@@ -17,5 +22,8 @@ export async function POST(request: Request) {
   }
 
   const result = await reconcileStaleAccountDeletions()
+  await retryPendingAccountCleanups().catch((error) => {
+    console.error("Reconcile: storage cleanup retry failed", error)
+  })
   return NextResponse.json({ ok: true, ...result })
 }

--- a/app/api/internal/account-deletion/reconcile/route.ts
+++ b/app/api/internal/account-deletion/reconcile/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server"
+
+import { reconcileStaleAccountDeletions } from "@/lib/account-management"
+import { env } from "@/lib/env"
+
+export const runtime = "nodejs"
+
+/**
+ * Internal endpoint driven by the cron `scheduled` handler in `worker.ts`.
+ * Retries deletion flags that have gone stale so a dropped or dead-lettered
+ * job cannot lock an account out forever. Guarded by the server-only secret.
+ */
+export async function POST(request: Request) {
+  const secret = env.BETTER_AUTH_SECRET
+  if (!secret || request.headers.get("authorization") !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const result = await reconcileStaleAccountDeletions()
+  return NextResponse.json({ ok: true, ...result })
+}

--- a/app/api/internal/account-deletion/route.ts
+++ b/app/api/internal/account-deletion/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server"
+
+import { processAccountDeletion } from "@/lib/account-management"
+import { env } from "@/lib/env"
+
+export const runtime = "nodejs"
+
+/**
+ * Internal endpoint invoked by the account-deletion queue consumer
+ * (`worker.ts`). Running the deletion here — rather than directly in the queue
+ * handler — means it executes inside the OpenNext request context, where the
+ * D1 and R2 bindings resolve. Guarded by the server-only auth secret.
+ */
+export async function POST(request: Request) {
+  const secret = env.BETTER_AUTH_SECRET
+  if (!secret || request.headers.get("authorization") !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const body = (await request.json().catch(() => null)) as {
+    userId?: string
+  } | null
+  if (!body?.userId) {
+    return NextResponse.json({ error: "Missing userId" }, { status: 400 })
+  }
+
+  await processAccountDeletion(body.userId)
+  return NextResponse.json({ ok: true })
+}

--- a/app/dpa/page.tsx
+++ b/app/dpa/page.tsx
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
     "Review Tokokino's data processing terms for hosted account, sharing, and support features.",
 }
 
-const LAST_UPDATED = "March 2026"
+const LAST_UPDATED = "July 2026"
 
 type DpaSection = {
   title: string
@@ -64,6 +64,13 @@ const subProcessorGroups: SubProcessorGroup[] = [
         name: "Cloudflare R2",
         purpose:
           "Object storage used for hosted share images, draft state files, thumbnails, and related uploaded assets.",
+        entity: "Cloudflare, Inc.",
+        location: "United States / Global",
+      },
+      {
+        name: "Cloudflare Queues",
+        purpose:
+          "Managed message queue used for asynchronous background jobs such as account deletion and related cleanup workflows.",
         entity: "Cloudflare, Inc.",
         location: "United States / Global",
       },
@@ -283,8 +290,8 @@ const sections: DpaSection[] = [
         key="security-management-list"
         items={[
           "Security-conscious project maintenance, dependency review, and issue response processes.",
-          "Use of managed infrastructure providers for hosting, database, object storage, CDN delivery, and platform security controls.",
-          "Periodic review of security-sensitive code paths, including authentication, sharing, storage, and export proxy behavior.",
+          "Use of managed infrastructure providers for hosting, database, object storage, message queues, CDN delivery, and platform security controls.",
+          "Periodic review of security-sensitive code paths, including authentication, sharing, storage, account deletion, and export proxy behavior.",
         ]}
       />,
       <h3
@@ -325,6 +332,7 @@ const sections: DpaSection[] = [
         items={[
           "Hosted traffic is served over HTTPS/TLS through managed edge infrastructure.",
           "Share images and draft data are stored in Cloudflare R2, while share, draft, preset, and account metadata are stored in Cloudflare D1.",
+          "Background jobs such as account deletion are processed asynchronously through Cloudflare Queues.",
           "Public share links are accessible to anyone with the URL; users should avoid sharing content that they do not want made public.",
           "Server routes validate request types and size limits for upload and sharing workflows.",
           "External image export requests are proxied through a controlled API route to support browser rendering while reducing direct client-side CORS exposure.",
@@ -455,7 +463,7 @@ const sections: DpaSection[] = [
           {
             term: "Purpose of Processing",
             description:
-              "Providing authentication, editor-related hosted features, public sharing, draft storage, export support, abuse prevention, security, debugging, support, and service improvement.",
+              "Providing authentication, editor-related hosted features, public sharing, draft storage, export support, account deletion and related cleanup, abuse prevention, security, debugging, support, and service improvement.",
           },
           {
             term: "Duration of Processing",

--- a/app/login/login-form.tsx
+++ b/app/login/login-form.tsx
@@ -11,12 +11,18 @@ export function LoginForm({
   callbackURL = "/app",
   variant = "page",
   onBeforeSignIn,
+  errorMessage = null,
 }: {
   callbackURL?: string
   variant?: "page" | "dialog"
   onBeforeSignIn?: () => void | Promise<void>
+  errorMessage?: string | null
 }) {
   const [loading, setLoading] = React.useState(false)
+
+  React.useEffect(() => {
+    if (errorMessage) toast.error(errorMessage)
+  }, [errorMessage])
 
   const handleGoogle = async () => {
     if (loading) return

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -15,6 +15,11 @@ export const metadata: Metadata = {
 
 const DEFAULT_AUTH_REDIRECT = "/app"
 
+const AUTH_ERROR_MESSAGES: Record<string, string> = {
+  account_deleted:
+    "This account is being deleted and can no longer be accessed.",
+}
+
 function resolveCallbackRedirect(
   callbackURL: string | undefined,
   origin: string
@@ -37,17 +42,19 @@ const GRAIN_SVG =
 export default async function LoginPage({
   searchParams,
 }: {
-  searchParams: Promise<{ callbackURL?: string }>
+  searchParams: Promise<{ callbackURL?: string; error?: string }>
 }) {
   const requestHeaders = await headers()
   const session = await getAuth().api.getSession({ headers: requestHeaders })
+  const { callbackURL, error } = await searchParams
 
   if (session) {
     const host = requestHeaders.get("host") ?? "localhost"
     const proto = requestHeaders.get("x-forwarded-proto") ?? "https"
-    const { callbackURL } = await searchParams
     redirect(resolveCallbackRedirect(callbackURL, `${proto}://${host}`))
   }
+
+  const errorMessage = error ? (AUTH_ERROR_MESSAGES[error] ?? null) : null
 
   return (
     <main className="relative min-h-svh w-full overflow-hidden bg-background text-foreground">
@@ -111,7 +118,7 @@ export default async function LoginPage({
           </div>
 
           <div className="relative z-10 flex flex-1 items-center justify-center py-12">
-            <LoginForm />
+            <LoginForm errorMessage={errorMessage} />
           </div>
         </section>
       </div>

--- a/components/editor/settings/settings-dialog.tsx
+++ b/components/editor/settings/settings-dialog.tsx
@@ -341,11 +341,18 @@ function ConnectedAccounts() {
 
   React.useEffect(() => {
     let cancelled = false
-    void authClient.listAccounts().then((res) => {
-      if (cancelled) return
-      const list = (res.data ?? []) as LinkedAccount[]
-      setAccounts(list.filter((a) => a.providerId in SOCIAL_PROVIDERS))
-    })
+    authClient
+      .listAccounts()
+      .then((res) => {
+        if (cancelled) return
+        const list = (res.data ?? []) as LinkedAccount[]
+        setAccounts(list.filter((a) => a.providerId in SOCIAL_PROVIDERS))
+      })
+      .catch(() => {
+        // Network/auth failure — settle to empty so we don't hang on null and
+        // don't surface an unhandled rejection.
+        if (!cancelled) setAccounts([])
+      })
     return () => {
       cancelled = true
     }

--- a/components/editor/settings/settings-dialog.tsx
+++ b/components/editor/settings/settings-dialog.tsx
@@ -2,23 +2,32 @@
 
 import * as React from "react"
 import {
+  RiCheckLine,
   RiCloseLine,
   RiComputerLine,
+  RiDeleteBinLine,
   RiEyeLine,
+  RiFileCopyLine,
+  RiGoogleFill,
   RiLoader4Line,
+  RiLogoutBoxLine,
+  RiMapPinLine,
   RiMoonLine,
-  RiPaletteLine,
   RiResetLeftLine,
   RiSaveLine,
+  RiShieldCheckLine,
   RiSunLine,
   RiFunctionLine,
   RiImageLine,
   RiKeyboardLine,
+  RiUserLine,
+  RiUserSettingsLine,
 } from "@remixicon/react"
 import { LayoutGroup, motion } from "motion/react"
 import { useTheme } from "next-themes"
 import { toast } from "sonner"
 
+import { AccountAvatar } from "@/components/editor/account-avatar"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -27,7 +36,7 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { useSession } from "@/lib/auth-client"
+import { authClient, useSession } from "@/lib/auth-client"
 import { cn } from "@/lib/utils"
 import {
   applyExportFilenameFormat,
@@ -44,14 +53,15 @@ import {
   SHORTCUT_GROUPS,
 } from "@/lib/editor/shortcuts"
 
-type SettingsSection = "appearance" | "export" | "shortcuts"
+type SettingsSection = "profile" | "account" | "export" | "shortcuts"
 
 const NAV_ITEMS: {
   id: SettingsSection
   label: string
   icon: React.ComponentType<{ className?: string }>
 }[] = [
-  { id: "appearance", label: "Appearance", icon: RiPaletteLine },
+  { id: "profile", label: "Profile", icon: RiUserLine },
+  { id: "account", label: "Account", icon: RiUserSettingsLine },
   { id: "export", label: "Export", icon: RiImageLine },
   { id: "shortcuts", label: "Shortcuts", icon: RiKeyboardLine },
 ]
@@ -63,17 +73,17 @@ export function SettingsDialog({
   open: boolean
   onOpenChange: (open: boolean) => void
 }) {
-  const [section, setSection] = React.useState<SettingsSection>("appearance")
+  const [section, setSection] = React.useState<SettingsSection>("profile")
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton={false}
-        className="h-[560px] max-h-[85vh] gap-0 overflow-hidden rounded-md p-0 sm:max-w-3xl"
+        className="h-[calc(100dvh-1rem)] max-h-[44rem] w-[calc(100vw-1rem)] gap-0 overflow-hidden rounded-md bg-background p-0 sm:h-160 sm:max-h-[88vh] sm:w-[92vw] sm:max-w-5xl"
       >
         <DialogTitle className="sr-only">Settings</DialogTitle>
         <DialogDescription className="sr-only">
-          Configure appearance, export format, and view keyboard shortcuts.
+          Manage your profile, export format, and view keyboard shortcuts.
         </DialogDescription>
 
         <DialogClose asChild>
@@ -81,55 +91,75 @@ export function SettingsDialog({
             variant="ghost"
             size="icon-sm"
             aria-label="Close settings"
-            className="absolute top-3 right-3 z-20 cursor-pointer rounded-sm bg-foreground/8 text-foreground/60 ring-1 ring-border/50 backdrop-blur-sm hover:bg-foreground/12 hover:text-foreground"
+            className="absolute top-3 right-3 z-20 hidden cursor-pointer rounded-sm bg-foreground/8 text-foreground/60 ring-1 ring-border/50 backdrop-blur-sm hover:bg-foreground/12 hover:text-foreground lg:inline-flex"
           >
             <RiCloseLine />
           </Button>
         </DialogClose>
 
-        <div className="flex h-full min-h-0">
-          {/* Sidebar */}
-          <nav className="flex w-44 shrink-0 flex-col gap-1 border-r border-border/60 bg-secondary/30 p-3">
-            <p className="px-2 pt-1 pb-2 text-[11px] font-semibold tracking-wider text-muted-foreground uppercase">
+        <div className="flex h-full min-h-0 min-w-0 flex-col lg:flex-row">
+          {/* Mobile header — close button gets its own row so the tabs below it never collide with it */}
+          <div className="flex shrink-0 items-center justify-between border-b border-border/60 bg-card px-3 py-2.5 lg:hidden">
+            <p className="text-[11px] font-semibold tracking-wider text-muted-foreground uppercase">
               Settings
             </p>
-            <LayoutGroup id="settings-nav">
-              {NAV_ITEMS.map((item) => {
-                const active = section === item.id
-                return (
-                  <button
-                    key={item.id}
-                    type="button"
-                    onClick={() => setSection(item.id)}
-                    className={cn(
-                      "relative flex cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-[13px] font-medium transition-colors",
-                      active
-                        ? "text-primary-foreground"
-                        : "text-muted-foreground hover:text-foreground"
-                    )}
-                  >
-                    {active ? (
-                      <motion.span
-                        layoutId="settings-nav-pill"
-                        className="absolute inset-0 rounded-md bg-primary shadow-sm"
-                        transition={{
-                          type: "spring",
-                          stiffness: 420,
-                          damping: 34,
-                        }}
-                      />
-                    ) : null}
-                    <item.icon className="relative z-10 size-4" />
-                    <span className="relative z-10">{item.label}</span>
-                  </button>
-                )
-              })}
-            </LayoutGroup>
+            <DialogClose asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Close settings"
+                className="cursor-pointer rounded-sm bg-foreground/8 text-foreground/60 ring-1 ring-border/50 hover:bg-foreground/12 hover:text-foreground"
+              >
+                <RiCloseLine />
+              </Button>
+            </DialogClose>
+          </div>
+
+          {/* Sidebar — lighter surface */}
+          <nav className="flex w-full shrink-0 flex-row gap-0.5 overflow-x-auto border-b border-border/60 bg-card p-2 lg:w-60 lg:flex-col lg:overflow-visible lg:border-r lg:border-b-0 lg:p-3">
+            <p className="hidden px-2 pt-1 pb-2 text-[11px] font-semibold tracking-wider text-muted-foreground uppercase lg:block">
+              Settings
+            </p>
+            <div className="flex gap-0.5 lg:block">
+              <LayoutGroup id="settings-nav">
+                {NAV_ITEMS.map((item) => {
+                  const active = section === item.id
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => setSection(item.id)}
+                      className={cn(
+                        "relative flex shrink-0 cursor-pointer items-center gap-2 rounded-md px-2.5 py-1.5 text-[12px] font-medium transition-colors lg:w-full lg:justify-start",
+                        active
+                          ? "text-primary-foreground"
+                          : "text-muted-foreground hover:text-foreground"
+                      )}
+                    >
+                      {active ? (
+                        <motion.span
+                          layoutId="settings-nav-pill"
+                          className="absolute inset-0 rounded-md bg-primary shadow-sm"
+                          transition={{
+                            type: "spring",
+                            stiffness: 420,
+                            damping: 34,
+                          }}
+                        />
+                      ) : null}
+                      <item.icon className="relative z-10 size-3.5" />
+                      <span className="relative z-10">{item.label}</span>
+                    </button>
+                  )
+                })}
+              </LayoutGroup>
+            </div>
           </nav>
 
-          {/* Content */}
-          <div className="min-w-0 flex-1 overflow-y-auto p-6">
-            {section === "appearance" && <AppearanceSection />}
+          {/* Content — darker surface */}
+          <div className="min-w-0 flex-1 overflow-y-auto bg-background px-4 py-5 sm:px-8 sm:py-7">
+            {section === "profile" && <ProfileSection />}
+            {section === "account" && <AccountSection />}
             {section === "export" && <ExportSection />}
             {section === "shortcuts" && <ShortcutsSection />}
           </div>
@@ -149,7 +179,7 @@ const THEME_OPTIONS: {
   { value: "system", label: "System", icon: RiComputerLine },
 ]
 
-function AppearanceSection() {
+function ThemeToggle() {
   const { theme, setTheme } = useTheme()
   const [mounted, setMounted] = React.useState(false)
   // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -157,51 +187,600 @@ function AppearanceSection() {
   const active = mounted ? (theme ?? "system") : "system"
 
   return (
+    <LayoutGroup id="settings-theme">
+      <div className="flex w-full max-w-sm items-center gap-1 rounded-xl bg-secondary/50 p-1">
+        {THEME_OPTIONS.map((opt) => {
+          const isActive = active === opt.value
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setTheme(opt.value)}
+              className={cn(
+                "relative flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-[12px] font-medium transition-colors",
+                isActive
+                  ? "text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {isActive ? (
+                <motion.span
+                  layoutId="settings-theme-pill"
+                  className="absolute inset-0 rounded-lg bg-primary shadow-sm"
+                  transition={{ type: "spring", stiffness: 420, damping: 34 }}
+                />
+              ) : null}
+              <opt.icon className="relative z-10 size-4" />
+              <span className="relative z-10">{opt.label}</span>
+            </button>
+          )
+        })}
+      </div>
+    </LayoutGroup>
+  )
+}
+
+type LinkedAccount = { providerId: string; accountId: string }
+
+const SOCIAL_PROVIDERS: Record<
+  string,
+  { label: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  google: { label: "Google", icon: RiGoogleFill },
+}
+
+type SessionUser = NonNullable<ReturnType<typeof useSession>["data"]>["user"]
+
+function ProfileSection() {
+  const { data: session, isPending } = useSession()
+  const user = session?.user
+
+  if (!user && !isPending) {
+    return (
+      <div className="space-y-6">
+        <SectionHeader
+          title="Profile"
+          description="Manage how you appear in Tokokino."
+        />
+        <div className="space-y-8">
+          <div className="space-y-3">
+            <p className="text-[13px] font-medium text-foreground">
+              Appearance
+            </p>
+            <ThemeToggle />
+          </div>
+          <div className="rounded-lg border border-border/60 bg-secondary/30 px-4 py-3 text-[13px] text-muted-foreground">
+            Sign in to view your profile and connected accounts.
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
     <div className="space-y-6">
       <SectionHeader
-        title="Appearance"
-        description="Choose how Tokokino looks on this device."
+        title="Profile"
+        description="Manage how you appear in Tokokino."
       />
 
-      <div className="space-y-2">
-        <p className="text-[13px] font-medium text-foreground">Theme</p>
-        <LayoutGroup id="settings-theme">
-          <div className="flex w-full max-w-sm items-center gap-1 rounded-xl bg-secondary/50 p-1">
-            {THEME_OPTIONS.map((opt) => {
-              const isActive = active === opt.value
-              return (
-                <button
-                  key={opt.value}
-                  type="button"
-                  onClick={() => setTheme(opt.value)}
-                  className={cn(
-                    "relative flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-[12px] font-medium transition-colors",
-                    isActive
-                      ? "text-primary-foreground"
-                      : "text-muted-foreground hover:text-foreground"
-                  )}
-                >
-                  {isActive ? (
-                    <motion.span
-                      layoutId="settings-theme-pill"
-                      className="absolute inset-0 rounded-lg bg-primary shadow-sm"
-                      transition={{
-                        type: "spring",
-                        stiffness: 420,
-                        damping: 34,
-                      }}
-                    />
-                  ) : null}
-                  <opt.icon className="relative z-10 size-4" />
-                  <span className="relative z-10">{opt.label}</span>
-                </button>
-              )
-            })}
-          </div>
-        </LayoutGroup>
+      <div className="space-y-8">
+        <ProfileHeader user={user} />
+
+        <Divider />
+
+        <div className="space-y-3">
+          <p className="text-[13px] font-medium text-foreground">Appearance</p>
+          <p className="text-[12px] text-muted-foreground">
+            Choose how Tokokino looks on this device.
+          </p>
+          <ThemeToggle />
+        </div>
+
+        <Divider />
+
+        <EmailField user={user} />
+
+        <Divider />
+
+        <ConnectedAccounts />
       </div>
     </div>
   )
+}
+
+function ProfileHeader({ user }: { user: SessionUser | undefined }) {
+  return (
+    <div className="flex items-center gap-4">
+      <AccountAvatar
+        src={user?.image}
+        name={user?.name}
+        className="size-16 rounded-full ring-1 ring-border/70"
+        iconClassName="size-6"
+      />
+      <div className="min-w-0">
+        <p className="truncate text-lg font-semibold text-foreground">
+          {user?.name?.trim() || "Your account"}
+        </p>
+        {user?.email ? (
+          <p className="truncate text-[13px] text-muted-foreground">
+            {user.email}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function EmailField({ user }: { user: SessionUser | undefined }) {
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <p className="text-base font-semibold text-foreground">Email</p>
+        <p className="text-[12px] text-muted-foreground">
+          The address we use to sign you in and send account notices.
+        </p>
+      </div>
+      <div className="flex items-center gap-3 rounded-md border border-border/60 bg-secondary/30 px-3.5 py-3">
+        <span className="min-w-0 flex-1 truncate text-[13px] text-foreground">
+          {user?.email ?? "—"}
+        </span>
+        {user?.emailVerified ? (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] font-medium text-emerald-500">
+            <RiShieldCheckLine className="size-3.5" />
+            Verified
+          </span>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function ConnectedAccounts() {
+  const [accounts, setAccounts] = React.useState<LinkedAccount[] | null>(null)
+
+  React.useEffect(() => {
+    let cancelled = false
+    void authClient.listAccounts().then((res) => {
+      if (cancelled) return
+      const list = (res.data ?? []) as LinkedAccount[]
+      setAccounts(list.filter((a) => a.providerId in SOCIAL_PROVIDERS))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (accounts !== null && accounts.length === 0) return null
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <p className="text-base font-semibold text-foreground">
+          Connected accounts
+        </p>
+        <p className="text-[12px] text-muted-foreground">
+          Providers linked to your account.
+        </p>
+      </div>
+      <div className="space-y-2">
+        {(accounts ?? []).map((account) => {
+          const provider = SOCIAL_PROVIDERS[account.providerId]
+          const Icon = provider.icon
+          return (
+            <div
+              key={account.providerId}
+              className="flex items-center gap-3 rounded-md border border-border/60 bg-secondary/30 px-3.5 py-3"
+            >
+              <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-background ring-1 ring-border/60">
+                <Icon className="size-5" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-[13px] font-medium text-foreground">
+                  {provider.label}
+                </p>
+                <p className="truncate text-[12px] text-muted-foreground">
+                  Connected
+                </p>
+              </div>
+              <span className="inline-flex shrink-0 items-center gap-1 text-[12px] text-muted-foreground">
+                <RiCheckLine className="size-4 text-emerald-500" />
+                Linked
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+type ManagedSession = {
+  id: string
+  device: string
+  location: string
+  lastActive: string
+  current: boolean
+}
+
+function relativeTime(value: string) {
+  const seconds = Math.round((new Date(value).getTime() - Date.now()) / 1000)
+  const ranges: Array<[number, Intl.RelativeTimeFormatUnit]> = [
+    [60, "second"],
+    [60, "minute"],
+    [24, "hour"],
+    [7, "day"],
+    [4.34524, "week"],
+    [12, "month"],
+    [Number.POSITIVE_INFINITY, "year"],
+  ]
+  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" })
+  let duration = seconds
+  for (const [amount, unit] of ranges) {
+    if (Math.abs(duration) < amount) return formatter.format(duration, unit)
+    duration = Math.round(duration / amount)
+  }
+  return formatter.format(duration, "year")
+}
+
+function AccountSection() {
+  const { data: session, isPending } = useSession()
+  const user = session?.user
+  const [sessions, setSessions] = React.useState<ManagedSession[] | null>(null)
+  const [isRevokingAll, setIsRevokingAll] = React.useState(false)
+  const [revokingId, setRevokingId] = React.useState<string | null>(null)
+  const [deleteOpen, setDeleteOpen] = React.useState(false)
+  const [deleteConfirmation, setDeleteConfirmation] = React.useState("")
+  const [isDeleting, setIsDeleting] = React.useState(false)
+  const [copiedUserId, setCopiedUserId] = React.useState(false)
+  const copyResetRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  React.useEffect(
+    () => () => {
+      if (copyResetRef.current) clearTimeout(copyResetRef.current)
+    },
+    []
+  )
+
+  const loadSessions = React.useCallback(async () => {
+    try {
+      const response = await fetch("/api/account", { credentials: "include" })
+      if (!response.ok) throw new Error("Could not load sessions")
+      const body: { sessions: ManagedSession[] } = await response.json()
+      setSessions(body.sessions)
+    } catch {
+      toast.error("Couldn't load active sessions")
+      setSessions([])
+    }
+  }, [])
+
+  React.useEffect(() => {
+    if (user) void loadSessions()
+  }, [loadSessions, user])
+
+  const postSessionAction = React.useCallback(
+    async (body: { action: "revoke" | "revoke-all"; sessionId?: string }) => {
+      const response = await fetch("/api/account", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) throw new Error("Could not update session")
+      const result: { current: boolean } = await response.json()
+      return result
+    },
+    []
+  )
+
+  const handleLogOutAll = React.useCallback(async () => {
+    setIsRevokingAll(true)
+    try {
+      await postSessionAction({ action: "revoke-all" })
+      await authClient.signOut()
+      toast.success("Logged out of all devices")
+    } catch {
+      toast.error("Couldn't log out of all devices")
+    } finally {
+      setIsRevokingAll(false)
+    }
+  }, [postSessionAction])
+
+  const handleLogOutSession = React.useCallback(
+    async (item: ManagedSession) => {
+      setRevokingId(item.id)
+      try {
+        const result = await postSessionAction({
+          action: "revoke",
+          sessionId: item.id,
+        })
+        if (result.current) {
+          await authClient.signOut()
+          toast.success("Logged out of this device")
+          return
+        }
+        setSessions(
+          (current) =>
+            current?.filter((session) => session.id !== item.id) ?? []
+        )
+        toast.success("Device logged out")
+      } catch {
+        toast.error("Couldn't log out that device")
+      } finally {
+        setRevokingId(null)
+      }
+    },
+    [postSessionAction]
+  )
+
+  const copyUserId = React.useCallback(async () => {
+    if (!user?.id) return
+    try {
+      await navigator.clipboard.writeText(user.id)
+      setCopiedUserId(true)
+      if (copyResetRef.current) clearTimeout(copyResetRef.current)
+      copyResetRef.current = setTimeout(() => setCopiedUserId(false), 1500)
+    } catch {
+      toast.error("Couldn't copy user ID")
+    }
+  }, [user?.id])
+
+  const handleDeleteAccount = React.useCallback(async () => {
+    if (deleteConfirmation !== "DELETE") return
+    setIsDeleting(true)
+    try {
+      const response = await fetch("/api/account", {
+        method: "DELETE",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirmation: deleteConfirmation }),
+      })
+      if (!response.ok) throw new Error("Could not delete account")
+      await authClient.signOut()
+      setDeleteOpen(false)
+      toast.success("Account deletion started — you've been signed out")
+    } catch {
+      toast.error("Couldn't delete your account. Please try again.")
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [deleteConfirmation])
+
+  if (!user && !isPending) {
+    return (
+      <div className="space-y-6">
+        <SectionHeader
+          title="Account"
+          description="Manage your sessions and account security."
+        />
+        <div className="rounded-lg border border-border/60 bg-secondary/30 px-4 py-3 text-[13px] text-muted-foreground">
+          Sign in to manage active sessions and your account.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-7">
+      <SectionHeader
+        title="Account"
+        description="Sign out across devices, review sessions, and manage your account."
+      />
+
+      <section className="flex flex-col gap-3 border-b border-border/50 pb-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-base font-medium text-foreground">
+            Log out of all devices
+          </p>
+          <p className="mt-1 text-[12px] text-muted-foreground">
+            End every active Tokokino session, including this one.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="destructive"
+          size="lg"
+          onClick={() => void handleLogOutAll()}
+          disabled={isRevokingAll}
+          className="shrink-0"
+        >
+          {isRevokingAll ? (
+            <RiLoader4Line className="size-4 animate-spin" />
+          ) : (
+            <RiLogoutBoxLine className="size-4" />
+          )}
+          Log out
+        </Button>
+      </section>
+
+      <section className="space-y-3 border-b border-border/50 pb-6">
+        <p className="text-base font-medium text-foreground">User ID</p>
+        <div className="flex min-w-0 items-center gap-2 rounded-md border border-border/60 bg-secondary/30 px-3 py-2.5">
+          <code className="min-w-0 flex-1 truncate font-mono text-[12px] text-foreground">
+            {user?.id ?? "—"}
+          </code>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={copiedUserId ? "User ID copied" : "Copy user ID"}
+            onClick={() => void copyUserId()}
+            className="shrink-0"
+          >
+            {copiedUserId ? (
+              <RiCheckLine className="size-4 animate-in text-emerald-500 duration-200 zoom-in-50" />
+            ) : (
+              <RiFileCopyLine className="size-4" />
+            )}
+          </Button>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <p className="text-base font-semibold text-foreground">
+            Active sessions
+          </p>
+          <p className="text-[12px] text-muted-foreground">
+            Revoke any session you don&apos;t recognise.
+          </p>
+        </div>
+        <div className="overflow-x-auto rounded-md border border-border/50">
+          <div className="min-w-[38rem] divide-y divide-border/50">
+            <div className="grid grid-cols-[minmax(10rem,1.5fr)_minmax(9rem,1fr)_minmax(7rem,.8fr)_7.5rem] gap-4 bg-secondary/30 px-4 py-2.5 text-[11px] font-medium text-muted-foreground">
+              <span>Device</span>
+              <span>Location</span>
+              <span>Last active</span>
+              <span className="text-right">Action</span>
+            </div>
+            {sessions?.map((item) => (
+              <div
+                key={item.id}
+                className="grid grid-cols-[minmax(10rem,1.5fr)_minmax(9rem,1fr)_minmax(7rem,.8fr)_7.5rem] items-center gap-4 px-4 py-3 text-[12px]"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <RiComputerLine className="size-4 shrink-0 text-muted-foreground" />
+                  <span className="truncate text-foreground">
+                    {item.device}
+                  </span>
+                  {item.current ? (
+                    <span className="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium text-emerald-500">
+                      Current
+                    </span>
+                  ) : null}
+                </div>
+                <span className="flex min-w-0 items-center gap-1.5 truncate text-muted-foreground">
+                  <RiMapPinLine className="size-3.5 shrink-0" />
+                  {item.location}
+                </span>
+                <span
+                  className="text-muted-foreground"
+                  title={new Date(item.lastActive).toLocaleString()}
+                >
+                  {relativeTime(item.lastActive)}
+                </span>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="default"
+                  onClick={() => void handleLogOutSession(item)}
+                  disabled={revokingId === item.id}
+                  className="min-w-[7rem] justify-self-end"
+                >
+                  {revokingId === item.id ? (
+                    <>
+                      <RiLoader4Line className="size-3.5 animate-spin" />
+                      Logging out
+                    </>
+                  ) : (
+                    "Log out"
+                  )}
+                </Button>
+              </div>
+            ))}
+            {sessions === null
+              ? Array.from({ length: 3 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="grid animate-pulse grid-cols-[minmax(10rem,1.5fr)_minmax(9rem,1fr)_minmax(7rem,.8fr)_7.5rem] items-center gap-4 px-4 py-3"
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="size-4 shrink-0 rounded bg-foreground/10" />
+                      <span className="h-3.5 w-32 rounded bg-foreground/10" />
+                    </div>
+                    <span className="h-3.5 w-28 rounded bg-foreground/10" />
+                    <span className="h-3.5 w-20 rounded bg-foreground/10" />
+                    <span className="h-7 w-[7rem] justify-self-end rounded-md bg-foreground/10" />
+                  </div>
+                ))
+              : null}
+            {sessions?.length === 0 ? (
+              <div className="px-4 py-5 text-[12px] text-muted-foreground">
+                No active sessions found.
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3 border-t border-border/50 pt-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-base font-medium text-foreground">
+            Delete your account permanently
+          </p>
+          <p className="mt-1 text-[12px] text-muted-foreground">
+            This removes your shares, drafts, presets, preferences, and active
+            sessions.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="destructive"
+          size="lg"
+          onClick={() => setDeleteOpen(true)}
+          className="shrink-0"
+        >
+          <RiDeleteBinLine className="size-4" />
+          Delete account
+        </Button>
+      </section>
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent showCloseButton={false} className="max-w-md p-5">
+          <DialogTitle className="text-base font-semibold">
+            Delete account permanently?
+          </DialogTitle>
+          <DialogDescription className="mt-2">
+            This cannot be undone. Your shares, drafts, custom presets,
+            preferences, connected accounts, and active sessions will be
+            deleted.
+          </DialogDescription>
+          <label className="mt-1 block space-y-3 text-[12px] font-medium text-foreground">
+            <span className="inline-flex items-center gap-1.5">
+              Type
+              <code className="rounded-md border border-red-500/30 bg-red-500/10 px-1.5 py-0.5 font-mono font-bold text-red-500">
+                DELETE
+              </code>
+              to confirm
+            </span>
+            <input
+              value={deleteConfirmation}
+              onChange={(event) => setDeleteConfirmation(event.target.value)}
+              autoComplete="off"
+              className="w-full rounded-md border border-border/60 bg-secondary/30 px-3 py-2.5 text-[13px] font-normal text-foreground outline-none focus:border-red-500/60"
+            />
+          </label>
+          <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setDeleteOpen(false)}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => void handleDeleteAccount()}
+              disabled={deleteConfirmation !== "DELETE" || isDeleting}
+            >
+              {isDeleting ? (
+                <RiLoader4Line className="size-4 animate-spin" />
+              ) : (
+                <RiDeleteBinLine className="size-4" />
+              )}
+              Delete account
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+function Divider() {
+  return <div className="h-px w-full bg-border/50" />
 }
 
 const PREVIEW_SAMPLE = {

--- a/lib/account-deletion.ts
+++ b/lib/account-deletion.ts
@@ -88,6 +88,12 @@ export async function listStalePendingDeletions(options?: {
 }): Promise<StalePendingDeletion[]> {
   const olderThanMinutes = options?.olderThanMinutes ?? 15
   const limit = options?.limit ?? 25
+  if (!Number.isFinite(olderThanMinutes) || olderThanMinutes < 0) {
+    throw new Error(`Invalid olderThanMinutes: ${olderThanMinutes}`)
+  }
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(`Invalid limit: ${limit}`)
+  }
   const cutoff = new Date(Date.now() - olderThanMinutes * 60_000).toISOString()
   const rows = await getD1Database()
     .prepare(

--- a/lib/account-deletion.ts
+++ b/lib/account-deletion.ts
@@ -1,0 +1,67 @@
+import "server-only"
+
+import { getCloudflareContext } from "@opennextjs/cloudflare"
+
+import { getD1Database } from "@/lib/d1"
+
+/** Cloudflare Queue binding that carries heavy account-deletion jobs. */
+export const ACCOUNT_DELETION_QUEUE = "ACCOUNT_DELETION_QUEUE"
+
+export type AccountDeletionMessage = { userId: string; requestedAt: string }
+export type AccountDeletionStatus = "pending" | "processing"
+
+type DeletionQueue = { send: (body: AccountDeletionMessage) => Promise<void> }
+
+/**
+ * The queue binding only exists in the Workers runtime (preview/deploy and
+ * `wrangler dev`). Under plain `next dev` it is absent, so callers fall back to
+ * running the deletion inline.
+ */
+export function getAccountDeletionQueue(): DeletionQueue | null {
+  try {
+    const binding = (
+      getCloudflareContext().env as unknown as Record<string, unknown>
+    )[ACCOUNT_DELETION_QUEUE]
+    if (binding && typeof (binding as DeletionQueue).send === "function") {
+      return binding as DeletionQueue
+    }
+  } catch {
+    // No Cloudflare context available (local `next dev` / `next build`).
+  }
+  return null
+}
+
+/**
+ * Records or advances the deletion flag. `requested_at` is only written on the
+ * first insert so the original request time survives a status transition.
+ */
+export async function markAccountDeletion(
+  userId: string,
+  status: AccountDeletionStatus
+) {
+  const now = new Date().toISOString()
+  await getD1Database()
+    .prepare(
+      "INSERT INTO account_deletions (user_id, status, requested_at, updated_at) VALUES (?, ?, ?, ?) ON CONFLICT(user_id) DO UPDATE SET status = excluded.status, updated_at = excluded.updated_at"
+    )
+    .bind(userId, status, now, now)
+    .run()
+}
+
+/** True while an account is flagged for deletion — used to block re-login. */
+export async function isAccountDeletionPending(
+  userId: string
+): Promise<boolean> {
+  const row = await getD1Database()
+    .prepare("SELECT 1 AS present FROM account_deletions WHERE user_id = ?")
+    .bind(userId)
+    .first<{ present: number }>()
+  return Boolean(row)
+}
+
+export async function clearAccountDeletion(userId: string) {
+  await getD1Database()
+    .prepare("DELETE FROM account_deletions WHERE user_id = ?")
+    .bind(userId)
+    .run()
+}

--- a/lib/account-deletion.ts
+++ b/lib/account-deletion.ts
@@ -8,7 +8,11 @@ import { getD1Database } from "@/lib/d1"
 export const ACCOUNT_DELETION_QUEUE = "ACCOUNT_DELETION_QUEUE"
 
 export type AccountDeletionMessage = { userId: string; requestedAt: string }
-export type AccountDeletionStatus = "pending" | "processing"
+// "failed" is terminal: the deletion could not complete after repeated retries.
+// It stays in the table for manual recovery but no longer blocks login or gets
+// re-reconciled.
+export type AccountDeletionStatus = "pending" | "processing" | "failed"
+export type StalePendingDeletion = { userId: string; requestedAt: string }
 
 type DeletionQueue = { send: (body: AccountDeletionMessage) => Promise<void> }
 
@@ -48,12 +52,18 @@ export async function markAccountDeletion(
     .run()
 }
 
-/** True while an account is flagged for deletion — used to block re-login. */
+/**
+ * True while an account is actively flagged for deletion — used to block
+ * re-login. A terminal "failed" flag does not count, so a deletion that can
+ * never complete cannot lock the account out forever.
+ */
 export async function isAccountDeletionPending(
   userId: string
 ): Promise<boolean> {
   const row = await getD1Database()
-    .prepare("SELECT 1 AS present FROM account_deletions WHERE user_id = ?")
+    .prepare(
+      "SELECT 1 AS present FROM account_deletions WHERE user_id = ? AND status IN ('pending', 'processing')"
+    )
     .bind(userId)
     .first<{ present: number }>()
   return Boolean(row)
@@ -75,15 +85,18 @@ export async function clearAccountDeletion(userId: string) {
 export async function listStalePendingDeletions(options?: {
   olderThanMinutes?: number
   limit?: number
-}): Promise<string[]> {
+}): Promise<StalePendingDeletion[]> {
   const olderThanMinutes = options?.olderThanMinutes ?? 15
   const limit = options?.limit ?? 25
   const cutoff = new Date(Date.now() - olderThanMinutes * 60_000).toISOString()
   const rows = await getD1Database()
     .prepare(
-      "SELECT user_id FROM account_deletions WHERE updated_at <= ? ORDER BY updated_at ASC LIMIT ?"
+      "SELECT user_id, requested_at FROM account_deletions WHERE status IN ('pending', 'processing') AND updated_at <= ? ORDER BY updated_at ASC LIMIT ?"
     )
     .bind(cutoff, limit)
-    .all<{ user_id: string }>()
-  return (rows.results ?? []).map((row) => row.user_id)
+    .all<{ user_id: string; requested_at: string }>()
+  return (rows.results ?? []).map((row) => ({
+    userId: row.user_id,
+    requestedAt: row.requested_at,
+  }))
 }

--- a/lib/account-deletion.ts
+++ b/lib/account-deletion.ts
@@ -65,3 +65,25 @@ export async function clearAccountDeletion(userId: string) {
     .bind(userId)
     .run()
 }
+
+/**
+ * User ids whose deletion flag has not advanced for a while — a job that was
+ * dropped, dead-lettered, or hit a transient failure. `updated_at` bumps on
+ * every status transition, so an actively-processing row is never returned and
+ * a repeatedly-failing one backs off ~`olderThanMinutes` between retries.
+ */
+export async function listStalePendingDeletions(options?: {
+  olderThanMinutes?: number
+  limit?: number
+}): Promise<string[]> {
+  const olderThanMinutes = options?.olderThanMinutes ?? 15
+  const limit = options?.limit ?? 25
+  const cutoff = new Date(Date.now() - olderThanMinutes * 60_000).toISOString()
+  const rows = await getD1Database()
+    .prepare(
+      "SELECT user_id FROM account_deletions WHERE updated_at <= ? ORDER BY updated_at ASC LIMIT ?"
+    )
+    .bind(cutoff, limit)
+    .all<{ user_id: string }>()
+  return (rows.results ?? []).map((row) => row.user_id)
+}

--- a/lib/account-management.ts
+++ b/lib/account-management.ts
@@ -172,28 +172,54 @@ export async function processAccountDeletion(userId: string) {
 }
 
 /**
+ * After this long a still-failing deletion is treated as terminal: a permanent
+ * fault (e.g. missing R2 config) would otherwise retry forever under a flag
+ * that keeps blocking login. Marking it "failed" stops the retries and unblocks
+ * sign-in, while leaving the row for manual recovery.
+ */
+const DELETION_GIVE_UP_AFTER_MS = 24 * 60 * 60 * 1000
+
+/**
  * Retries deletion for accounts whose flag has gone stale (a job that was
  * dropped or dead-lettered). Runs on a cron so a stuck `account_deletions` row
  * cannot lock a user out permanently — a transient failure clears on a later
- * pass. Idempotent: an already-deleted account's rows simply no-op.
+ * pass. Idempotent: an already-deleted account's rows simply no-op. A failure
+ * that persists past `DELETION_GIVE_UP_AFTER_MS` becomes terminal.
  */
 export async function reconcileStaleAccountDeletions(): Promise<{
   processed: number
   failed: number
+  abandoned: number
 }> {
-  const userIds = await listStalePendingDeletions()
+  const stale = await listStalePendingDeletions()
   let processed = 0
   let failed = 0
-  for (const userId of userIds) {
+  let abandoned = 0
+  for (const { userId, requestedAt } of stale) {
     try {
       await processAccountDeletion(userId)
       processed++
     } catch (error) {
-      failed++
-      console.error("Reconcile: account deletion still failing", userId, error)
+      const stuckMs = Date.now() - new Date(requestedAt).getTime()
+      if (stuckMs >= DELETION_GIVE_UP_AFTER_MS) {
+        await markAccountDeletion(userId, "failed")
+        abandoned++
+        console.error(
+          "Reconcile: giving up on account deletion (terminal)",
+          userId,
+          error
+        )
+      } else {
+        failed++
+        console.error(
+          "Reconcile: account deletion still failing",
+          userId,
+          error
+        )
+      }
     }
   }
-  return { processed, failed }
+  return { processed, failed, abandoned }
 }
 
 /** Retries durable R2 cleanup from previous account-deletion requests. */

--- a/lib/account-management.ts
+++ b/lib/account-management.ts
@@ -1,0 +1,188 @@
+import "server-only"
+
+import { DeleteObjectCommand } from "@aws-sdk/client-s3"
+import { eq } from "drizzle-orm"
+
+import {
+  clearAccountDeletion,
+  getAccountDeletionQueue,
+  markAccountDeletion,
+} from "@/lib/account-deletion"
+import { draftMedia, drafts, shares, shareUploads } from "@/lib/db/schema"
+import { getD1Database, getDb } from "@/lib/d1"
+import { requireR2Config } from "@/lib/env"
+import { getR2Client } from "@/lib/r2-client"
+import { abortShareMultipartUpload } from "@/lib/share-storage"
+
+type AccountCleanup = {
+  objectKeys: string[]
+  uploads: Array<{ objectKey: string; r2UploadId: string }>
+}
+
+function uniqueKeys(keys: Array<string | null>) {
+  return [...new Set(keys.filter((key): key is string => Boolean(key)))]
+}
+
+async function removeR2Objects(cleanup: AccountCleanup) {
+  const { bucket } = requireR2Config()
+  const aborts = await Promise.allSettled(
+    cleanup.uploads.map((upload) => abortShareMultipartUpload(upload))
+  )
+  const deletions = await Promise.allSettled(
+    cleanup.objectKeys.map((key) =>
+      getR2Client().send(new DeleteObjectCommand({ Bucket: bucket, Key: key }))
+    )
+  )
+
+  // An already-completed upload cannot be aborted, but its object is still
+  // deleted above. Keeping the outbox for only object deletion failures avoids
+  // a permanently stale retry record in that normal race.
+  return (
+    deletions.every((result) => result.status === "fulfilled") &&
+    aborts.every(
+      (result) =>
+        result.status === "fulfilled" || result.reason?.name === "NoSuchUpload"
+    )
+  )
+}
+
+async function clearCleanup(id: string) {
+  await getD1Database()
+    .prepare("DELETE FROM account_deletion_cleanups WHERE id = ?")
+    .bind(id)
+    .run()
+}
+
+/**
+ * Removes a user's database records in one D1 batch and stores an outbox row
+ * before attempting R2 cleanup. D1 and R2 do not support a shared transaction;
+ * the outbox makes failed object deletion durable and idempotent.
+ */
+export async function deleteManagedAccount(userId: string) {
+  const db = getDb()
+  const [userDrafts, media, userShares, uploads] = await Promise.all([
+    db
+      .select({ stateKey: drafts.stateKey, thumbnailKey: drafts.thumbnailKey })
+      .from(drafts)
+      .where(eq(drafts.userId, userId)),
+    db
+      .select({ objectKey: draftMedia.objectKey })
+      .from(draftMedia)
+      .where(eq(draftMedia.userId, userId)),
+    db
+      .select({ objectKey: shares.objectKey, posterKey: shares.posterKey })
+      .from(shares)
+      .where(eq(shares.userId, userId)),
+    db
+      .select({
+        objectKey: shareUploads.objectKey,
+        r2UploadId: shareUploads.r2UploadId,
+      })
+      .from(shareUploads)
+      .where(eq(shareUploads.userId, userId)),
+  ])
+
+  const cleanup: AccountCleanup = {
+    objectKeys: uniqueKeys([
+      ...userDrafts.flatMap((draft) => [draft.stateKey, draft.thumbnailKey]),
+      ...media.map((item) => item.objectKey),
+      ...userShares.flatMap((share) => [share.objectKey, share.posterKey]),
+      ...uploads.map((upload) => upload.objectKey),
+    ]),
+    uploads,
+  }
+  const cleanupId = crypto.randomUUID()
+  const d1 = getD1Database()
+  const now = new Date().toISOString()
+
+  await d1.batch([
+    d1
+      .prepare(
+        "INSERT INTO account_deletion_cleanups (id, object_keys, uploads, created_at) VALUES (?, ?, ?, ?)"
+      )
+      .bind(
+        cleanupId,
+        JSON.stringify(cleanup.objectKeys),
+        JSON.stringify(cleanup.uploads),
+        now
+      ),
+    d1
+      .prepare(
+        "DELETE FROM session_locations WHERE session_id IN (SELECT id FROM session WHERE userId = ?)"
+      )
+      .bind(userId),
+    d1.prepare("DELETE FROM user_preferences WHERE user_id = ?").bind(userId),
+    d1.prepare("DELETE FROM custom_presets WHERE user_id = ?").bind(userId),
+    d1.prepare("DELETE FROM draft_media WHERE user_id = ?").bind(userId),
+    d1.prepare("DELETE FROM drafts WHERE user_id = ?").bind(userId),
+    d1
+      .prepare(
+        "DELETE FROM share_upload_parts WHERE upload_id IN (SELECT id FROM share_uploads WHERE user_id = ?)"
+      )
+      .bind(userId),
+    d1.prepare("DELETE FROM share_uploads WHERE user_id = ?").bind(userId),
+    d1
+      .prepare(
+        "DELETE FROM share_views WHERE share_id IN (SELECT id FROM shares WHERE user_id = ?)"
+      )
+      .bind(userId),
+    d1.prepare("DELETE FROM shares WHERE user_id = ?").bind(userId),
+    d1.prepare("DELETE FROM user WHERE id = ?").bind(userId),
+  ])
+
+  if (await removeR2Objects(cleanup)) await clearCleanup(cleanupId)
+}
+
+/**
+ * Flags the account for deletion and hands the heavy work to the Cloudflare
+ * Queue. When the queue binding is unavailable (local `next dev`), the deletion
+ * runs inline so the flow still completes end to end.
+ */
+export async function requestAccountDeletion(
+  userId: string
+): Promise<{ queued: boolean }> {
+  await markAccountDeletion(userId, "pending")
+
+  const queue = getAccountDeletionQueue()
+  if (!queue) {
+    await processAccountDeletion(userId)
+    return { queued: false }
+  }
+
+  await queue.send({ userId, requestedAt: new Date().toISOString() })
+  return { queued: true }
+}
+
+/**
+ * Runs the actual deletion. Invoked by the queue consumer through the internal
+ * route so it executes inside the OpenNext request context (where the D1 and R2
+ * bindings resolve).
+ */
+export async function processAccountDeletion(userId: string) {
+  await markAccountDeletion(userId, "processing")
+  await deleteManagedAccount(userId)
+  await clearAccountDeletion(userId)
+}
+
+/** Retries durable R2 cleanup from previous account-deletion requests. */
+export async function retryPendingAccountCleanups() {
+  const rows = await getD1Database()
+    .prepare(
+      "SELECT id, object_keys, uploads FROM account_deletion_cleanups ORDER BY created_at ASC LIMIT 10"
+    )
+    .all<{ id: string; object_keys: string; uploads: string }>()
+
+  await Promise.all(
+    (rows.results ?? []).map(async (row) => {
+      try {
+        const cleanup: AccountCleanup = {
+          objectKeys: JSON.parse(row.object_keys) as string[],
+          uploads: JSON.parse(row.uploads) as AccountCleanup["uploads"],
+        }
+        if (await removeR2Objects(cleanup)) await clearCleanup(row.id)
+      } catch (error) {
+        console.error("Could not retry account storage cleanup", error)
+      }
+    })
+  )
+}

--- a/lib/account-management.ts
+++ b/lib/account-management.ts
@@ -6,6 +6,7 @@ import { eq } from "drizzle-orm"
 import {
   clearAccountDeletion,
   getAccountDeletionQueue,
+  listStalePendingDeletions,
   markAccountDeletion,
 } from "@/lib/account-deletion"
 import { draftMedia, drafts, shares, shareUploads } from "@/lib/db/schema"
@@ -168,6 +169,31 @@ export async function processAccountDeletion(userId: string) {
   await markAccountDeletion(userId, "processing")
   await deleteManagedAccount(userId)
   await clearAccountDeletion(userId)
+}
+
+/**
+ * Retries deletion for accounts whose flag has gone stale (a job that was
+ * dropped or dead-lettered). Runs on a cron so a stuck `account_deletions` row
+ * cannot lock a user out permanently — a transient failure clears on a later
+ * pass. Idempotent: an already-deleted account's rows simply no-op.
+ */
+export async function reconcileStaleAccountDeletions(): Promise<{
+  processed: number
+  failed: number
+}> {
+  const userIds = await listStalePendingDeletions()
+  let processed = 0
+  let failed = 0
+  for (const userId of userIds) {
+    try {
+      await processAccountDeletion(userId)
+      processed++
+    } catch (error) {
+      failed++
+      console.error("Reconcile: account deletion still failing", userId, error)
+    }
+  }
+  return { processed, failed }
 }
 
 /** Retries durable R2 cleanup from previous account-deletion requests. */

--- a/lib/account-management.ts
+++ b/lib/account-management.ts
@@ -144,13 +144,19 @@ export async function requestAccountDeletion(
   await markAccountDeletion(userId, "pending")
 
   const queue = getAccountDeletionQueue()
-  if (!queue) {
-    await processAccountDeletion(userId)
-    return { queued: false }
+  if (queue) {
+    try {
+      await queue.send({ userId, requestedAt: new Date().toISOString() })
+      return { queued: true }
+    } catch (error) {
+      // A failed send must not leave the account flagged with no job to run it
+      // (the flag blocks re-login). Fall back to deleting inline.
+      console.error("Account deletion enqueue failed; deleting inline", error)
+    }
   }
 
-  await queue.send({ userId, requestedAt: new Date().toISOString() })
-  return { queued: true }
+  await processAccountDeletion(userId)
+  return { queued: false }
 }
 
 /**

--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -5,6 +5,9 @@ import { NextResponse } from "next/server"
 import { getAuth } from "@/lib/auth"
 
 export type AuthorizedSession = {
+  session: {
+    id: string
+  }
   user: {
     id: string
     name?: string | null

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,8 @@
 import { betterAuth } from "better-auth"
+import { APIError } from "better-auth/api"
 import { nextCookies } from "better-auth/next-js"
 
+import { isAccountDeletionPending } from "@/lib/account-deletion"
 import { getD1Database } from "@/lib/d1"
 import { env, requireAuthConfig } from "@/lib/env"
 
@@ -32,6 +34,42 @@ function createAuth() {
         "/sign-up/email": { window: 60, max: 5 },
         "/forget-password": { window: 60, max: 3 },
         "/reset-password": { window: 60, max: 5 },
+      },
+    },
+    databaseHooks: {
+      session: {
+        create: {
+          // Block sign-in for accounts queued for deletion. The user row still
+          // exists until the queue consumer finishes, so this closes the window
+          // where someone could re-authenticate mid-deletion.
+          before: async (session, ctx) => {
+            if (!(await isAccountDeletionPending(session.userId))) {
+              return { data: session }
+            }
+
+            const message =
+              "This account is being deleted and can no longer be accessed."
+
+            // OAuth logins finish on a `/callback` (or `/oauth2/callback`)
+            // route mid-redirect — a plain APIError does not abort that flow, so
+            // we redirect instead (mirrors better-auth's own banned-user gate).
+            if (
+              ctx &&
+              (ctx.path.startsWith("/callback") ||
+                ctx.path.startsWith("/oauth2/callback"))
+            ) {
+              // An absolute "/login" path resolves against the origin whether or
+              // not `baseURL` carries the `/api/auth` suffix.
+              const target = ctx.context.options.onAPIError?.errorURL
+                ? new URL(ctx.context.options.onAPIError.errorURL)
+                : new URL("/login", ctx.context.baseURL)
+              target.searchParams.set("error", "account_deleted")
+              throw ctx.redirect(target.toString())
+            }
+
+            throw new APIError("FORBIDDEN", { message })
+          },
+        },
       },
     },
     plugins: [nextCookies()],

--- a/migrations/0012_account_session_management.sql
+++ b/migrations/0012_account_session_management.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "session_locations" (
+  "session_id" TEXT PRIMARY KEY NOT NULL,
+  "location" TEXT NOT NULL,
+  "updated_at" TEXT NOT NULL,
+  FOREIGN KEY ("session_id") REFERENCES "session"("id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "account_deletion_cleanups" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "object_keys" TEXT NOT NULL,
+  "uploads" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL
+);

--- a/migrations/0013_account_deletions.sql
+++ b/migrations/0013_account_deletions.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS "account_deletions" (
+  "user_id" TEXT PRIMARY KEY NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'pending',
+  "requested_at" TEXT NOT NULL,
+  "updated_at" TEXT NOT NULL
+);

--- a/tests/app/api/account-route.test.ts
+++ b/tests/app/api/account-route.test.ts
@@ -147,9 +147,24 @@ describe("/api/account", () => {
     const response = await DELETE(request("DELETE", { confirmation: "DELETE" }))
 
     expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      status: "pending",
+    })
+    expect(mocks.requestAccountDeletion).toHaveBeenCalledWith("user_1")
+  })
+
+  it("signs the user out before handing the deletion to the queue", async () => {
+    const { DELETE } = await loadRoute()
+
+    await DELETE(request("DELETE", { confirmation: "DELETE" }))
+
+    const revokeOrder = mocks.revokeSessions.mock.invocationCallOrder[0]
+    const requestOrder =
+      mocks.requestAccountDeletion.mock.invocationCallOrder[0]
     expect(mocks.revokeSessions).toHaveBeenCalledWith({
       headers: expect.any(Headers),
     })
-    expect(mocks.requestAccountDeletion).toHaveBeenCalledWith("user_1")
+    expect(revokeOrder).toBeLessThan(requestOrder)
   })
 })

--- a/tests/app/api/account-route.test.ts
+++ b/tests/app/api/account-route.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const mocks = vi.hoisted(() => ({
   requestAccountDeletion: vi.fn(),
   first: vi.fn(),
+  all: vi.fn(),
   getSession: vi.fn(),
   listSessions: vi.fn(),
   prepare: vi.fn(),
@@ -14,7 +15,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 const statement = {
-  bind: vi.fn(() => ({ first: mocks.first, run: mocks.run })),
+  bind: vi.fn(() => ({ first: mocks.first, run: mocks.run, all: mocks.all })),
 }
 
 vi.mock("@/lib/auth", () => ({
@@ -66,7 +67,9 @@ describe("/api/account", () => {
     vi.clearAllMocks()
     mocks.getSession.mockResolvedValue(SESSION)
     mocks.listSessions.mockResolvedValue([OTHER_SESSION])
-    mocks.first.mockResolvedValue({ location: "Dispur, Assam" })
+    mocks.all.mockResolvedValue({
+      results: [{ session_id: "session_other", location: "Dispur, Assam" }],
+    })
     mocks.run.mockResolvedValue(undefined)
     mocks.prepare.mockReturnValue(statement)
     mocks.revokeSession.mockResolvedValue({ status: true })

--- a/tests/app/api/account-route.test.ts
+++ b/tests/app/api/account-route.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  requestAccountDeletion: vi.fn(),
+  first: vi.fn(),
+  getSession: vi.fn(),
+  listSessions: vi.fn(),
+  prepare: vi.fn(),
+  revokeSession: vi.fn(),
+  revokeSessions: vi.fn(),
+  retryPendingAccountCleanups: vi.fn(),
+  run: vi.fn(),
+}))
+
+const statement = {
+  bind: vi.fn(() => ({ first: mocks.first, run: mocks.run })),
+}
+
+vi.mock("@/lib/auth", () => ({
+  getAuth: () => ({
+    api: {
+      getSession: mocks.getSession,
+      listSessions: mocks.listSessions,
+      revokeSession: mocks.revokeSession,
+      revokeSessions: mocks.revokeSessions,
+    },
+  }),
+}))
+
+vi.mock("@/lib/account-management", () => ({
+  requestAccountDeletion: mocks.requestAccountDeletion,
+  retryPendingAccountCleanups: mocks.retryPendingAccountCleanups,
+}))
+
+vi.mock("@/lib/d1", () => ({
+  getD1Database: () => ({ prepare: mocks.prepare }),
+}))
+
+const SESSION = {
+  user: { id: "user_1" },
+  session: { id: "session_current" },
+}
+const OTHER_SESSION = {
+  id: "session_other",
+  token: "secret-other-token",
+  userAgent:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/131.0.0.0 Safari/537.36",
+  updatedAt: new Date("2026-07-22T10:00:00.000Z"),
+}
+
+async function loadRoute() {
+  return import("@/app/api/account/route")
+}
+
+function request(method: "GET" | "POST" | "DELETE", body?: unknown) {
+  return new Request("http://localhost:3000/api/account", {
+    method,
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+
+describe("/api/account", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getSession.mockResolvedValue(SESSION)
+    mocks.listSessions.mockResolvedValue([OTHER_SESSION])
+    mocks.first.mockResolvedValue({ location: "Dispur, Assam" })
+    mocks.run.mockResolvedValue(undefined)
+    mocks.prepare.mockReturnValue(statement)
+    mocks.revokeSession.mockResolvedValue({ status: true })
+    mocks.revokeSessions.mockResolvedValue({ status: true })
+    mocks.requestAccountDeletion.mockResolvedValue({ queued: true })
+    mocks.retryPendingAccountCleanups.mockResolvedValue(undefined)
+  })
+
+  it("requires a session before listing active devices", async () => {
+    mocks.getSession.mockResolvedValue(null)
+    const { GET } = await loadRoute()
+
+    const response = await GET(request("GET"))
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error: "Sign in required",
+    })
+    expect(mocks.listSessions).not.toHaveBeenCalled()
+  })
+
+  it("lists safe session details without returning session tokens", async () => {
+    const { GET } = await loadRoute()
+
+    const response = await GET(request("GET"))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      sessions: [
+        {
+          id: "session_other",
+          device: "Chrome on macOS",
+          location: "Dispur, Assam",
+          lastActive: "2026-07-22T10:00:00.000Z",
+          current: false,
+        },
+      ],
+    })
+  })
+
+  it("revokes only a session owned by the current user", async () => {
+    const { POST } = await loadRoute()
+
+    const response = await POST(
+      request("POST", { action: "revoke", sessionId: "session_other" })
+    )
+
+    expect(response.status).toBe(200)
+    expect(mocks.revokeSession).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+      body: { token: "secret-other-token" },
+    })
+  })
+
+  it("revokes all sessions for the current account", async () => {
+    const { POST } = await loadRoute()
+
+    const response = await POST(request("POST", { action: "revoke-all" }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.revokeSessions).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+    })
+  })
+
+  it("requires the exact deletion confirmation", async () => {
+    const { DELETE } = await loadRoute()
+
+    const response = await DELETE(request("DELETE", { confirmation: "delete" }))
+
+    expect(response.status).toBe(400)
+    expect(mocks.requestAccountDeletion).not.toHaveBeenCalled()
+  })
+
+  it("queues deletion for the authenticated account after confirmation", async () => {
+    const { DELETE } = await loadRoute()
+
+    const response = await DELETE(request("DELETE", { confirmation: "DELETE" }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.revokeSessions).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+    })
+    expect(mocks.requestAccountDeletion).toHaveBeenCalledWith("user_1")
+  })
+})

--- a/tests/app/api/internal-account-deletion-reconcile-route.test.ts
+++ b/tests/app/api/internal-account-deletion-reconcile-route.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  reconcileStaleAccountDeletions: vi.fn(),
+}))
+
+vi.mock("@/lib/account-management", () => ({
+  reconcileStaleAccountDeletions: mocks.reconcileStaleAccountDeletions,
+}))
+
+vi.mock("@/lib/env", () => ({ env: { BETTER_AUTH_SECRET: "test-secret" } }))
+
+import { POST } from "@/app/api/internal/account-deletion/reconcile/route"
+
+function request(headers: Record<string, string>) {
+  return new Request(
+    "http://localhost:3000/api/internal/account-deletion/reconcile",
+    { method: "POST", headers }
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.reconcileStaleAccountDeletions.mockResolvedValue({
+    processed: 2,
+    failed: 0,
+  })
+})
+
+describe("POST /api/internal/account-deletion/reconcile", () => {
+  it("rejects a request without the shared secret", async () => {
+    const response = await POST(request({}))
+
+    expect(response.status).toBe(401)
+    expect(mocks.reconcileStaleAccountDeletions).not.toHaveBeenCalled()
+  })
+
+  it("rejects a request with the wrong secret", async () => {
+    const response = await POST(request({ authorization: "Bearer nope" }))
+
+    expect(response.status).toBe(401)
+    expect(mocks.reconcileStaleAccountDeletions).not.toHaveBeenCalled()
+  })
+
+  it("runs the reconciler and returns its counts for an authorized request", async () => {
+    const response = await POST(
+      request({ authorization: "Bearer test-secret" })
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      processed: 2,
+      failed: 0,
+    })
+    expect(mocks.reconcileStaleAccountDeletions).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/app/api/internal-account-deletion-reconcile-route.test.ts
+++ b/tests/app/api/internal-account-deletion-reconcile-route.test.ts
@@ -3,10 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   reconcileStaleAccountDeletions: vi.fn(),
+  retryPendingAccountCleanups: vi.fn(),
 }))
 
 vi.mock("@/lib/account-management", () => ({
   reconcileStaleAccountDeletions: mocks.reconcileStaleAccountDeletions,
+  retryPendingAccountCleanups: mocks.retryPendingAccountCleanups,
 }))
 
 vi.mock("@/lib/env", () => ({ env: { BETTER_AUTH_SECRET: "test-secret" } }))
@@ -27,6 +29,7 @@ beforeEach(() => {
     failed: 0,
     abandoned: 0,
   })
+  mocks.retryPendingAccountCleanups.mockResolvedValue(undefined)
 })
 
 describe("POST /api/internal/account-deletion/reconcile", () => {
@@ -57,5 +60,8 @@ describe("POST /api/internal/account-deletion/reconcile", () => {
       abandoned: 0,
     })
     expect(mocks.reconcileStaleAccountDeletions).toHaveBeenCalledTimes(1)
+    // The cron also drains the R2 cleanup outbox so a deleted user's orphaned
+    // objects don't depend on other account traffic to be removed.
+    expect(mocks.retryPendingAccountCleanups).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/app/api/internal-account-deletion-reconcile-route.test.ts
+++ b/tests/app/api/internal-account-deletion-reconcile-route.test.ts
@@ -25,6 +25,7 @@ beforeEach(() => {
   mocks.reconcileStaleAccountDeletions.mockResolvedValue({
     processed: 2,
     failed: 0,
+    abandoned: 0,
   })
 })
 
@@ -53,6 +54,7 @@ describe("POST /api/internal/account-deletion/reconcile", () => {
       ok: true,
       processed: 2,
       failed: 0,
+      abandoned: 0,
     })
     expect(mocks.reconcileStaleAccountDeletions).toHaveBeenCalledTimes(1)
   })

--- a/tests/app/api/internal-account-deletion-route.test.ts
+++ b/tests/app/api/internal-account-deletion-route.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  processAccountDeletion: vi.fn(),
+}))
+
+vi.mock("@/lib/account-management", () => ({
+  processAccountDeletion: mocks.processAccountDeletion,
+}))
+
+vi.mock("@/lib/env", () => ({ env: { BETTER_AUTH_SECRET: "test-secret" } }))
+
+import { POST } from "@/app/api/internal/account-deletion/route"
+
+function request(headers: Record<string, string>, body?: unknown) {
+  return new Request("http://localhost:3000/api/internal/account-deletion", {
+    method: "POST",
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+}
+
+const AUTHED = {
+  authorization: "Bearer test-secret",
+  "content-type": "application/json",
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.processAccountDeletion.mockResolvedValue(undefined)
+})
+
+describe("POST /api/internal/account-deletion", () => {
+  it("rejects a request with no authorization header", async () => {
+    const response = await POST(request({}, { userId: "user_1" }))
+
+    expect(response.status).toBe(401)
+    expect(mocks.processAccountDeletion).not.toHaveBeenCalled()
+  })
+
+  it("rejects a request with the wrong secret", async () => {
+    const response = await POST(
+      request(
+        { authorization: "Bearer nope", "content-type": "application/json" },
+        { userId: "user_1" }
+      )
+    )
+
+    expect(response.status).toBe(401)
+    expect(mocks.processAccountDeletion).not.toHaveBeenCalled()
+  })
+
+  it("returns 400 when the userId is missing", async () => {
+    const response = await POST(request(AUTHED, {}))
+
+    expect(response.status).toBe(400)
+    expect(mocks.processAccountDeletion).not.toHaveBeenCalled()
+  })
+
+  it("processes the deletion for an authorized request", async () => {
+    const response = await POST(request(AUTHED, { userId: "user_1" }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(mocks.processAccountDeletion).toHaveBeenCalledWith("user_1")
+  })
+})

--- a/tests/components/editor/settings-dialog.test.tsx
+++ b/tests/components/editor/settings-dialog.test.tsx
@@ -11,7 +11,10 @@ vi.mock("next-themes", () => ({
 }))
 
 vi.mock("@/lib/auth-client", () => ({
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false, refetch: vi.fn() }),
+  authClient: {
+    listAccounts: vi.fn(() => Promise.resolve({ data: [] })),
+  },
 }))
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
@@ -23,32 +26,49 @@ afterEach(() => vi.clearAllMocks())
 describe("SettingsDialog", () => {
   it("renders the section nav when open", () => {
     render(<SettingsDialog open onOpenChange={() => {}} />)
-    expect(
-      screen.getByRole("button", { name: /Appearance/ })
-    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Profile/ })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /Export/ })).toBeInTheDocument()
     expect(
       screen.getByRole("button", { name: /Shortcuts/ })
     ).toBeInTheDocument()
   })
 
-  it("shows the appearance (theme) section by default", () => {
+  it("keeps the desktop settings dialog at the wide layout", () => {
     render(<SettingsDialog open onOpenChange={() => {}} />)
-    expect(screen.getByText("Theme")).toBeInTheDocument()
+
+    expect(document.querySelector('[data-slot="dialog-content"]')).toHaveClass(
+      "sm:max-w-5xl"
+    )
+  })
+
+  it("keeps settings navigation above content until the desktop breakpoint", () => {
+    render(<SettingsDialog open onOpenChange={() => {}} />)
+
+    expect(
+      document.querySelector('[data-slot="dialog-content"] > div')
+    ).toHaveClass("lg:flex-row")
+  })
+
+  it("shows the profile section (with appearance) by default", () => {
+    render(<SettingsDialog open onOpenChange={() => {}} />)
+    expect(
+      screen.getByText("Manage how you appear in Tokokino.")
+    ).toBeInTheDocument()
+    // Appearance / theme toggle lives inside Profile now.
+    expect(screen.getByRole("button", { name: /Dark/ })).toBeInTheDocument()
   })
 
   it("switches to the export section", async () => {
     const user = userEvent.setup()
     render(<SettingsDialog open onOpenChange={() => {}} />)
     await user.click(screen.getByRole("button", { name: /Export/ }))
-    // Theme control is appearance-only, so it disappears after switching.
-    expect(screen.queryByText("Theme")).not.toBeInTheDocument()
+    expect(screen.getByText("Export filename format")).toBeInTheDocument()
   })
 
   it("renders nothing when closed", () => {
     render(<SettingsDialog open={false} onOpenChange={() => {}} />)
     expect(
-      screen.queryByRole("button", { name: /Appearance/ })
+      screen.queryByRole("button", { name: /Profile/ })
     ).not.toBeInTheDocument()
   })
 })

--- a/tests/lib/account-deletion.test.ts
+++ b/tests/lib/account-deletion.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  prepare: vi.fn(),
+  bind: vi.fn(),
+  run: vi.fn(),
+  first: vi.fn(),
+  getCloudflareContext: vi.fn(),
+}))
+
+vi.mock("@/lib/d1", () => ({
+  getD1Database: () => ({ prepare: mocks.prepare }),
+}))
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: mocks.getCloudflareContext,
+}))
+
+import {
+  clearAccountDeletion,
+  getAccountDeletionQueue,
+  isAccountDeletionPending,
+  markAccountDeletion,
+} from "@/lib/account-deletion"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.bind.mockReturnValue({ run: mocks.run, first: mocks.first })
+  mocks.prepare.mockReturnValue({ bind: mocks.bind })
+  mocks.run.mockResolvedValue(undefined)
+})
+
+describe("account-deletion flag store", () => {
+  describe("markAccountDeletion", () => {
+    it("upserts the flag with the given status and user", async () => {
+      await markAccountDeletion("user_1", "pending")
+
+      expect(mocks.prepare).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO account_deletions")
+      )
+      const [userId, status] = mocks.bind.mock.calls[0]
+      expect(userId).toBe("user_1")
+      expect(status).toBe("pending")
+    })
+
+    it("does not overwrite requested_at on status transitions", async () => {
+      await markAccountDeletion("user_1", "processing")
+
+      // ON CONFLICT updates status + updated_at only — requested_at is untouched.
+      const sql = String(mocks.prepare.mock.calls[0][0])
+      expect(sql).toContain(
+        "ON CONFLICT(user_id) DO UPDATE SET status = excluded.status, updated_at = excluded.updated_at"
+      )
+      expect(sql).not.toContain("requested_at = excluded.requested_at")
+    })
+  })
+
+  describe("isAccountDeletionPending", () => {
+    it("returns true when a flag row exists", async () => {
+      mocks.first.mockResolvedValue({ present: 1 })
+
+      expect(await isAccountDeletionPending("user_1")).toBe(true)
+      expect(mocks.bind).toHaveBeenCalledWith("user_1")
+    })
+
+    it("returns false when no flag row exists", async () => {
+      mocks.first.mockResolvedValue(null)
+
+      expect(await isAccountDeletionPending("user_1")).toBe(false)
+    })
+  })
+
+  describe("clearAccountDeletion", () => {
+    it("deletes the flag row for the user", async () => {
+      await clearAccountDeletion("user_1")
+
+      expect(mocks.prepare).toHaveBeenCalledWith(
+        expect.stringContaining("DELETE FROM account_deletions")
+      )
+      expect(mocks.bind).toHaveBeenCalledWith("user_1")
+    })
+  })
+
+  describe("getAccountDeletionQueue", () => {
+    it("returns the binding when it exposes send()", () => {
+      const send = vi.fn()
+      mocks.getCloudflareContext.mockReturnValue({
+        env: { ACCOUNT_DELETION_QUEUE: { send } },
+      })
+
+      expect(getAccountDeletionQueue()).toEqual({ send })
+    })
+
+    it("returns null when the binding is missing (local next dev)", () => {
+      mocks.getCloudflareContext.mockReturnValue({ env: {} })
+
+      expect(getAccountDeletionQueue()).toBeNull()
+    })
+
+    it("returns null when the binding lacks a send() method", () => {
+      mocks.getCloudflareContext.mockReturnValue({
+        env: { ACCOUNT_DELETION_QUEUE: {} },
+      })
+
+      expect(getAccountDeletionQueue()).toBeNull()
+    })
+
+    it("returns null when there is no Cloudflare context", () => {
+      mocks.getCloudflareContext.mockImplementation(() => {
+        throw new Error("no context")
+      })
+
+      expect(getAccountDeletionQueue()).toBeNull()
+    })
+  })
+})

--- a/tests/lib/account-deletion.test.ts
+++ b/tests/lib/account-deletion.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   bind: vi.fn(),
   run: vi.fn(),
   first: vi.fn(),
+  all: vi.fn(),
   getCloudflareContext: vi.fn(),
 }))
 
@@ -21,12 +22,17 @@ import {
   clearAccountDeletion,
   getAccountDeletionQueue,
   isAccountDeletionPending,
+  listStalePendingDeletions,
   markAccountDeletion,
 } from "@/lib/account-deletion"
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mocks.bind.mockReturnValue({ run: mocks.run, first: mocks.first })
+  mocks.bind.mockReturnValue({
+    run: mocks.run,
+    first: mocks.first,
+    all: mocks.all,
+  })
   mocks.prepare.mockReturnValue({ bind: mocks.bind })
   mocks.run.mockResolvedValue(undefined)
 })
@@ -79,6 +85,26 @@ describe("account-deletion flag store", () => {
         expect.stringContaining("DELETE FROM account_deletions")
       )
       expect(mocks.bind).toHaveBeenCalledWith("user_1")
+    })
+  })
+
+  describe("listStalePendingDeletions", () => {
+    it("returns the flagged user ids older than the cutoff", async () => {
+      mocks.all.mockResolvedValue({
+        results: [{ user_id: "user_1" }, { user_id: "user_2" }],
+      })
+
+      const ids = await listStalePendingDeletions()
+
+      expect(ids).toEqual(["user_1", "user_2"])
+      const sql = String(mocks.prepare.mock.calls[0][0])
+      expect(sql).toContain("FROM account_deletions WHERE updated_at <= ?")
+    })
+
+    it("returns an empty array when nothing is stale", async () => {
+      mocks.all.mockResolvedValue({ results: [] })
+
+      expect(await listStalePendingDeletions()).toEqual([])
     })
   })
 

--- a/tests/lib/account-deletion.test.ts
+++ b/tests/lib/account-deletion.test.ts
@@ -68,6 +68,9 @@ describe("account-deletion flag store", () => {
 
       expect(await isAccountDeletionPending("user_1")).toBe(true)
       expect(mocks.bind).toHaveBeenCalledWith("user_1")
+      // A terminal "failed" flag must not count as pending.
+      const sql = String(mocks.prepare.mock.calls[0][0])
+      expect(sql).toContain("status IN ('pending', 'processing')")
     })
 
     it("returns false when no flag row exists", async () => {
@@ -89,16 +92,23 @@ describe("account-deletion flag store", () => {
   })
 
   describe("listStalePendingDeletions", () => {
-    it("returns the flagged user ids older than the cutoff", async () => {
+    it("returns the stale flags with their request time, excluding failed", async () => {
       mocks.all.mockResolvedValue({
-        results: [{ user_id: "user_1" }, { user_id: "user_2" }],
+        results: [
+          { user_id: "user_1", requested_at: "2026-07-22T00:00:00.000Z" },
+          { user_id: "user_2", requested_at: "2026-07-22T01:00:00.000Z" },
+        ],
       })
 
-      const ids = await listStalePendingDeletions()
+      const stale = await listStalePendingDeletions()
 
-      expect(ids).toEqual(["user_1", "user_2"])
+      expect(stale).toEqual([
+        { userId: "user_1", requestedAt: "2026-07-22T00:00:00.000Z" },
+        { userId: "user_2", requestedAt: "2026-07-22T01:00:00.000Z" },
+      ])
       const sql = String(mocks.prepare.mock.calls[0][0])
-      expect(sql).toContain("FROM account_deletions WHERE updated_at <= ?")
+      expect(sql).toContain("status IN ('pending', 'processing')")
+      expect(sql).toContain("updated_at <= ?")
     })
 
     it("returns an empty array when nothing is stale", async () => {

--- a/tests/lib/account-deletion.test.ts
+++ b/tests/lib/account-deletion.test.ts
@@ -116,6 +116,22 @@ describe("account-deletion flag store", () => {
 
       expect(await listStalePendingDeletions()).toEqual([])
     })
+
+    it("rejects invalid options without touching the database", async () => {
+      await expect(
+        listStalePendingDeletions({ olderThanMinutes: -1 })
+      ).rejects.toThrow(/olderThanMinutes/)
+      await expect(
+        listStalePendingDeletions({ olderThanMinutes: Number.NaN })
+      ).rejects.toThrow(/olderThanMinutes/)
+      await expect(listStalePendingDeletions({ limit: -5 })).rejects.toThrow(
+        /limit/
+      )
+      await expect(listStalePendingDeletions({ limit: 2.5 })).rejects.toThrow(
+        /limit/
+      )
+      expect(mocks.all).not.toHaveBeenCalled()
+    })
   })
 
   describe("getAccountDeletionQueue", () => {

--- a/tests/lib/account-management.test.ts
+++ b/tests/lib/account-management.test.ts
@@ -82,6 +82,18 @@ describe("requestAccountDeletion", () => {
     expect(mocks.clearAccountDeletion).not.toHaveBeenCalled()
   })
 
+  it("falls back to inline deletion when the enqueue fails", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("queue unavailable"))
+    mocks.getAccountDeletionQueue.mockReturnValue({ send })
+
+    const result = await requestAccountDeletion("user_1")
+
+    // Must not leave the account flagged with no job to run it.
+    expect(result).toEqual({ queued: false })
+    expect(mocks.batch).toHaveBeenCalledTimes(1)
+    expect(mocks.clearAccountDeletion).toHaveBeenCalledWith("user_1")
+  })
+
   it("deletes inline when no queue binding is available (local next dev)", async () => {
     mocks.getAccountDeletionQueue.mockReturnValue(null)
 

--- a/tests/lib/account-management.test.ts
+++ b/tests/lib/account-management.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   markAccountDeletion: vi.fn(),
   getAccountDeletionQueue: vi.fn(),
   clearAccountDeletion: vi.fn(),
+  listStalePendingDeletions: vi.fn(),
   batch: vi.fn(),
   prepare: vi.fn(),
   bind: vi.fn(),
@@ -17,6 +18,7 @@ vi.mock("@/lib/account-deletion", () => ({
   markAccountDeletion: mocks.markAccountDeletion,
   getAccountDeletionQueue: mocks.getAccountDeletionQueue,
   clearAccountDeletion: mocks.clearAccountDeletion,
+  listStalePendingDeletions: mocks.listStalePendingDeletions,
 }))
 
 vi.mock("@/lib/d1", () => ({
@@ -49,6 +51,7 @@ vi.mock("@/lib/db/schema", () => ({
 
 import {
   processAccountDeletion,
+  reconcileStaleAccountDeletions,
   requestAccountDeletion,
 } from "@/lib/account-management"
 
@@ -129,5 +132,29 @@ describe("processAccountDeletion", () => {
 
     // Flag stays so the queue retry (or login gate) still sees it as pending.
     expect(mocks.clearAccountDeletion).not.toHaveBeenCalled()
+  })
+})
+
+describe("reconcileStaleAccountDeletions", () => {
+  it("retries every stale flag and reports the count", async () => {
+    mocks.listStalePendingDeletions.mockResolvedValue(["user_1", "user_2"])
+
+    const result = await reconcileStaleAccountDeletions()
+
+    expect(result).toEqual({ processed: 2, failed: 0 })
+    expect(mocks.batch).toHaveBeenCalledTimes(2)
+    expect(mocks.clearAccountDeletion).toHaveBeenCalledWith("user_1")
+    expect(mocks.clearAccountDeletion).toHaveBeenCalledWith("user_2")
+  })
+
+  it("counts failures and keeps going after one throws", async () => {
+    mocks.listStalePendingDeletions.mockResolvedValue(["user_1", "user_2"])
+    mocks.batch.mockRejectedValueOnce(new Error("still failing"))
+
+    const result = await reconcileStaleAccountDeletions()
+
+    expect(result).toEqual({ processed: 1, failed: 1 })
+    // The second account still got processed despite the first failing.
+    expect(mocks.clearAccountDeletion).toHaveBeenCalledWith("user_2")
   })
 })

--- a/tests/lib/account-management.test.ts
+++ b/tests/lib/account-management.test.ts
@@ -136,25 +136,53 @@ describe("processAccountDeletion", () => {
 })
 
 describe("reconcileStaleAccountDeletions", () => {
+  const recent = () => new Date().toISOString()
+  const longAgo = () => new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString()
+
   it("retries every stale flag and reports the count", async () => {
-    mocks.listStalePendingDeletions.mockResolvedValue(["user_1", "user_2"])
+    mocks.listStalePendingDeletions.mockResolvedValue([
+      { userId: "user_1", requestedAt: recent() },
+      { userId: "user_2", requestedAt: recent() },
+    ])
 
     const result = await reconcileStaleAccountDeletions()
 
-    expect(result).toEqual({ processed: 2, failed: 0 })
+    expect(result).toEqual({ processed: 2, failed: 0, abandoned: 0 })
     expect(mocks.batch).toHaveBeenCalledTimes(2)
     expect(mocks.clearAccountDeletion).toHaveBeenCalledWith("user_1")
     expect(mocks.clearAccountDeletion).toHaveBeenCalledWith("user_2")
   })
 
-  it("counts failures and keeps going after one throws", async () => {
-    mocks.listStalePendingDeletions.mockResolvedValue(["user_1", "user_2"])
+  it("counts recent failures and keeps going after one throws", async () => {
+    mocks.listStalePendingDeletions.mockResolvedValue([
+      { userId: "user_1", requestedAt: recent() },
+      { userId: "user_2", requestedAt: recent() },
+    ])
     mocks.batch.mockRejectedValueOnce(new Error("still failing"))
 
     const result = await reconcileStaleAccountDeletions()
 
-    expect(result).toEqual({ processed: 1, failed: 1 })
+    expect(result).toEqual({ processed: 1, failed: 1, abandoned: 0 })
+    // A recent failure is not marked terminal — it will retry next pass.
+    expect(mocks.markAccountDeletion).not.toHaveBeenCalledWith(
+      "user_1",
+      "failed"
+    )
     // The second account still got processed despite the first failing.
     expect(mocks.clearAccountDeletion).toHaveBeenCalledWith("user_2")
+  })
+
+  it("gives up terminally when a failure persists past the window", async () => {
+    mocks.listStalePendingDeletions.mockResolvedValue([
+      { userId: "user_1", requestedAt: longAgo() },
+    ])
+    mocks.batch.mockRejectedValue(new Error("missing R2 config"))
+
+    const result = await reconcileStaleAccountDeletions()
+
+    expect(result).toEqual({ processed: 0, failed: 0, abandoned: 1 })
+    // Flag is marked terminal so it stops retrying and no longer blocks login.
+    expect(mocks.markAccountDeletion).toHaveBeenCalledWith("user_1", "failed")
+    expect(mocks.clearAccountDeletion).not.toHaveBeenCalled()
   })
 })

--- a/tests/lib/account-management.test.ts
+++ b/tests/lib/account-management.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  markAccountDeletion: vi.fn(),
+  getAccountDeletionQueue: vi.fn(),
+  clearAccountDeletion: vi.fn(),
+  batch: vi.fn(),
+  prepare: vi.fn(),
+  bind: vi.fn(),
+  run: vi.fn(),
+  r2send: vi.fn(),
+  abort: vi.fn(),
+}))
+
+vi.mock("@/lib/account-deletion", () => ({
+  markAccountDeletion: mocks.markAccountDeletion,
+  getAccountDeletionQueue: mocks.getAccountDeletionQueue,
+  clearAccountDeletion: mocks.clearAccountDeletion,
+}))
+
+vi.mock("@/lib/d1", () => ({
+  getD1Database: () => ({ prepare: mocks.prepare, batch: mocks.batch }),
+  // Every ownership lookup returns no rows so the R2 cleanup is a no-op.
+  getDb: () => ({
+    select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+  }),
+}))
+
+vi.mock("@/lib/env", () => ({ requireR2Config: () => ({ bucket: "bucket" }) }))
+vi.mock("@/lib/r2-client", () => ({
+  getR2Client: () => ({ send: mocks.r2send }),
+}))
+vi.mock("@/lib/share-storage", () => ({
+  abortShareMultipartUpload: mocks.abort,
+}))
+vi.mock("@aws-sdk/client-s3", () => ({ DeleteObjectCommand: class {} }))
+vi.mock("drizzle-orm", () => ({ eq: vi.fn() }))
+vi.mock("@/lib/db/schema", () => ({
+  drafts: { userId: "user_id", stateKey: "state_key", thumbnailKey: "thumb" },
+  draftMedia: { userId: "user_id", objectKey: "object_key" },
+  shares: { userId: "user_id", objectKey: "object_key", posterKey: "poster" },
+  shareUploads: {
+    userId: "user_id",
+    objectKey: "object_key",
+    r2UploadId: "r2_upload_id",
+  },
+}))
+
+import {
+  processAccountDeletion,
+  requestAccountDeletion,
+} from "@/lib/account-management"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.bind.mockReturnValue({ run: mocks.run })
+  mocks.prepare.mockReturnValue({ bind: mocks.bind })
+  mocks.run.mockResolvedValue(undefined)
+  mocks.batch.mockResolvedValue(undefined)
+  mocks.markAccountDeletion.mockResolvedValue(undefined)
+  mocks.clearAccountDeletion.mockResolvedValue(undefined)
+})
+
+describe("requestAccountDeletion", () => {
+  it("flags pending and enqueues the job when the queue binding exists", async () => {
+    const send = vi.fn().mockResolvedValue(undefined)
+    mocks.getAccountDeletionQueue.mockReturnValue({ send })
+
+    const result = await requestAccountDeletion("user_1")
+
+    expect(result).toEqual({ queued: true })
+    expect(mocks.markAccountDeletion).toHaveBeenCalledWith("user_1", "pending")
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user_1",
+        requestedAt: expect.any(String),
+      })
+    )
+    // The heavy delete must not run in the request when it is queued.
+    expect(mocks.batch).not.toHaveBeenCalled()
+    expect(mocks.clearAccountDeletion).not.toHaveBeenCalled()
+  })
+
+  it("deletes inline when no queue binding is available (local next dev)", async () => {
+    mocks.getAccountDeletionQueue.mockReturnValue(null)
+
+    const result = await requestAccountDeletion("user_1")
+
+    expect(result).toEqual({ queued: false })
+    expect(mocks.markAccountDeletion).toHaveBeenCalledWith("user_1", "pending")
+    expect(mocks.markAccountDeletion).toHaveBeenCalledWith(
+      "user_1",
+      "processing"
+    )
+    expect(mocks.batch).toHaveBeenCalledTimes(1)
+    expect(mocks.clearAccountDeletion).toHaveBeenCalledWith("user_1")
+  })
+})
+
+describe("processAccountDeletion", () => {
+  it("marks processing, runs the delete batch, then clears the flag", async () => {
+    await processAccountDeletion("user_1")
+
+    expect(mocks.markAccountDeletion).toHaveBeenCalledWith(
+      "user_1",
+      "processing"
+    )
+    expect(mocks.batch).toHaveBeenCalledTimes(1)
+    expect(mocks.clearAccountDeletion).toHaveBeenCalledWith("user_1")
+  })
+
+  it("keeps the flag set if the delete batch fails", async () => {
+    mocks.batch.mockRejectedValueOnce(new Error("d1 down"))
+
+    await expect(processAccountDeletion("user_1")).rejects.toThrow("d1 down")
+
+    // Flag stays so the queue retry (or login gate) still sees it as pending.
+    expect(mocks.clearAccountDeletion).not.toHaveBeenCalled()
+  })
+})

--- a/tests/stubs/server-only.ts
+++ b/tests/stubs/server-only.ts
@@ -1,0 +1,4 @@
+// `server-only` throws when bundled outside a React Server Component. In the
+// Vitest node/jsdom environment there is no such guard to enforce, so we alias
+// the package to this empty module and let server modules import cleanly.
+export {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": fileURLToPath(new URL(".", import.meta.url)),
+      "server-only": fileURLToPath(
+        new URL("./tests/stubs/server-only.ts", import.meta.url)
+      ),
     },
   },
   test: {

--- a/worker.ts
+++ b/worker.ts
@@ -112,4 +112,24 @@ export default {
       }
     }
   },
+
+  // Cron reconciler: retries deletion flags that went stale (a dropped or
+  // dead-lettered job) so a stuck row can never lock an account out for good.
+  async scheduled(_controller, env, ctx): Promise<void> {
+    const cfEnv = env as CloudflareEnv
+    const request = new Request(
+      new URL(
+        "/api/internal/account-deletion/reconcile",
+        cfEnv.BETTER_AUTH_URL
+      ),
+      {
+        method: "POST",
+        headers: { authorization: `Bearer ${cfEnv.BETTER_AUTH_SECRET}` },
+      }
+    ) as unknown as Parameters<typeof handler.fetch>[0]
+    const response = await handler.fetch(request, env, ctx)
+    if (!response.ok) {
+      console.error(`account deletion reconcile responded ${response.status}`)
+    }
+  },
 } satisfies ExportedHandler

--- a/worker.ts
+++ b/worker.ts
@@ -1,3 +1,5 @@
+import type { AccountDeletionMessage } from "@/lib/account-deletion"
+
 import handler from "./.open-next/worker.js"
 
 const SITE_URL = "https://tokokino.com"
@@ -55,8 +57,6 @@ function wantsMarkdown(request: Request): boolean {
   return (request.headers.get("accept") ?? "").includes("text/markdown")
 }
 
-type AccountDeletionMessage = { userId: string; requestedAt: string }
-
 export default {
   ...handler,
   // Params are left unannotated so they pick up their types contextually from
@@ -102,12 +102,27 @@ export default {
           }
         ) as unknown as Parameters<typeof handler.fetch>[0]
         const response = await handler.fetch(internalRequest, env, ctx)
-        if (!response.ok) {
-          throw new Error(`account deletion route responded ${response.status}`)
+        if (response.ok) {
+          message.ack()
+          continue
         }
-        message.ack()
+        // 4xx is terminal (bad message, wrong secret) — retrying can't fix it,
+        // so ack and surface it rather than looping into the dead-letter queue.
+        // 5xx is transient (D1/R2 hiccup) — let it retry.
+        if (response.status >= 400 && response.status < 500) {
+          console.error(
+            `Account deletion job for ${body.userId} failed terminally: ${response.status}`
+          )
+          message.ack()
+        } else {
+          console.error(
+            `Account deletion job for ${body.userId} failed: ${response.status}; retrying`
+          )
+          message.retry()
+        }
       } catch (error) {
-        console.error("Account deletion job failed", error)
+        // Network/exception — transient, so retry.
+        console.error("Account deletion job errored; retrying", error)
         message.retry()
       }
     }

--- a/worker.ts
+++ b/worker.ts
@@ -55,6 +55,8 @@ function wantsMarkdown(request: Request): boolean {
   return (request.headers.get("accept") ?? "").includes("text/markdown")
 }
 
+type AccountDeletionMessage = { userId: string; requestedAt: string }
+
 export default {
   ...handler,
   // Params are left unannotated so they pick up their types contextually from
@@ -77,5 +79,37 @@ export default {
     }
 
     return handler.fetch(request, env, ctx)
+  },
+
+  // Consumes the account-deletion queue. The heavy work lives behind an
+  // internal Next route so it runs inside the OpenNext request context (where
+  // the D1/R2 bindings resolve); this handler is just a durable, retrying
+  // trigger.
+  async queue(batch, env, ctx): Promise<void> {
+    const cfEnv = env as CloudflareEnv
+    for (const message of batch.messages) {
+      const body = message.body as AccountDeletionMessage
+      try {
+        const internalRequest = new Request(
+          new URL("/api/internal/account-deletion", cfEnv.BETTER_AUTH_URL),
+          {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${cfEnv.BETTER_AUTH_SECRET}`,
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({ userId: body.userId }),
+          }
+        ) as unknown as Parameters<typeof handler.fetch>[0]
+        const response = await handler.fetch(internalRequest, env, ctx)
+        if (!response.ok) {
+          throw new Error(`account deletion route responded ${response.status}`)
+        }
+        message.ack()
+      } catch (error) {
+        console.error("Account deletion job failed", error)
+        message.retry()
+      }
+    }
   },
 } satisfies ExportedHandler

--- a/worker.ts
+++ b/worker.ts
@@ -142,9 +142,13 @@ export default {
         headers: { authorization: `Bearer ${cfEnv.BETTER_AUTH_SECRET}` },
       }
     ) as unknown as Parameters<typeof handler.fetch>[0]
-    const response = await handler.fetch(request, env, ctx)
-    if (!response.ok) {
-      console.error(`account deletion reconcile responded ${response.status}`)
+    try {
+      const response = await handler.fetch(request, env, ctx)
+      if (!response.ok) {
+        console.error(`account deletion reconcile responded ${response.status}`)
+      }
+    } catch (error) {
+      console.error("Account deletion reconcile errored", error)
     }
   },
 } satisfies ExportedHandler

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -40,7 +40,8 @@
         "queue": "tokokino-account-deletion",
         "max_batch_size": 10,
         "max_batch_timeout": 30,
-        "max_retries": 5
+        "max_retries": 5,
+        "dead_letter_queue": "tokokino-account-deletion-dlq"
       }
     ]
   },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -38,7 +38,9 @@
     "consumers": [
       {
         "queue": "tokokino-account-deletion",
-        "max_batch_size": 10,
+        // Deletions run sequentially per batch and each does a D1 batch + R2
+        // cleanup, so keep batches small to bound per-invocation work.
+        "max_batch_size": 5,
         "max_batch_timeout": 30,
         "max_retries": 5,
         "dead_letter_queue": "tokokino-account-deletion-dlq"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -28,6 +28,22 @@
       "simple": { "limit": 60, "period": 60 }
     }
   ],
+  "queues": {
+    "producers": [
+      {
+        "binding": "ACCOUNT_DELETION_QUEUE",
+        "queue": "tokokino-account-deletion"
+      }
+    ],
+    "consumers": [
+      {
+        "queue": "tokokino-account-deletion",
+        "max_batch_size": 10,
+        "max_batch_timeout": 30,
+        "max_retries": 5
+      }
+    ]
+  },
   "observability": {
     "enabled": true
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -45,6 +45,9 @@
       }
     ]
   },
+  "triggers": {
+    "crons": ["*/15 * * * *"]
+  },
   "observability": {
     "enabled": true
   }


### PR DESCRIPTION
## Overview

Adds an **Account** tab to the settings dialog and a supporting server surface for managing sessions and deleting accounts. The heavy account deletion is offloaded to a **Cloudflare Queue** so the request returns immediately.

## Sessions & account
- Active sessions list (device, location, last-active) with per-session revoke and log-out-all.
- Skeleton loader while sessions fetch; inline "copied" checkmark on the User ID (no toast).
- New `GET/POST/DELETE /api/account`, all on the shared `requireSession` helper and rate-limited with `WRITE_RATE_LIMITER`.
- Session geolocation comes from Cloudflare `request.cf` — only populated in the Workers runtime, so it reads **"Location unavailable"** under `next dev` (works in prod).

## Queue-backed account deletion
- `DELETE /api/account` flags the account (`account_deletions`), revokes sessions, and enqueues to `ACCOUNT_DELETION_QUEUE` instead of deleting inline.
- The queue **consumer** in `worker.ts` is a thin, retrying trigger that calls an internal route (`/api/internal/account-deletion`) so the heavy delete runs inside the OpenNext request context where the D1/R2 bindings resolve.
- Local dev (no queue binding) falls back to **inline deletion**, so the flow still works end-to-end.
- Re-login during the pending window is blocked by a better-auth `session.create.before` hook. OAuth callbacks can't be stopped by a plain `APIError`, so they redirect to `/login?error=account_deleted`, which the login page surfaces.

## Migrations
- `0012_account_session_management.sql` — `session_locations`, `account_deletion_cleanups`
- `0013_account_deletions.sql` — the deletion flag table

Both already applied to **local and remote** D1.

## Deploy prerequisites
- Queue `tokokino-account-deletion` is **already created** (Cloudflare Queues runs on the **Workers Free** plan).
- `pnpm deploy` attaches the consumer (queue flips Inactive → Active).
- `cloudflare-env.d.ts` regenerated to include `ACCOUNT_DELETION_QUEUE`.

## Testing
- `pnpm typecheck` clean; full suite **1044 tests pass**.
- Updated `account-route.test.ts` for the queued flow; added a `server-only` vitest stub so server modules import in the node/jsdom env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned Settings into Profile, Account, Export, and Shortcuts with a responsive theme toggle.
  * Added Profile details with connected accounts.
  * Added Account session management (view device/location context, revoke single/all, sign out everywhere).
  * Added permanent account deletion with confirmation and asynchronous background processing.
* **Bug Fixes**
  * When an account is pending deletion, sign-in is blocked and the login page displays the account-deleted message.
* **Documentation**
  * Updated DPA disclosures to reflect queue-based account deletion processing.
* **Tests**
  * Expanded test coverage for settings UI and account/session deletion flows, including internal reconciliation and worker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds account management and asynchronous account deletion. The main changes are:

- Active-session listing and revocation in Account settings.
- Queue-backed account deletion with an inline local fallback.
- Scheduled recovery for stale deletions and pending storage cleanup.
- Sign-in blocking while deletion is pending.
- Internal deletion routes, migrations, deployment configuration, and tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Failed queue sends now fall back to inline deletion.
- Scheduled reconciliation recovers stale jobs and retries storage cleanup.
- Persistent deletion failures stop blocking sign-in after reaching a terminal state.
- Connected-account requests now settle when the promise rejects.
- No blocking issues were found in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/account-management.ts | Adds queued deletion, inline fallback, durable storage cleanup, and stale-deletion recovery. |
| lib/account-deletion.ts | Adds deletion status persistence, pending-state checks, and stale-record lookup. |
| worker.ts | Adds queue consumption and scheduled reconciliation handlers. |
| wrangler.jsonc | Configures the deletion queue, dead-letter queue, retries, and reconciliation schedule. |
| app/api/internal/account-deletion/reconcile/route.ts | Adds the authenticated endpoint for stale deletion recovery and storage cleanup. |
| components/editor/settings/settings-dialog.tsx | Adds profile, session, and account-deletion controls and handles failed connected-account requests. |

<sub>Reviews (5): Last reviewed commit: ["fix: drain R2 cleanup outbox from the cr..."](https://github.com/shivabhattacharjee/tokokino/commit/4f0779646901f0fa1d69ce89d22e6ab723a1ece1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46284028)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/sideprojects/github/ShivaBhattacharjee/tokokino/-/custom-context?memory=7a22f059-86c3-428b-88f5-f28e5fb51882))
- Context used - agents.md ([source](https://app.greptile.com/sideprojects/github/ShivaBhattacharjee/tokokino/-/custom-context?memory=0b3651fa-1db4-4837-8570-4aaf8d2a4cc2))

<!-- /greptile_comment -->