### PR TITLE
fix: empty-state placement for templates + color swatch React style warning

### DIFF
--- a/components/editor/canvas/canvas-empty-state.tsx
+++ b/components/editor/canvas/canvas-empty-state.tsx
@@ -4,6 +4,10 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 import { shadowDropFilterPreviewCss } from "@/lib/editor/css-utils"
+import {
+  MAIN_BARE_LEFT_VAR,
+  MAIN_BARE_TOP_VAR,
+} from "@/lib/editor/live-preview-vars"
 import { useEditor } from "@/lib/editor/store"
 import type { TweetCardSettings } from "@/lib/editor/tweet-settings"
 import { BoxEmptyState } from "./box-empty-state"
@@ -11,6 +15,14 @@ import { frameFitStyle, framePositionTransform } from "./helpers"
 import { InnerLightingOverlay } from "./inner-lighting-overlay"
 import type { EditorTool } from "@/lib/editor/store"
 import type { CaptureDevice, CaptureSettings } from "./upload-card"
+
+/** Free-placement box matching bare {@link ScreenshotBare} left/top/size math. */
+export type EmptyFreePlacement = {
+  left: number
+  top: number
+  width: number
+  height: number
+}
 
 type CanvasEmptyStateProps = {
   isDragOver: boolean
@@ -36,6 +48,12 @@ type CanvasEmptyStateProps = {
   /** When provided, the empty state is positioned using the anchor/offset like device frames. */
   screenshotAnchor?: { x: number; y: number }
   screenshotOffset?: { x: number; y: number }
+  /**
+   * Bare (no-frame) free placement — same pixel left/top/size math as
+   * {@link ScreenshotBare}. Takes priority over frame-style anchor positioning
+   * so empty templates land where the screenshot will after upload.
+   */
+  freePlacement?: EmptyFreePlacement | null
   /** The CSS transform string for tilt/scale (e.g. perspective + rotateX/Y/Z + scale). */
   transform?: string
   /** The shadow drop-filter for the screenshot box. */
@@ -67,6 +85,7 @@ export function CanvasEmptyState({
   innerLightingStyle,
   screenshotAnchor,
   screenshotOffset,
+  freePlacement,
   transform,
   shadowFilter,
   boxStyle,
@@ -103,6 +122,76 @@ export function CanvasEmptyState({
     trigger?.click()
   }
 
+  const interactionClass = cn(
+    "pointer-events-auto absolute top-0 left-0 select-none",
+    "overflow-hidden rounded-3xl border border-border/30 transition-all duration-300 ease-out dark:border-white/8",
+    "data-[drag-over=true]:border-primary/60 data-[drag-over=true]:ring-2 data-[drag-over=true]:ring-primary/35",
+    onPointerDown && activeTool === "pointer"
+      ? isBeingDragged
+        ? "cursor-grabbing transition-none"
+        : "cursor-grab"
+      : "cursor-pointer"
+  )
+
+  const emptyBody = (
+    <>
+      <InnerLightingOverlay style={innerLightingStyle} />
+      <BoxEmptyState
+        isDragOver={isDragOver}
+        onBrowse={onBrowse}
+        onCapture={onCapture}
+        onLoadTweet={onLoadTweet}
+        onDemo={onDemo}
+        compact={useCompact}
+        allowVideo={allowVideo}
+        defaultCaptureDevice={defaultCaptureDevice}
+        captureStateKey={captureStateKey}
+      />
+    </>
+  )
+
+  // Bare free placement: same pixel left/top/size path as ScreenshotBare so a
+  // template with corner anchors + offsets (e.g. Silent Reveal) doesn't jump
+  // the moment a screenshot lands.
+  if (freePlacement) {
+    return (
+      <div
+        className="pointer-events-none relative h-full w-full"
+        style={{ containerType: "size" }}
+      >
+        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+        <div
+          ref={rootRef}
+          onClick={handleAreaClick}
+          data-drag-over={isDragOver}
+          data-active={isActive}
+          data-editor-shadow-filter-target
+          data-editor-shadow-filter-base={shadowFilter || ""}
+          className={interactionClass}
+          style={{
+            ...boxStyle,
+            left: `var(${MAIN_BARE_LEFT_VAR}, ${freePlacement.left}px)`,
+            top: `var(${MAIN_BARE_TOP_VAR}, ${freePlacement.top}px)`,
+            width: freePlacement.width,
+            height: freePlacement.height,
+            maxWidth: "none",
+            maxHeight: "none",
+            transform: transform || undefined,
+            transformOrigin: "center",
+            transformStyle: "preserve-3d",
+            filter: shadowDropFilterPreviewCss(shadowFilter) || undefined,
+          }}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+        >
+          {emptyBody}
+        </div>
+      </div>
+    )
+  }
+
   // When screenshotAnchor is provided, use absolute positioning like frame
   // empty states do — the box is sized via container queries and positioned
   // with framePositionTransform so it follows the preset direction.
@@ -125,16 +214,7 @@ export function CanvasEmptyState({
           data-active={isActive}
           data-editor-shadow-filter-target
           data-editor-shadow-filter-base={shadowFilter || ""}
-          className={cn(
-            "pointer-events-auto absolute top-0 left-0 max-h-full max-w-full select-none",
-            "overflow-hidden rounded-3xl border border-border/30 transition-all duration-300 ease-out dark:border-white/8",
-            "data-[drag-over=true]:border-primary/60 data-[drag-over=true]:ring-2 data-[drag-over=true]:ring-primary/35",
-            onPointerDown && activeTool === "pointer"
-              ? isBeingDragged
-                ? "cursor-grabbing transition-none"
-                : "cursor-grab"
-              : "cursor-pointer"
-          )}
+          className={cn(interactionClass, "max-h-full max-w-full")}
           style={{
             ...fitStyle,
             ...boxStyle,
@@ -158,18 +238,7 @@ export function CanvasEmptyState({
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
         >
-          <InnerLightingOverlay style={innerLightingStyle} />
-          <BoxEmptyState
-            isDragOver={isDragOver}
-            onBrowse={onBrowse}
-            onCapture={onCapture}
-            onLoadTweet={onLoadTweet}
-            onDemo={onDemo}
-            compact={useCompact}
-            allowVideo={allowVideo}
-            defaultCaptureDevice={defaultCaptureDevice}
-            captureStateKey={captureStateKey}
-          />
+          {emptyBody}
         </div>
       </div>
     )

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -67,6 +67,7 @@ import {
 import { MockupEmptyState } from "./mockup-empty-state"
 import {
   deviceMockupSpec,
+  fitContainBox,
   lightingOverlayCss,
   overlayLayerCss,
   screenshotPlacementStyle,
@@ -257,6 +258,10 @@ function CanvasViewInner({
     w: number
     h: number
   } | null>(null)
+  // Ignore stale intrinsic size while empty. Keeping naturalDims after delete
+  // made Auto-aspect empty boxes reuse the previous image ratio (tall full-page
+  // captures became a thin vertical strip) even after applying a new template.
+  const activeNaturalDims = screenshot ? naturalDims : null
   // Chrome/Edge: native object-view-box. Firefox/Safari: overflow polyfill.
   // Server snapshot prefers native so SSR matches the working Chrome path.
   const nativeVideoCrop = React.useSyncExternalStore(
@@ -289,7 +294,7 @@ function CanvasViewInner({
     // Natural dims cover a media swap: they reset to null and land again on
     // load, and without them a new image/video keeps the previous media's
     // measured box (the contain shell is sized from it, so it never resizes).
-    layoutKey: `${inRowMode ? "row" : "single"}:${frame.id}:${frame.orientation}:${screenshotSlots.length}:${widthPx}:${heightPx}:${padding}:${objectFit ?? "cover"}:${naturalDims ? `${naturalDims.w}x${naturalDims.h}` : "none"}`,
+    layoutKey: `${inRowMode ? "row" : "single"}:${frame.id}:${frame.orientation}:${screenshotSlots.length}:${widthPx}:${heightPx}:${padding}:${objectFit ?? "cover"}:${activeNaturalDims ? `${activeNaturalDims.w}x${activeNaturalDims.h}` : "none"}`,
   })
   const suppressTransitionPlacement = useSuppressTransitionOnChange(
     placementDims
@@ -375,20 +380,24 @@ function CanvasViewInner({
   ])
   const isAuto = aspect.id === "auto" || aspect.w === 0 || aspect.h === 0
   const canUseNaturalCanvasAspect =
-    isAuto && naturalDims && !inRowMode && frame.id === "none"
+    isAuto && activeNaturalDims && !inRowMode && frame.id === "none"
   // Visible media size after a non-destructive video crop (full size otherwise).
   const croppedDims =
-    naturalDims &&
+    activeNaturalDims &&
     lastCropRegion &&
     isVideoSrc(screenshot) &&
     isActiveCropRegion(lastCropRegion)
-      ? croppedNaturalSize(naturalDims.w, naturalDims.h, lastCropRegion)
+      ? croppedNaturalSize(
+          activeNaturalDims.w,
+          activeNaturalDims.h,
+          lastCropRegion
+        )
       : null
   // Drives the CANVAS box (and so the encoder's frame size), which must not move
   // while a crop animates — see `cropAnimated`.
   const visibleNaturalDims = cropAnimated
-    ? naturalDims
-    : (croppedDims ?? naturalDims)
+    ? activeNaturalDims
+    : (croppedDims ?? activeNaturalDims)
   // Auto canvas aspect follows the visible video crop when one is set.
   const autoDims = canUseNaturalCanvasAspect ? visibleNaturalDims : null
   const aw = autoDims ? autoDims.w : aspect.w || 16
@@ -477,6 +486,46 @@ function CanvasViewInner({
   const positionedStyle: React.CSSProperties | null = placementDims
     ? screenshotPlacementStyle(placementDims, scaleFactor, positionX, positionY)
     : null
+  // Bare (no-frame) empty / preparing placeholder: same free-placement math as
+  // ScreenshotBare so templates with corner anchors + offsets (Silent Reveal)
+  // don't jump when a screenshot lands. Assumes the empty box fills the stage
+  // the way cover/contain-matching-aspect will after upload.
+  const bareEmptyFreePlacement = React.useMemo(() => {
+    if (frame.id !== "none" || inRowMode || tweet) return null
+    // CSS % padding is relative to the containing block's WIDTH on every side.
+    const padPx = (Math.max(0, Math.min(240, padding)) / 1200) * widthPx
+    const stageW = Math.max(1, widthPx - 2 * padPx)
+    const stageH = Math.max(1, heightPx - 2 * padPx)
+    const fit = objectFit ?? "contain"
+    let imgW = stageW
+    let imgH = stageH
+    if (fit === "contain") {
+      const box = fitContainBox(stageW, stageH, canvasAspectRatio)
+      imgW = box.width
+      imgH = box.height
+    }
+    const base = screenshotPlacementStyle(
+      { stageW, stageH, imgW, imgH },
+      scaleFactor,
+      positionX,
+      positionY
+    )
+    const left = typeof base.left === "number" ? base.left : 0
+    const top = typeof base.top === "number" ? base.top : 0
+    return { left, top, width: imgW, height: imgH }
+  }, [
+    canvasAspectRatio,
+    frame.id,
+    heightPx,
+    inRowMode,
+    objectFit,
+    padding,
+    positionX,
+    positionY,
+    scaleFactor,
+    tweet,
+    widthPx,
+  ])
   const enhanceFilter = enhanceFilterCss(enhance)
   // Read the animated radius via a var so an Animate-mode clip can ease it,
   // falling back to the committed value at rest / outside Animate mode.
@@ -666,12 +715,23 @@ function CanvasViewInner({
           positionedStyle.left + offset.x,
           positionedStyle.top + offset.y
         )
+        return
+      }
+
+      // Empty bare canvas: same free-placement base as the empty placeholder.
+      if (bareEmptyFreePlacement) {
+        setMainScreenshotBarePreviewPx(
+          canvasEl,
+          bareEmptyFreePlacement.left + offset.x,
+          bareEmptyFreePlacement.top + offset.y
+        )
       }
     },
     [
       ah,
       aspect.id,
       aw,
+      bareEmptyFreePlacement,
       frame,
       inRowMode,
       positionedStyle,
@@ -1130,6 +1190,16 @@ function CanvasViewInner({
                   label="Preparing GIF…"
                   screenshotAnchor={screenshotAnchor}
                   screenshotOffset={effectiveOffset}
+                  freePlacement={
+                    bareEmptyFreePlacement
+                      ? {
+                          left: bareEmptyFreePlacement.left + effectiveOffset.x,
+                          top: bareEmptyFreePlacement.top + effectiveOffset.y,
+                          width: bareEmptyFreePlacement.width,
+                          height: bareEmptyFreePlacement.height,
+                        }
+                      : null
+                  }
                   transform={transform}
                   shadowFilter={computedShadowFilter}
                   boxStyle={emptyStateBoxStyle}
@@ -1221,13 +1291,23 @@ function CanvasViewInner({
                   innerLightingStyle={innerLightingStyle}
                   screenshotAnchor={screenshotAnchor}
                   screenshotOffset={effectiveOffset}
+                  freePlacement={
+                    bareEmptyFreePlacement
+                      ? {
+                          left: bareEmptyFreePlacement.left + effectiveOffset.x,
+                          top: bareEmptyFreePlacement.top + effectiveOffset.y,
+                          width: bareEmptyFreePlacement.width,
+                          height: bareEmptyFreePlacement.height,
+                        }
+                      : null
+                  }
                   transform={transform}
                   shadowFilter={computedShadowFilter}
                   boxStyle={emptyStateBoxStyle}
-                  // Match the canvas box's aspect (which follows the last loaded
-                  // screenshot's natural ratio on an auto canvas) so deleting the
-                  // screenshot doesn't snap the empty box to the default 16:10 and
-                  // make it jump under tilt/scale.
+                  // Canvas aspect for frame-style empty (and portrait compact).
+                  // Free-placement bare empty uses stage contain math instead;
+                  // activeNaturalDims is null while empty so Auto doesn't keep a
+                  // previous tall capture as a thin strip after delete.
                   aspectW={aw}
                   aspectH={ah}
                   compact={

--- a/components/editor/canvas/media-preparing-state.tsx
+++ b/components/editor/canvas/media-preparing-state.tsx
@@ -4,9 +4,14 @@ import * as React from "react"
 
 import { ShimmerBox } from "@/components/ui/shimmer-image"
 import { shadowDropFilterPreviewCss } from "@/lib/editor/css-utils"
+import {
+  MAIN_BARE_LEFT_VAR,
+  MAIN_BARE_TOP_VAR,
+} from "@/lib/editor/live-preview-vars"
 import { useEditor } from "@/lib/editor/store"
 import { cn } from "@/lib/utils"
 
+import type { EmptyFreePlacement } from "./canvas-empty-state"
 import { frameFitStyle, framePositionTransform } from "./helpers"
 import { InnerLightingOverlay } from "./inner-lighting-overlay"
 
@@ -18,6 +23,8 @@ type MediaPreparingStateProps = {
   innerLightingStyle?: React.CSSProperties | null
   screenshotAnchor: { x: number; y: number }
   screenshotOffset?: { x: number; y: number }
+  /** Bare free placement — same as {@link CanvasEmptyState.freePlacement}. */
+  freePlacement?: EmptyFreePlacement | null
   transform?: string
   shadowFilter?: string
   boxStyle?: React.CSSProperties
@@ -36,6 +43,7 @@ export function MediaPreparingState({
   innerLightingStyle,
   screenshotAnchor,
   screenshotOffset,
+  freePlacement,
   transform,
   shadowFilter,
   boxStyle,
@@ -52,6 +60,59 @@ export function MediaPreparingState({
     }
   )
 
+  const shellClass = cn(
+    "absolute top-0 left-0 overflow-hidden select-none",
+    "rounded-3xl border border-border/40"
+  )
+
+  const content = (
+    <>
+      <InnerLightingOverlay style={innerLightingStyle} />
+      <ShimmerBox className="absolute inset-0 size-full rounded-3xl" />
+      <div className="absolute inset-0 flex items-center justify-center px-4">
+        <span
+          aria-hidden
+          className="animate-text-shimmer bg-linear-to-r from-muted-foreground/45 via-foreground/70 to-muted-foreground/45 bg-clip-text text-xs font-medium text-transparent sm:text-sm dark:from-muted-foreground/40 dark:via-muted-foreground dark:to-muted-foreground/40"
+        >
+          {label}
+        </span>
+      </div>
+    </>
+  )
+
+  if (freePlacement) {
+    return (
+      <div
+        className="pointer-events-none relative h-full w-full"
+        style={{ containerType: "size" }}
+        role="status"
+        aria-live="polite"
+        aria-label={label}
+      >
+        <div
+          data-editor-shadow-filter-target
+          data-editor-shadow-filter-base={shadowFilter || ""}
+          className={shellClass}
+          style={{
+            ...boxStyle,
+            left: `var(${MAIN_BARE_LEFT_VAR}, ${freePlacement.left}px)`,
+            top: `var(${MAIN_BARE_TOP_VAR}, ${freePlacement.top}px)`,
+            width: freePlacement.width,
+            height: freePlacement.height,
+            maxWidth: "none",
+            maxHeight: "none",
+            transform: transform || undefined,
+            transformOrigin: "center",
+            transformStyle: "preserve-3d",
+            filter: shadowDropFilterPreviewCss(shadowFilter) || undefined,
+          }}
+        >
+          {content}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div
       className="pointer-events-none relative h-full w-full"
@@ -63,10 +124,7 @@ export function MediaPreparingState({
       <div
         data-editor-shadow-filter-target
         data-editor-shadow-filter-base={shadowFilter || ""}
-        className={cn(
-          "absolute top-0 left-0 max-h-full max-w-full overflow-hidden select-none",
-          "rounded-3xl border border-border/40"
-        )}
+        className={cn(shellClass, "max-h-full max-w-full")}
         style={{
           ...fitStyle,
           ...boxStyle,
@@ -82,16 +140,7 @@ export function MediaPreparingState({
           filter: shadowDropFilterPreviewCss(shadowFilter) || undefined,
         }}
       >
-        <InnerLightingOverlay style={innerLightingStyle} />
-        <ShimmerBox className="absolute inset-0 size-full rounded-3xl" />
-        <div className="absolute inset-0 flex items-center justify-center px-4">
-          <span
-            aria-hidden
-            className="animate-text-shimmer bg-linear-to-r from-muted-foreground/45 via-foreground/70 to-muted-foreground/45 bg-clip-text text-xs font-medium text-transparent sm:text-sm dark:from-muted-foreground/40 dark:via-muted-foreground dark:to-muted-foreground/40"
-          >
-            {label}
-          </span>
-        </div>
+        {content}
       </div>
     </div>
   )

--- a/components/editor/inspector/primitives.tsx
+++ b/components/editor/inspector/primitives.tsx
@@ -188,9 +188,12 @@ export function ColorPresetGrid({
             <span
               className="block size-full rounded-[inherit]"
               style={{
-                background: isCustom ? customColor : "transparent",
+                // Longhands only — mixing `background` + `backgroundImage`
+                // across isCustom toggles triggers React's shorthand conflict
+                // warning and can leave a stale gradient under a solid color.
+                backgroundColor: isCustom ? customColor : "transparent",
                 backgroundImage: isCustom
-                  ? undefined
+                  ? "none"
                   : "conic-gradient(from 180deg at 50% 50%, #f87171, #fbbf24, #34d399, #60a5fa, #a78bfa, #f472b6, #f87171)",
               }}
             />

--- a/components/editor/text-toolbar.tsx
+++ b/components/editor/text-toolbar.tsx
@@ -699,9 +699,11 @@ function TextBorderSettings({
               <span
                 className="block size-full rounded-full"
                 style={{
-                  background: isCustomColor ? currentColor : undefined,
+                  // Longhands only — don't mix `background` + `backgroundImage`
+                  // or React warns and a stale gradient can stick under solids.
+                  backgroundColor: isCustomColor ? currentColor : "transparent",
                   backgroundImage: isCustomColor
-                    ? undefined
+                    ? "none"
                     : "conic-gradient(from 180deg, #f87171, #fbbf24, #34d399, #60a5fa, #a78bfa, #f472b6, #f87171)",
                 }}
               />

--- a/tests/components/editor/canvas-empty-state.test.tsx
+++ b/tests/components/editor/canvas-empty-state.test.tsx
@@ -65,4 +65,27 @@ describe("CanvasEmptyState", () => {
     expect(positioned).not.toBeNull()
     expect(positioned.style.transform).toContain("translate(-50%, -50%)")
   })
+
+  it("prefers bare free placement over frame-style anchor positioning", () => {
+    const { container } = render(
+      <CanvasEmptyState
+        isDragOver={false}
+        onBrowse={() => {}}
+        screenshotAnchor={{ x: 100, y: 100 }}
+        freePlacement={{ left: 12, top: 34, width: 200, height: 120 }}
+        transform="perspective(1400px) scale(1.16)"
+      />
+    )
+    const positioned = container.querySelector(
+      "[data-editor-shadow-filter-target]"
+    ) as HTMLElement
+    expect(positioned).not.toBeNull()
+    // Free placement uses pixel left/top (via live-preview vars) — not the
+    // frame translate(-50%, -50%) centering used by device mockups.
+    expect(positioned.style.left).toContain("12px")
+    expect(positioned.style.top).toContain("34px")
+    expect(positioned.style.width).toBe("200px")
+    expect(positioned.style.height).toBe("120px")
+    expect(positioned.style.transform).toBe("perspective(1400px) scale(1.16)")
+  })
 })


### PR DESCRIPTION
## Summary

- **Bare empty placement matches filled screenshots.** No-frame empty (and GIF preparing) placeholders now use the same free-placement left/top/size math as `ScreenshotBare`, so templates with corner anchors, offsets, tilt, and non-100% scale (e.g. Silent Reveal) no longer jump when a screenshot is added.
- **Stale Auto aspect after delete.** While empty, ignore previous media `naturalDims` so Auto-aspect empty boxes don’t keep a tall capture’s ratio as a thin vertical strip after delete or applying another template.
- **Custom color swatches.** Inspector/text-toolbar custom color tiles always set `backgroundColor` + `backgroundImage` longhands (with `none` when solid) so React stops warning about mixing `background` and `backgroundImage` across re-renders.

## Test plan

- [ ] Apply **Silent Reveal** with no screenshot — empty box sits where media will land (corner + tilt/scale/offset)
- [ ] Add a screenshot — no position/size jump
- [ ] Delete the screenshot — empty box is a normal full-stage placeholder, not a thin vertical strip
- [ ] Apply **Screenshot, Glow** after delete — empty remains normal size/position
- [ ] Toggle custom vs preset colors in inspector (border/shadow) and text border color — no console warning about `background` / `backgroundImage`
- [ ] Drag empty bare placeholder — still tracks pointer via live-preview bare left/top vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved positioning for empty and loading canvases, preventing jumps and preserving pointer alignment during previews and dragging.
  - Prevented stale aspect ratios from affecting canvas sizing after deletions or template changes.
  - Fixed custom color swatches when switching between custom and preset colors.

- **Tests**
  - Added coverage confirming free-placement positioning takes precedence over frame-based positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves empty-media placement consistency and removes React color-style warnings.
- Positions bare empty and GIF-preparing placeholders using the same sizing, anchoring, scaling, and live-drag variables as rendered bare screenshots.
- Ignores stale media dimensions when no screenshot is active, restoring the default Auto-aspect placeholder after deletion.
- Uses explicit background longhands for custom color swatches.
- Adds coverage for free-placement precedence and geometry.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete regressions identified in the changed paths.

The new placement calculations align empty and preparing states with the rendered bare-media geometry, stale dimensions are excluded only when media is absent, and the swatch changes consistently assign nonconflicting CSS longhands.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| components/editor/canvas/canvas-view.tsx | Computes bare placeholder placement from canvas geometry, gates natural dimensions on active media, and connects empty-state drag previews without an identified defect. |
| components/editor/canvas/canvas-empty-state.tsx | Adds a free-placement rendering branch aligned with ScreenshotBare while preserving framed and flow layouts. |
| components/editor/canvas/media-preparing-state.tsx | Applies the same free-placement behavior to media-preparation placeholders. |
| components/editor/inspector/primitives.tsx | Replaces conflicting background shorthand usage with stable color and image longhands. |
| components/editor/text-toolbar.tsx | Applies the same longhand style correction to custom text-border swatches. |
| tests/components/editor/canvas-empty-state.test.tsx | Verifies free placement takes precedence over frame-style anchor positioning and preserves explicit geometry and transforms. |

<sub>Reviews (1): Last reviewed commit: ["fix: align bare empty placement with scr..."](https://github.com/shivabhattacharjee/tokokino/commit/5f08e8a77c0696809f6c24183c4584461cbbb57c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46971786)</sub>

<!-- /greptile_comment -->