### PR TITLE
fix(export): render video frames at export resolution, keep MP4 audio playable

### DIFF
--- a/components/landing/nav.tsx
+++ b/components/landing/nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { useEffect, useState } from "react"
+import { useEffect, useState, useSyncExternalStore } from "react"
 import { createPortal } from "react-dom"
 import { motion, AnimatePresence } from "motion/react"
 import { useTheme } from "next-themes"
@@ -25,16 +25,24 @@ const links = [
   { label: "Contact", href: "#contact" },
 ]
 
+/**
+ * False on the server and through hydration, true on the client — the gate the
+ * portal needs, without the extra render a mount effect costs.
+ */
+function useMounted() {
+  return useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  )
+}
+
 export function Nav() {
   const pathname = usePathname()
   const showRails = pathname === "/"
   const [open, setOpen] = useState(false)
-  const [mounted, setMounted] = useState(false)
+  const mounted = useMounted()
   const { resolvedTheme, setTheme } = useTheme()
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
 
   useEffect(() => {
     if (!open) return

--- a/lib/editor/animation-export/animation-audio.ts
+++ b/lib/editor/animation-export/animation-audio.ts
@@ -29,7 +29,7 @@ import {
 import { throwIfAborted } from "./utils"
 import type { VideoSegment } from "./video-layer"
 import {
-  preferredAudioCodecs,
+  containerAudioCodecs,
   prepareSourceAudio,
   type SourceAudioFeed,
 } from "./video-media/audio"
@@ -108,9 +108,9 @@ export async function prepareAnimationAudio({
       return null
     }
 
-    const supported = outputFormat.getSupportedAudioCodecs()
-    const candidates = preferredAudioCodecs(format).filter((c) =>
-      supported.includes(c)
+    const candidates = containerAudioCodecs(
+      format,
+      outputFormat.getSupportedAudioCodecs()
     )
     if (candidates.length === 0) {
       input.dispose()

--- a/lib/editor/animation-export/video-media/audio.ts
+++ b/lib/editor/animation-export/video-media/audio.ts
@@ -2,7 +2,8 @@
  * Source-clip audio for the video-media export.
  *
  * MP4/WebM carry the source clip's audio when present: remux (passthrough) when
- * the codec fits the container, otherwise re-encode to AAC (MP4) or Opus (WebM).
+ * the codec is one the container is expected to carry (see
+ * `containerAudioCodecs`), otherwise re-encode to AAC (MP4) or Opus (WebM).
  * GIF has no audio track by nature.
  */
 
@@ -34,6 +35,26 @@ export function preferredAudioCodecs(format: "mp4" | "webm"): AudioCodec[] {
     : (["opus", "vorbis"] as AudioCodec[])
 }
 
+/**
+ * The codecs this export will actually put in `format` — deliberately narrower
+ * than what the muxer accepts.
+ *
+ * Mediabunny's MP4 muxer can write Opus, FLAC and PCM. Players and uploaders
+ * don't follow: X/Twitter rejects an MP4 with Opus audio as "incompatible audio
+ * codecs", as do QuickTime and most NLEs. Any WebM/MKV source clip carries Opus,
+ * so without this narrowing the common "record in the browser → export MP4"
+ * path produces a file no one will take. (WebM's own list is already spec-tight;
+ * routing it through here keeps remux and re-encode judged against one list.)
+ */
+export function containerAudioCodecs(
+  format: "mp4" | "webm",
+  supported: readonly AudioCodec[]
+): AudioCodec[] {
+  return preferredAudioCodecs(format).filter((codec) =>
+    supported.includes(codec)
+  )
+}
+
 /** True when `codec` can be copied into the container without re-encoding. */
 export function canRemuxAudioCodec(
   codec: AudioCodec,
@@ -61,13 +82,11 @@ export function resolveAudioMuxStrategy(
   canDecode: boolean
 ): AudioMuxStrategy {
   if (!sourceCodec) return { kind: "skip" }
-  if (canRemuxAudioCodec(sourceCodec, supported)) {
+  const candidates = containerAudioCodecs(format, supported)
+  if (canRemuxAudioCodec(sourceCodec, candidates)) {
     return { kind: "remux", codec: sourceCodec }
   }
   if (!canDecode) return { kind: "skip" }
-  const candidates = preferredAudioCodecs(format).filter((c) =>
-    supported.includes(c)
-  )
   if (candidates.length === 0) return { kind: "skip" }
   return { kind: "reencode", candidates }
 }
@@ -136,7 +155,10 @@ export async function prepareSourceAudio(
       return null
     }
 
-    const supported = outputFormat.getSupportedAudioCodecs()
+    const supported = containerAudioCodecs(
+      format,
+      outputFormat.getSupportedAudioCodecs()
+    )
     const endSec = Math.max(0, durationSec)
     const boundInput = input
 

--- a/lib/editor/animation-export/video-media/frame-renderer.ts
+++ b/lib/editor/animation-export/video-media/frame-renderer.ts
@@ -61,10 +61,42 @@ export type { UvProjector, UvProjectorH } from "./frame-geometry"
 export type { VideoMediaFx } from "./frame-inner-lighting"
 
 /**
+ * How much bigger than its CSS layout box the decoded-frame buffer should be.
+ *
+ * Sizing that buffer in root CSS px throws the export's resolution away: a 4K
+ * render resamples the video up from the editor's ~900px layout box, so the
+ * chrome around it is sharp and the video itself is HD at best. Render it at the
+ * export's own scale instead — but never past the point where every source pixel
+ * already lands 1:1, beyond which it is memory and encode time for no detail.
+ */
+export function mediaBufferScale(
+  fit: string,
+  localW: number,
+  localH: number,
+  fw: number,
+  fh: number,
+  maxScale: number
+): number {
+  if (localW <= 0 || localH <= 0 || fw <= 0 || fh <= 0) return 1
+  const wRatio = fw / localW
+  const hRatio = fh / localH
+  // The scale at which object-fit maps source pixels 1:1 into the buffer.
+  // `contain` and `fill` are bounded by the tighter axis, `cover` by the looser.
+  const oneToOne =
+    fit === "cover" ? Math.min(wRatio, hRatio) : Math.max(wRatio, hRatio)
+  return Math.min(maxScale, Math.max(1, oneToOne))
+}
+
+/**
  * Paint a decoded frame into a local buffer the size of the shell's layout box,
  * honoring object-fit/object-position and the media's own enhance filter.
  * `media` is the element whose computed styles govern fit/position — the
  * `<video>` here, or the `<img>` standing in for it in the Animate clone.
+ *
+ * `localW`/`localH` and `borderRadius` are buffer pixels, so a caller rendering
+ * above CSS scale must pre-multiply all three. `reuse` lets a per-frame caller
+ * keep one buffer instead of allocating a fresh (at 4K, 8 megapixel) canvas for
+ * every frame.
  */
 export function paintFrameToLocalBox(
   frame: CanvasImageSource,
@@ -74,13 +106,26 @@ export function paintFrameToLocalBox(
   fw: number,
   fh: number,
   borderRadius = 0,
-  mediaFx?: VideoMediaFx | null
+  mediaFx?: VideoMediaFx | null,
+  reuse?: HTMLCanvasElement
 ): HTMLCanvasElement | null {
-  const buf = document.createElement("canvas")
-  buf.width = Math.max(1, Math.round(localW))
-  buf.height = Math.max(1, Math.round(localH))
-  const ctx = buf.getContext("2d", { willReadFrequently: true })
+  const buf = reuse ?? document.createElement("canvas")
+  const width = Math.max(1, Math.round(localW))
+  const height = Math.max(1, Math.round(localH))
+  if (buf.width !== width || buf.height !== height) {
+    buf.width = width
+    buf.height = height
+  }
+  // Draw-only surface — the result is uploaded as a GL texture or blitted, never
+  // read back — so no willReadFrequently, which would force it onto the CPU at
+  // the megapixel counts a 4K export asks for.
+  const ctx = buf.getContext("2d")
   if (!ctx) return null
+  // A reused buffer starts with the previous frame's pixels, and its clip would
+  // otherwise accumulate across frames.
+  ctx.setTransform(1, 0, 0, 1, 0, 0)
+  ctx.clearRect(0, 0, buf.width, buf.height)
+  ctx.save()
 
   const style = getComputedStyle(media)
   const fit = style.objectFit || "contain"
@@ -123,9 +168,10 @@ export function paintFrameToLocalBox(
       : undefined
     if (enhance) ctx.filter = enhance
     ctx.drawImage(frame, 0, 0, fw, fh, dx, dy, dw, dh)
-    ctx.filter = "none"
   } catch {
     return null
+  } finally {
+    ctx.restore()
   }
 
   return buf
@@ -831,6 +877,21 @@ async function createCompositeRenderer(
   // that poke out past the bezel's rounded silhouette (cover/fill especially).
   const shellRadius = resolveVideoClipRadius(video, shell, localW)
 
+  // Render the decoded frames at the export's resolution, not the editor's
+  // layout size — see mediaBufferScale. Both are constant for the whole export,
+  // so the buffer is sized once and reused.
+  const boxW = useQuad ? localW : (region?.destW ?? localW)
+  const boxH = useQuad ? localH : (region?.destH ?? localH)
+  const mediaScale = mediaBufferScale(
+    getComputedStyle(video).objectFit || "contain",
+    boxW,
+    boxH,
+    naturalW,
+    naturalH,
+    scale
+  )
+  const mediaBuffer = document.createElement("canvas")
+
   return async (i: number) => {
     const t = plan.timeForFrame(i)
     const frame = await decoded.getFrameAt(t)
@@ -846,13 +907,14 @@ async function createCompositeRenderer(
           // object-fit but the shell's border-radius.
           const local = paintFrameToLocalBox(
             frame,
-            localW,
-            localH,
+            localW * mediaScale,
+            localH * mediaScale,
             video,
             fw,
             fh,
-            shellRadius,
-            mediaFx
+            shellRadius * mediaScale,
+            mediaFx,
+            mediaBuffer
           )
           if (local) {
             drawImageToQuadWarp(
@@ -868,13 +930,14 @@ async function createCompositeRenderer(
           // AABB path: paint into a local box (with fx) then drawImage that.
           const local = paintFrameToLocalBox(
             frame,
-            region.destW,
-            region.destH,
+            region.destW * mediaScale,
+            region.destH * mediaScale,
             video,
             fw,
             fh,
-            shellRadius,
-            mediaFx
+            shellRadius * mediaScale,
+            mediaFx,
+            mediaBuffer
           )
           const dx = region.destX * scale
           const dy = region.destY * scale

--- a/tests/lib/editor/animation-export/video-media.test.ts
+++ b/tests/lib/editor/animation-export/video-media.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { canvasIsVideoMedia } from "@/lib/editor/animation-export/video-media"
 import {
   canRemuxAudioCodec,
+  containerAudioCodecs,
   exportAudioDurationSec,
   preferredAudioCodecs,
   resolveAudioMuxStrategy,
@@ -19,6 +20,7 @@ import {
 } from "@/lib/editor/animation-export/video-media/encode-gif"
 import {
   chooseQuadSubdivision,
+  mediaBufferScale,
   quadAffineError,
 } from "@/lib/editor/animation-export/video-media/frame-renderer"
 import { planFrames } from "@/lib/editor/animation-export/video-media/frames"
@@ -124,6 +126,17 @@ describe("preferredAudioCodecs / canRemuxAudioCodec — audio mux strategy", () 
       expect(webm).toContain(codec)
     }
   })
+
+  it("narrows the muxer's codec list to what players actually accept", () => {
+    // Mediabunny's MP4 muxer will happily write Opus (and FLAC, and PCM); X and
+    // QuickTime will not. WebM's own list is already spec-tight.
+    const mp4 = new Mp4OutputFormat().getSupportedAudioCodecs()
+    const webm = new WebMOutputFormat().getSupportedAudioCodecs()
+    expect(mp4).toContain("opus")
+    expect(mp4).toContain("flac")
+    expect(containerAudioCodecs("mp4", mp4)).toEqual(["aac", "mp3"])
+    expect(containerAudioCodecs("webm", webm)).toEqual(["opus", "vorbis"])
+  })
 })
 
 describe("resolveAudioMuxStrategy — remux / re-encode / skip", () => {
@@ -147,6 +160,23 @@ describe("resolveAudioMuxStrategy — remux / re-encode / skip", () => {
     expect(
       resolveAudioMuxStrategy("opus", "webm", webmSupported, false)
     ).toEqual({ kind: "remux", codec: "opus" })
+  })
+
+  it("re-encodes Opus → MP4 to AAC even though the muxer would take Opus", () => {
+    // Remuxing here is what makes X reject the upload with "incompatible audio
+    // codecs"; every WebM source clip carries Opus.
+    expect(resolveAudioMuxStrategy("opus", "mp4", mp4Supported, true)).toEqual({
+      kind: "reencode",
+      candidates: ["aac", "mp3"],
+    })
+  })
+
+  it("goes silent rather than writing Opus into MP4 when it can't decode", () => {
+    expect(resolveAudioMuxStrategy("opus", "mp4", mp4Supported, false)).toEqual(
+      {
+        kind: "skip",
+      }
+    )
   })
 
   it("re-encodes AAC → WebM to Opus/Vorbis when decode is available", () => {
@@ -571,6 +601,44 @@ describe("export stack visibility", () => {
       foreground: 1,
       videos: 1,
     })
+  })
+})
+
+describe("mediaBufferScale — decoded frames at export resolution", () => {
+  // A 1080p clip in a 900×506 CSS box, exported at 4K (scale ≈ 4.27).
+  const localW = 900
+  const localH = 506
+  const fw = 1920
+  const fh = 1080
+
+  it("renders at the export scale instead of the editor's layout size", () => {
+    // The bug: the buffer was fixed at 1× (900px wide) whatever the export
+    // resolution, so 4K was a 900px video resampled up.
+    expect(
+      mediaBufferScale("contain", localW, localH, fw, fh, 4.27)
+    ).toBeCloseTo(2.13, 2)
+  })
+
+  it("stops once every source pixel lands 1:1", () => {
+    // Past 2.13× here the source has nothing more to give.
+    expect(mediaBufferScale("contain", localW, localH, fw, fh, 8)).toBeCloseTo(
+      2.13,
+      2
+    )
+  })
+
+  it("takes the looser axis for cover, the tighter one otherwise", () => {
+    // 1:1 box, 2:1 source. cover crops the sides (height binds), contain and
+    // fill letterbox (width binds).
+    expect(mediaBufferScale("cover", 100, 100, 2000, 1000, 100)).toBe(10)
+    expect(mediaBufferScale("contain", 100, 100, 2000, 1000, 100)).toBe(20)
+    expect(mediaBufferScale("fill", 100, 100, 2000, 1000, 100)).toBe(20)
+  })
+
+  it("never shrinks below the CSS box, and survives degenerate input", () => {
+    expect(mediaBufferScale("contain", 900, 506, 320, 180, 4)).toBe(1)
+    expect(mediaBufferScale("contain", 0, 506, 1920, 1080, 4)).toBe(1)
+    expect(mediaBufferScale("contain", 900, 506, 1920, 0, 4)).toBe(1)
   })
 })
 

--- a/wiki/core/animation-export.md
+++ b/wiki/core/animation-export.md
@@ -226,12 +226,14 @@ flowchart TD
 ```mermaid
 flowchart TD
   Q{"Timeline vs source?"}
-  Q -->|untouched| PASS["Passthrough remux"]
+  Q -->|untouched| PASS["Passthrough remux<br/>only if container-compatible"]
   Q -->|trimmed / shifted| RETIME["Re-encode / segment-aware retiming"]
   PASS --> MUX["Mux into Mediabunny output"]
   RETIME --> MUX
   MUX -->|audio missing / unusable| SILENT["Silent export — never fail the whole job"]
 ```
+
+Both branches pick codecs through `containerAudioCodecs` (AAC/MP3 for MP4, Opus/Vorbis for WebM) rather than the muxer's own capability list — see [video-export.md](./video-export.md#encode--audio) for why Opus-in-MP4 has to be re-encoded.
 
 MediaRecorder fallback has **no** audio.
 

--- a/wiki/core/video-export.md
+++ b/wiki/core/video-export.md
@@ -117,6 +117,8 @@ flowchart TB
 
 Export stack visibility is toggled via `data-export-stack` (`export-stack.ts`) so html-to-image can capture underlay and foreground as separate passes without the live video in the way.
 
+The decoded frame is painted into its own buffer before being warped into the scene, and that buffer is sized by `mediaBufferScale` — the export's scale (`exportWidth / cssWidth`), capped where source pixels already land 1:1. Sizing it in CSS px instead caps every export at the editor's layout width, which is what made 4K exports come back with sharp chrome around a soft video. One buffer is allocated for the whole export and reused per frame.
+
 ---
 
 ## Frame renderer paths
@@ -144,6 +146,7 @@ flowchart TD
 | Seamless perspective warp | `warp-gl.ts` (avoids Canvas2D seam lattice) |
 | Untransformed texture + warp | `captureProjectedElementTexture` / `warpProjectedTexture` (exported; Animate reuses) |
 | Local media box paint | `paintFrameToLocalBox` (video or stand-in `<img>`) |
+| Media buffer resolution | `mediaBufferScale` — buffer is sized at the export scale, not the CSS box |
 | Inner lighting on WebKit | `frame-inner-lighting.ts` |
 | Canvas probes / copies | `frame-canvas-utils.ts` |
 | Stack show/hide | `export-stack.ts` |
@@ -180,7 +183,7 @@ flowchart LR
   PLAN["FramePlan<br/>frameCount = duration × fps"] --> GIF["encode-gif.ts<br/>MAX_GIF_TOTAL_PIXELS guard"]
   PLAN --> VID["encode-video.ts<br/>MP4 / WebM Mediabunny"]
   AUD["prepareSourceAudio"] --> VID
-  AUD -->|"remux if possible"| MUX["Mux"]
+  AUD -->|"remux if codec is container-compatible"| MUX["Mux"]
   AUD -->|"else re-encode"| MUX
   AUD -->|"unusable"| SILENT["Silent track"]
 ```
@@ -191,7 +194,10 @@ flowchart LR
 | GIF memory | `MAX_GIF_TOTAL_PIXELS ≈ 350e6` OOM guard |
 | Audio length | `exportAudioDurationSec(plan)` — matches styled frame count, not raw clip length |
 | Audio failure | Silent export; never fail the job |
-| Codecs | Same Mediabunny preferences as keyframe path (avc/hevc/av1, vp9/vp8/av1) |
+| Video codecs | Same Mediabunny preferences as keyframe path (avc/hevc/av1, vp9/vp8/av1) |
+| Audio codecs | `containerAudioCodecs` — AAC/MP3 for MP4, Opus/Vorbis for WebM |
+
+Remux is judged against `containerAudioCodecs`, **not** the muxer's own capability list. Mediabunny's MP4 muxer will write Opus, FLAC and PCM; X, QuickTime and most NLEs reject those, so an Opus source (i.e. any WebM/MKV clip) is re-encoded to AAC rather than copied through. The keyframe path applies the same narrowing via `animation-audio.ts`.
 
 ---
 


### PR DESCRIPTION
## Summary

Two bugs in the video-media export path (a plain video canvas outside Animate mode), both hit while exporting an MP4 to upload to X:

1. **4K export produced low-res video.** Decoded frames were painted into a buffer sized in the editor's on-screen CSS box, then warped up to the export canvas — so the styled chrome was captured at 3840px while the video inside it was rendered at ~900px and resampled. HD, Full HD and 4K all produced identical video detail.
2. **X rejected the upload with "incompatible audio codecs".** Remux was judged against what the muxer *can* write, and mediabunny's MP4 muxer accepts Opus. Every WebM/MKV source clip carries Opus, so "import a browser recording → export MP4" wrote Opus-in-MP4 — legal ISO-BMFF, but rejected by X, QuickTime and most NLEs.

## Type of Change

- [x] fix
- [ ] refactor
- [ ] delete
- [ ] optimised
- [ ] docs

## Related Issues

<!-- none -->

## Changes Made

**Resolution — `lib/editor/animation-export/video-media/frame-renderer.ts`**

- New `mediaBufferScale()` sizes the decoded-frame buffer by the export's own scale (`exportWidth / cssWidth`) rather than leaving it at 1×, capped at the point where source pixels land 1:1 so a 1080p clip doesn't allocate a 4K buffer for nothing. `cover` is bounded by the looser axis, `contain`/`fill` by the tighter one.
- Both composite call sites (perspective-quad and AABB) now pass `localW * mediaScale`, `localH * mediaScale` and `shellRadius * mediaScale`.
- `paintFrameToLocalBox` takes an optional reusable canvas — one buffer for the whole export instead of a fresh megapixel canvas per frame — and dropped `willReadFrequently` from it, which would force a draw-only surface onto the CPU at 4K sizes.

The WebKit layered path (`webkit-layered-frame.ts:276`) already multiplied by `scale`; that call site is what identified the omission.

**Audio — `lib/editor/animation-export/video-media/audio.ts`**

- New `containerAudioCodecs(format, supported)` narrows the muxer's list to what the container is actually expected to carry: AAC/MP3 for MP4, Opus/Vorbis for WebM.
- `resolveAudioMuxStrategy` and the passthrough branch in `prepareSourceAudio` both judge remux against that list, so an Opus source re-encodes to AAC instead of being copied through.
- Animate mode's separate audio module (`animation-audio.ts`) routes through the same helper, covering both its untouched-timeline and re-timed branches.

**Scope notes**

- The Animate-mode export paths did not have the resolution bug — Chromium rasterizes the frame `<img>` at native size, WebKit already scaled its buffer — so only the audio change touches them.
- Also included, as separate commits: `components/landing/nav.tsx` swaps a `setMounted(true)` mount effect for `useSyncExternalStore`, clearing the repo's only lint warning so `pnpm lint:strict` passes; and `wiki/core/video-export.md` / `animation-export.md` are updated, since both documented remux as "if possible" and neither described the media buffer's resolution.

**Not fixed here:** the video's ceiling is still the source clip's own resolution — a 1080p recording exported at 4K now uses all 1920 of its pixels instead of ~900, but won't invent more. Separately, X caps uploads at 1920×1200, so Full HD remains the right setting for that target regardless of these fixes.

## Screenshots / Recordings (if UI)

Not attached — verifying the resolution change means exporting a video and comparing pixels, which needs a real browser run rather than a screenshot.

## Checklist

- [x] I ran `pnpm lint`
- [x] I ran `pnpm typecheck`
- [x] I ran `pnpm test`
- [x] I did not include secrets or sensitive data
- [x] I updated docs when behavior changed
- [x] I kept this PR focused and reasonably small

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animation and video export compatibility by preventing unsupported audio codecs from being passed through to incompatible containers.
  * Opus audio is now re-encoded or omitted appropriately during MP4 exports.
  * Improved exported video frame quality by rendering at the effective export scale.
  * Reduced rendering overhead by reusing video frame buffers.

* **Documentation**
  * Clarified audio compatibility, remuxing, and video buffer-sizing behavior in export documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves video-media export fidelity and MP4 audio compatibility.
- Renders decoded video frames into reusable buffers sized for the export resolution while respecting source-resolution limits.
- Restricts remuxed and re-encoded audio to broadly compatible container codecs across plain-video and Animate exports.
- Replaces the navigation mount effect with a hydration-safe external-store gate.
- Adds regression tests and updates video-export documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security failures identified.

The changed rendering paths preserve their coordinate and lifecycle contracts, while codec selection consistently prevents incompatible passthrough and retains established graceful fallback behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/editor/animation-export/video-media/frame-renderer.ts | Adds export-aware media-buffer scaling and safe per-frame canvas reuse while preserving object-fit, clipping, and warp coordinate mappings. |
| lib/editor/animation-export/video-media/audio.ts | Narrows audio remux and encoding choices to compatible MP4 and WebM codec sets, with existing best-effort silence behavior retained when conversion is unavailable. |
| lib/editor/animation-export/animation-audio.ts | Applies the same container-compatible codec selection to untouched and retimed Animate audio paths. |
| components/landing/nav.tsx | Replaces effect-driven mounted state with a server-snapshot-aware useSyncExternalStore hydration gate. |
| tests/lib/editor/animation-export/video-media.test.ts | Adds focused regression coverage for container codec narrowing and export-resolution media-buffer scaling. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(wiki): record the media buffer scal..."](https://github.com/shivabhattacharjee/tokokino/commit/8e9bba9e3eeba8f6edd7523118d0a7f8edfced19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47349478)</sub>

<!-- /greptile_comment -->