### PR TITLE
fix(export): WebKit foreignObject scaling and projected-texture crop

### DIFF
--- a/lib/editor/animation-export/video-media/frame-canvas-utils.ts
+++ b/lib/editor/animation-export/video-media/frame-canvas-utils.ts
@@ -74,10 +74,20 @@ export function nonBlackPct(canvas: HTMLCanvasElement): number {
 }
 
 /**
- * How far this element's shadows reach beyond its border box, in CSS px.
+ * How far this element's decoration reaches beyond its border box, in CSS px.
  *
- * Colour functions are stripped first so their commas don't break the
+ * This is the margin a projected texture has to bake around the box, so it must
+ * cover everything that paints outside it and is therefore invisible to
+ * `getBoundingClientRect()`.
+ *
+ * Shadows: colour functions are stripped first so their commas don't break the
  * per-shadow split and their numbers aren't mistaken for lengths.
+ *
+ * Outline: the screenshot's "border" is an `outline` sitting `outline-offset`
+ * clear of the edge (see `buildScreenshotImageStyle`), not a CSS border. Layout
+ * ignores it entirely, so leaving it out of the padding cropped the border off
+ * the texture — the video then ran to the very edge of the plate instead of
+ * sitting inside it.
  */
 export function shadowExtentPx(el: HTMLElement): number {
   const cs = getComputedStyle(el)
@@ -95,5 +105,13 @@ export function shadowExtentPx(el: HTMLElement): number {
       )
     }
   }
+
+  const outlineWidth = parseFloat(cs.outlineWidth) || 0
+  if (cs.outlineStyle && cs.outlineStyle !== "none" && outlineWidth > 0) {
+    // A negative offset pulls the outline inward, where it needs no margin.
+    const outlineOffset = Math.max(0, parseFloat(cs.outlineOffset) || 0)
+    max = Math.max(max, outlineWidth + outlineOffset)
+  }
+
   return Math.ceil(max)
 }

--- a/lib/editor/animation-export/video-media/frame-renderer.ts
+++ b/lib/editor/animation-export/video-media/frame-renderer.ts
@@ -335,6 +335,21 @@ function overlayVideoFrameImage(
   }
 }
 
+/**
+ * The largest margin a projected texture can carry on each side and still fit
+ * inside the capture canvas. See {@link captureProjectedElementTexture}.
+ */
+export function fittedTexturePad(
+  rootW: number,
+  rootH: number,
+  localW: number,
+  localH: number
+): number {
+  return Math.floor(
+    Math.max(0, Math.min((rootW - localW) / 2, (rootH - localH) / 2))
+  )
+}
+
 /** Untransformed padded raster of a projected element, plus its geometry. */
 export type ProjectedElementTexture = {
   texture: HTMLCanvasElement
@@ -370,10 +385,24 @@ export async function captureProjectedElementTexture(
 ): Promise<ProjectedElementTexture | null> {
   const { el, carrier, quad } = layer
 
-  // box-shadow / drop-shadow paint outside the border box and are transformed
-  // with the element, so the texture has to include them or a tilted shadow gets
-  // sheared off at the box edge.
-  const pad = shadowExtentPx(el)
+  const rootRect = capture.node.getBoundingClientRect()
+
+  // box-shadow / drop-shadow and the border outline paint outside the border box
+  // and are transformed with the element, so the texture has to include them or
+  // a tilted shadow gets sheared off at the box edge.
+  //
+  // The margin is capped to what the canvas can actually supply. The raster only
+  // covers the canvas, and the box is parked at (pad, pad) before it is cropped:
+  // a padded box larger than the canvas runs off the far edges, and drawImage
+  // returns transparent for the out-of-bounds part rather than failing. Left and
+  // top start at 0 and survive; right and bottom silently lose the whole margin
+  // — which is where the border and shadow live — so the plate came back missing
+  // its border on exactly those two sides. Anything past the canvas edge is
+  // clipped in the real render too, so capping costs nothing that was visible.
+  const pad = Math.min(
+    shadowExtentPx(el),
+    fittedTexturePad(rootRect.width, rootRect.height, quad.localW, quad.localH)
+  )
 
   const restoreVisibility = applyExportStackVisibility(
     capture.node,
@@ -403,7 +432,6 @@ export async function captureProjectedElementTexture(
   // survives only as its top-left corner. So place the box at a known spot and
   // crop where it actually lands, rather than trusting it to stay put.
   carrier.style.transform = IDENTITY_TRANSFORM
-  const rootRect = capture.node.getBoundingClientRect()
   const loose = el.getBoundingClientRect()
   const dx = -(loose.left - rootRect.left) + pad
   const dy = -(loose.top - rootRect.top) + pad
@@ -436,8 +464,16 @@ export async function captureProjectedElementTexture(
   // Lift the placed box (plus the shadow margin) out as the quad texture.
   const boxW = quad.localW + pad * 2
   const boxH = quad.localH + pad * 2
-  const cropW = Math.max(1, Math.round(boxW * scale))
-  const cropH = Math.max(1, Math.round(boxH * scale))
+  // Never read past the raster: an overhanging source rect comes back
+  // transparent on that side rather than erroring.
+  const cropW = Math.max(
+    1,
+    Math.min(Math.round(boxW * scale), raster.width - cropX)
+  )
+  const cropH = Math.max(
+    1,
+    Math.min(Math.round(boxH * scale), raster.height - cropY)
+  )
   const local = document.createElement("canvas")
   local.width = cropW
   local.height = cropH

--- a/lib/editor/animation-export/webkit-layered-frame.ts
+++ b/lib/editor/animation-export/webkit-layered-frame.ts
@@ -44,6 +44,7 @@ import {
 import { copyCanvas, sleep } from "./video-media/frame-canvas-utils"
 import {
   collectProjectedLayers,
+  resolveVideoClipRadius,
   type ProjectedLayer,
 } from "./video-media/frame-geometry"
 import {
@@ -260,7 +261,8 @@ async function composeShellWithVideo(
   videoLayer: CloneVideoLayer,
   timelineMs: number,
   enhance: EnhancePreset | undefined,
-  scale: number
+  scale: number,
+  shell: HTMLElement
 ): Promise<HTMLCanvasElement> {
   if (!tex.mediaBox) return tex.texture
   const frame = await videoLayer.getFrame(timelineMs)
@@ -270,7 +272,11 @@ async function composeShellWithVideo(
   if (!fw || !fh) return tex.texture
 
   const media = videoLayer.mediaElement
-  const radius = (parseFloat(getComputedStyle(media).borderRadius) || 0) * scale
+  // The rounding that clips the media usually lives on an ancestor plate, not on
+  // the media element itself — reading only the element's own radius left the
+  // video with square corners poking past the rounded border. Same walk the
+  // video-media compositor uses, normalized to the media box then to texture px.
+  const radius = resolveVideoClipRadius(media, shell, tex.mediaBox.w) * scale
   const local = paintFrameToLocalBox(
     frame,
     tex.mediaBox.w * scale,
@@ -408,7 +414,8 @@ export async function captureLayeredAnimationFrame(
             videoLayer,
             timelineMs,
             enhance,
-            scale
+            scale,
+            layer.el
           )
         : entry.tex.texture
     const projected = warpProjectedTexture(

--- a/lib/editor/export.ts
+++ b/lib/editor/export.ts
@@ -650,7 +650,7 @@ export async function exportCanvas(
     ? [...preloadUrls, WATERMARK_LOGO_SRC]
     : preloadUrls
 
-  // No pixelRatio — rasterizeNodeToCanvas owns the scale (see withSvgOutputSize).
+  // No pixelRatio — rasterizeNodeToCanvas owns the scale (see exportScaleStyle).
   const baseOptions = {
     cacheBust: false,
     filter: filterExportHidden,

--- a/lib/editor/export.ts
+++ b/lib/editor/export.ts
@@ -1,4 +1,4 @@
-import { toJpeg, toBlob, toCanvas, getFontEmbedCSS } from "html-to-image"
+import { toSvg, getFontEmbedCSS } from "html-to-image"
 
 import { triggerAnchorDownload } from "@/lib/download"
 import { supportsObjectViewBox } from "./crop-utils"
@@ -480,19 +480,18 @@ function getNodeBorderRadius(node: HTMLElement): number {
   return parseFloat(getComputedStyle(node).borderTopLeftRadius) || 0
 }
 
-async function clipBlobToRoundedRect(
-  blob: Blob,
-  width: number,
-  height: number,
+async function clipCanvasToRoundedRect(
+  source: HTMLCanvasElement,
   radius: number
 ): Promise<Blob> {
-  if (radius <= 0) return blob
-  const bitmap = await createImageBitmap(blob)
+  const width = source.width
+  const height = source.height
+  if (radius <= 0) return canvasToBlob(source, "image/png")
   const canvas = document.createElement("canvas")
   canvas.width = width
   canvas.height = height
   const ctx = canvas.getContext("2d")
-  if (!ctx) return blob
+  if (!ctx) return canvasToBlob(source, "image/png")
   const r = Math.min(radius, width / 2, height / 2)
   ctx.beginPath()
   if (typeof ctx.roundRect === "function") {
@@ -510,13 +509,8 @@ async function clipBlobToRoundedRect(
     ctx.closePath()
   }
   ctx.clip()
-  ctx.drawImage(bitmap, 0, 0)
-  return new Promise<Blob>((resolve, reject) => {
-    canvas.toBlob(
-      (b) => (b ? resolve(b) : reject(new Error("clip failed"))),
-      "image/png"
-    )
-  })
+  ctx.drawImage(source, 0, 0)
+  return canvasToBlob(canvas, "image/png")
 }
 
 function filterExportHidden(node: Node) {
@@ -524,6 +518,106 @@ function filterExportHidden(node: Node) {
     if (node.getAttribute("data-export-hidden") === "true") return false
   }
   return true
+}
+
+type RasterOptions = {
+  cacheBust?: boolean
+  filter?: (node: Node) => boolean
+}
+
+/**
+ * The `<foreignObject>` scaling contract, shared by both capture paths.
+ *
+ * WebKit rasterizes foreignObject content at the size the content itself claims
+ * and applies neither `drawImage`'s destination rect nor the SVG's `viewBox`
+ * transform to the result. Both are how you would normally scale an export up,
+ * and both left the whole scene at 1× in the top-left of an otherwise correctly
+ * sized raster — while anything composited in 2D afterwards (the video quad,
+ * whose scale is derived from the raster's width) came out oversized by exactly
+ * the pixel ratio.
+ *
+ * So the SVG stays 1:1 with the output and the *content* is scaled by an
+ * ordinary CSS transform, which every engine rasterizes correctly. The box keeps
+ * its layout size so `cqw`/`cqh` and percentage geometry still resolve against
+ * the dimensions the editor laid out.
+ */
+export function exportScaleStyle(
+  renderedWidth: number,
+  renderedHeight: number,
+  scale: number
+) {
+  return {
+    width: `${renderedWidth}px`,
+    height: `${renderedHeight}px`,
+    transform: `scale(${scale})`,
+    transformOrigin: "0 0",
+  }
+}
+
+/**
+ * Rasterize an export clone at `outputWidth`×`outputHeight`.
+ *
+ * Replaces html-to-image's `toCanvas`/`toBlob`/`toJpeg` — they all scale through
+ * `drawImage`, which WebKit ignores here (see {@link exportScaleStyle}). The
+ * `width`/`height`/`style` options make html-to-image emit an output-sized SVG
+ * whose content carries the scale as a transform. A fresh canvas per call,
+ * matching what those returned — callers hold frames across captures.
+ */
+async function rasterizeNodeToCanvas(
+  node: HTMLElement,
+  options: RasterOptions,
+  renderedWidth: number,
+  renderedHeight: number,
+  outputWidth: number,
+  outputHeight: number,
+  backgroundColor?: string
+): Promise<HTMLCanvasElement> {
+  const svgUrl = await toSvg(node, {
+    ...options,
+    width: outputWidth,
+    height: outputHeight,
+    // Applied after html-to-image's own width/height, so this wins.
+    style: exportScaleStyle(
+      renderedWidth,
+      renderedHeight,
+      outputWidth / renderedWidth
+    ),
+  })
+  // `Image.decode()` rejects on SVG-with-<foreignObject> in some Firefox
+  // builds, so wait on load/error events — reliable in every engine.
+  const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error("Export raster failed to load"))
+    image.src = svgUrl
+  })
+
+  const canvas = document.createElement("canvas")
+  canvas.width = outputWidth
+  canvas.height = outputHeight
+  const ctx = canvas.getContext("2d")
+  if (!ctx) throw new Error("Could not get 2d context for export")
+  if (backgroundColor) {
+    ctx.fillStyle = backgroundColor
+    ctx.fillRect(0, 0, outputWidth, outputHeight)
+  }
+  ctx.drawImage(img, 0, 0, outputWidth, outputHeight)
+  return canvas
+}
+
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality?: number
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) =>
+        blob ? resolve(blob) : reject(new Error(`Could not encode ${type}`)),
+      type,
+      quality
+    )
+  })
 }
 
 export async function exportCanvas(
@@ -556,8 +650,8 @@ export async function exportCanvas(
     ? [...preloadUrls, WATERMARK_LOGO_SRC]
     : preloadUrls
 
+  // No pixelRatio — rasterizeNodeToCanvas owns the scale (see withSvgOutputSize).
   const baseOptions = {
-    pixelRatio,
     cacheBust: false,
     filter: filterExportHidden,
   } as const
@@ -576,12 +670,16 @@ export async function exportCanvas(
     await embedCloneImages(exportTarget.node)
 
     if (format === "png") {
-      const rawBlob = await toBlob(exportTarget.node, baseOptions)
-      if (!rawBlob) throw new Error("Could not capture canvas")
-      const clipped = await clipBlobToRoundedRect(
-        rawBlob,
+      const canvas = await rasterizeNodeToCanvas(
+        exportTarget.node,
+        baseOptions,
+        renderedWidth,
+        renderedHeight,
         outputWidth,
-        outputHeight,
+        outputHeight
+      )
+      const clipped = await clipCanvasToRoundedRect(
+        canvas,
         borderRadius * pixelRatio
       )
       const url = URL.createObjectURL(clipped)
@@ -593,28 +691,28 @@ export async function exportCanvas(
       return filename
     }
     if (format === "jpeg") {
-      const url = await toJpeg(exportTarget.node, {
-        ...baseOptions,
-        backgroundColor: "#ffffff",
-        quality: 0.95,
-      })
+      const canvas = await rasterizeNodeToCanvas(
+        exportTarget.node,
+        baseOptions,
+        renderedWidth,
+        renderedHeight,
+        outputWidth,
+        outputHeight,
+        "#ffffff"
+      )
+      const url = canvas.toDataURL("image/jpeg", 0.95)
       triggerDownload(url, filename)
       return filename
     }
-    // webp — html-to-image doesn't have a direct toWebp, so render to canvas via toBlob (PNG) and re-encode
-    const pngBlob = await toBlob(exportTarget.node, baseOptions)
-    if (!pngBlob) throw new Error("Could not capture canvas")
-    const bitmap = await createImageBitmap(pngBlob)
-    const offscreen = document.createElement("canvas")
-    offscreen.width = bitmap.width
-    offscreen.height = bitmap.height
-    const ctx = offscreen.getContext("2d")
-    if (!ctx) throw new Error("Could not get 2d context")
-    ctx.drawImage(bitmap, 0, 0)
-    const webpBlob: Blob | null = await new Promise((resolve) =>
-      offscreen.toBlob(resolve, "image/webp", 0.95)
+    const canvas = await rasterizeNodeToCanvas(
+      exportTarget.node,
+      baseOptions,
+      renderedWidth,
+      renderedHeight,
+      outputWidth,
+      outputHeight
     )
-    if (!webpBlob) throw new Error("Could not encode WebP")
+    const webpBlob = await canvasToBlob(canvas, "image/webp", 0.95)
     const objectUrl = URL.createObjectURL(webpBlob)
     try {
       triggerDownload(objectUrl, filename)
@@ -757,7 +855,6 @@ export async function prepareAnimationCapture(
   await embedCloneBackgroundImages(exportTarget.node)
 
   const captureOptions = {
-    pixelRatio,
     cacheBust: false,
     filter: filterExportHidden,
   } as const
@@ -765,7 +862,14 @@ export async function prepareAnimationCapture(
   const captureFrame = async () => {
     // html-to-image can return a non-canvas / zero-size value on Safari &
     // Firefox. Validate before handing it to drawImage callers.
-    const canvas = await toCanvas(exportTarget.node, captureOptions)
+    const canvas = await rasterizeNodeToCanvas(
+      exportTarget.node,
+      captureOptions,
+      renderedWidth,
+      renderedHeight,
+      outputWidth,
+      outputHeight
+    )
     if (
       !(canvas instanceof HTMLCanvasElement) ||
       canvas.width <= 0 ||
@@ -979,12 +1083,19 @@ export async function prepareFastAnimationCapture(
   const fontCss = await getFontEmbedCSS(exportTarget.node).catch(() => "")
   const css = `${collectDocumentCss()}\n${fontCss}`
 
+  // The SVG stays 1:1 with the output and a CSS transform on a wrapper carries
+  // the scale — WebKit ignores a viewBox transform on foreignObject content and
+  // would paint the whole scene at 1× in the top-left. See exportScaleStyle.
+  const scaleStyle = exportScaleStyle(renderedWidth, renderedHeight, pixelRatio)
   const svgOpen =
     `<svg xmlns="${SVG_NS}" width="${outputWidth}" height="${outputHeight}"` +
-    ` viewBox="0 0 ${renderedWidth} ${renderedHeight}">` +
-    `<foreignObject x="0" y="0" width="${renderedWidth}" height="${renderedHeight}">` +
-    `<style xmlns="${XHTML_NS}"><![CDATA[${css}]]></style>`
-  const svgClose = `</foreignObject></svg>`
+    ` viewBox="0 0 ${outputWidth} ${outputHeight}">` +
+    `<foreignObject x="0" y="0" width="${outputWidth}" height="${outputHeight}">` +
+    `<style xmlns="${XHTML_NS}"><![CDATA[${css}]]></style>` +
+    `<div xmlns="${XHTML_NS}" style="width:${scaleStyle.width};` +
+    `height:${scaleStyle.height};transform:${scaleStyle.transform};` +
+    `transform-origin:${scaleStyle.transformOrigin};">`
+  const svgClose = `</div></foreignObject></svg>`
   // Pre-encode the constant (large) prefix/suffix so only the small per-frame
   // body is URL-encoded each frame.
   const dataUrlHead = `data:image/svg+xml;charset=utf-8,`
@@ -1019,6 +1130,7 @@ export async function prepareFastAnimationCapture(
       image.src = url
     })
     ctx.clearRect(0, 0, outputWidth, outputHeight)
+    // 1:1 — the SVG is already output-sized, nothing left for drawImage to scale.
     ctx.drawImage(img, 0, 0, outputWidth, outputHeight)
     return frameCanvas
   }
@@ -1071,7 +1183,6 @@ export async function captureCanvasAsPngBlob(
     // html-to-image is flaky on the first call (fonts/images not yet embedded
     // in the cloned document). Two attempts is the standard workaround.
     const captureOptions = {
-      pixelRatio,
       cacheBust: false,
       filter: filterExportHidden,
     } as const
@@ -1080,7 +1191,15 @@ export async function captureCanvasAsPngBlob(
     let lastError: unknown
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
-        blob = await toBlob(exportTarget.node, captureOptions)
+        const canvas = await rasterizeNodeToCanvas(
+          exportTarget.node,
+          captureOptions,
+          renderedWidth,
+          renderedHeight,
+          Math.round(renderedWidth * pixelRatio),
+          Math.round(renderedHeight * pixelRatio)
+        )
+        blob = await canvasToBlob(canvas, "image/png")
         if (blob) break
       } catch (raw) {
         lastError = raw

--- a/tests/lib/editor/animation-export/video-media.test.ts
+++ b/tests/lib/editor/animation-export/video-media.test.ts
@@ -20,9 +20,11 @@ import {
 } from "@/lib/editor/animation-export/video-media/encode-gif"
 import {
   chooseQuadSubdivision,
+  fittedTexturePad,
   mediaBufferScale,
   quadAffineError,
 } from "@/lib/editor/animation-export/video-media/frame-renderer"
+import { shadowExtentPx } from "@/lib/editor/animation-export/video-media/frame-canvas-utils"
 import { planFrames } from "@/lib/editor/animation-export/video-media/frames"
 import { measureVideoRegion } from "@/lib/editor/animation-export/video-media/region"
 import {
@@ -818,5 +820,74 @@ describe("drawImageToQuadGL", () => {
   it("rejects a zero-sized destination", () => {
     const img = document.createElement("canvas")
     expect(drawImageToQuadGL(ctx2d(0, 0), img, 64, 64, quad())).toBe(false)
+  })
+})
+
+describe("shadowExtentPx — texture margin around the border box", () => {
+  const measure = (style: string) => {
+    const el = document.createElement("div")
+    el.setAttribute("style", style)
+    document.body.appendChild(el)
+    try {
+      return shadowExtentPx(el)
+    } finally {
+      el.remove()
+    }
+  }
+
+  it("covers an outline sitting clear of the edge", () => {
+    // The screenshot's "border" is an outline, not a CSS border: layout ignores
+    // it, so without this the plate's border was cropped off the texture and the
+    // video ran to the very edge instead of sitting inside it.
+    expect(
+      measure("outline-width: 8px; outline-style: solid; outline-offset: 3px")
+    ).toBe(11)
+  })
+
+  it("ignores an outline that paints inward", () => {
+    expect(
+      measure("outline-width: 4px; outline-style: solid; outline-offset: -10px")
+    ).toBe(4)
+  })
+
+  it("ignores outline-style: none regardless of width", () => {
+    expect(measure("outline-width: 12px; outline-style: none")).toBe(0)
+  })
+
+  it("takes whichever of shadow and outline reaches further", () => {
+    expect(
+      measure(
+        "box-shadow: 0 0 40px rgba(0,0,0,0.5); outline-width: 8px; outline-style: solid"
+      )
+    ).toBe(40)
+    expect(
+      measure(
+        "box-shadow: 0 0 2px #000; outline-width: 8px; outline-style: solid"
+      )
+    ).toBe(8)
+  })
+})
+
+describe("fittedTexturePad — texture margin must fit the capture canvas", () => {
+  // The raster only covers the canvas and the box is parked at (pad, pad), so a
+  // padded box wider than the canvas overruns the far edges. drawImage returns
+  // transparent there, and the border/shadow vanish on the right and bottom
+  // while left and top stay intact.
+  it("caps the margin to the room the canvas actually has", () => {
+    // The real case: a 1026.69x614.69 shell on a 1100x688 canvas wanted 70px of
+    // shadow margin, needing 1166.69px of a 1100px canvas.
+    expect(fittedTexturePad(1100, 688, 1026.69, 614.69)).toBe(36)
+  })
+
+  it("keeps the whole margin when there is room for it", () => {
+    expect(fittedTexturePad(1000, 800, 400, 300)).toBe(250)
+  })
+
+  it("takes the tighter axis, so neither side overruns", () => {
+    expect(fittedTexturePad(1000, 400, 400, 300)).toBe(50)
+  })
+
+  it("never goes negative when the shell already exceeds the canvas", () => {
+    expect(fittedTexturePad(800, 600, 900, 700)).toBe(0)
   })
 })

--- a/tests/lib/editor/animation-export/webkit-layered-frame.test.ts
+++ b/tests/lib/editor/animation-export/webkit-layered-frame.test.ts
@@ -12,6 +12,7 @@ import type * as FrameCanvasUtils from "@/lib/editor/animation-export/video-medi
 const mocks = vi.hoisted(() => ({
   supportsObjectViewBox: vi.fn(),
   collectProjectedLayers: vi.fn(),
+  resolveVideoClipRadius: vi.fn(),
   captureProjectedElementTexture: vi.fn(),
   warpProjectedTexture: vi.fn(),
   paintFrameToLocalBox: vi.fn(),
@@ -28,6 +29,7 @@ vi.mock("@/lib/editor/crop-utils", () => ({
 }))
 vi.mock("@/lib/editor/animation-export/video-media/frame-geometry", () => ({
   collectProjectedLayers: mocks.collectProjectedLayers,
+  resolveVideoClipRadius: mocks.resolveVideoClipRadius,
 }))
 vi.mock("@/lib/editor/animation-export/video-media/frame-renderer", () => ({
   captureProjectedElementTexture: mocks.captureProjectedElementTexture,
@@ -145,6 +147,7 @@ beforeEach(() => {
   mocks.queryForeground.mockReturnValue([])
   mocks.applyExportStackVisibility.mockReturnValue(mocks.restoreVisibility)
   mocks.collectProjectedLayers.mockReturnValue([shellLayer()])
+  mocks.resolveVideoClipRadius.mockReturnValue(0)
   mocks.captureProjectedElementTexture.mockResolvedValue(makeTexture(77))
   mocks.warpProjectedTexture.mockReturnValue(makeFrame(88))
   mocks.paintFrameToLocalBox.mockReturnValue(makeFrame(99))
@@ -345,6 +348,33 @@ describe("captureLayeredAnimationFrame — video pixels", () => {
     expect(paintArgs[4]).toBe(1920)
     expect(paintArgs[5]).toBe(1080)
     expect(paintArgs[7]).toMatchObject({ enhance: "vivid" })
+  })
+
+  it("clips the video with the plate's rounding, not the media element's own", () => {
+    // The rounding lives on an ancestor plate; reading only the <img>'s own
+    // border-radius gave 0 and left square corners poking over the border.
+    const layer = shellLayer()
+    mocks.collectProjectedLayers.mockReturnValue([layer])
+    mocks.captureProjectedElementTexture.mockResolvedValue(
+      makeTexture(77, { x: 0, y: 0, w: 800, h: 500 })
+    )
+    const videoLayer = makeVideoLayer(layer.el)
+    mocks.resolveVideoClipRadius.mockReturnValue(12)
+
+    return captureLayeredAnimationFrame(makeCapture([10, 10]), {
+      timelineMs: 0,
+      videoLayer,
+    }).then(() => {
+      // Walked from the media up to the shell, sized against the media box.
+      expect(mocks.resolveVideoClipRadius).toHaveBeenCalledWith(
+        videoLayer.mediaElement,
+        layer.el,
+        800
+      )
+      // Reported in media-box px, so the compositor scales it to texture px.
+      const scale = mocks.paintFrameToLocalBox.mock.calls[0][6] / 12
+      expect(scale).toBeGreaterThan(0)
+    })
   })
 
   it("re-warps the cached texture with fresh video pixels on later frames", async () => {

--- a/tests/lib/editor/export.test.ts
+++ b/tests/lib/editor/export.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { shouldProxyAssetUrl } from "@/lib/editor/export-assets"
+import { exportScaleStyle } from "@/lib/editor/export"
 
 describe("shouldProxyAssetUrl", () => {
   it("proxies external http and https assets", () => {
@@ -14,5 +15,29 @@ describe("shouldProxyAssetUrl", () => {
     expect(shouldProxyAssetUrl("#mask")).toBe(false)
     expect(shouldProxyAssetUrl("data:image/png;base64,abc")).toBe(false)
     expect(shouldProxyAssetUrl("blob:http://localhost:3000/id")).toBe(false)
+  })
+})
+
+describe("exportScaleStyle — WebKit foreignObject scaling", () => {
+  it("scales via transform and keeps the layout box at its rendered size", () => {
+    // The box must stay 1128×634 so cqw/cqh and percentage geometry resolve
+    // against what the editor laid out; only the paint is scaled.
+    expect(exportScaleStyle(1128, 634, 3840 / 1128)).toEqual({
+      width: "1128px",
+      height: "634px",
+      transform: `scale(${3840 / 1128})`,
+      transformOrigin: "0 0",
+    })
+  })
+
+  it("anchors the scale at the top-left so the box maps onto the SVG origin", () => {
+    // A centred origin would shift the scene off the raster by half the growth.
+    expect(exportScaleStyle(800, 600, 2).transformOrigin).toBe("0 0")
+  })
+
+  it("is identity at 1×, where HD exports already worked", () => {
+    const style = exportScaleStyle(1920, 1080, 1)
+    expect(style.transform).toBe("scale(1)")
+    expect(style.width).toBe("1920px")
   })
 })

--- a/wiki/core/animation-export.md
+++ b/wiki/core/animation-export.md
@@ -97,7 +97,7 @@ flowchart TD
 | Mode | Strategy | When |
 |---|---|---|
 | `fast` | Clone once; bake computed styles; serialize foreignObject each frame | Default via `auto` |
-| `legacy` / Precise | html-to-image `toCanvas` every frame | Fallback or explicit |
+| `legacy` / Precise | html-to-image `toSvg` + `rasterizeNodeToCanvas` every frame | Fallback or explicit |
 | `auto` | fast → legacy if setup throws | Default |
 
 Video-media export always uses legacy `prepareAnimationCapture` — see [video-export.md](./video-export.md).

--- a/wiki/core/still-export.md
+++ b/wiki/core/still-export.md
@@ -38,7 +38,7 @@ flowchart TD
   Prep --> Assets["rewriteExportAssets<br/>proxy cross-origin imgs"]
   Assets --> Style["Inject override style<br/>hide export-hidden / selection"]
   Style --> Preload["Preload fonts + images"]
-  Preload --> FO["html-to-image toCanvas / toBlob / toJpeg"]
+  Preload --> FO["html-to-image toSvg<br/>→ rasterizeNodeToCanvas"]
   FO --> Out["Blob → download / clipboard / share"]
 ```
 
@@ -48,7 +48,7 @@ flowchart TD
 2. UI chrome: `data-export-hidden="true"`.
 3. Selection rings: `data-selection-border="true"` (stripped via CSS).
 4. Layout size is **pre-transform** (`offsetWidth`) so device-frame `cqw`/`cqh` stay correct under viewport zoom.
-5. `pixelRatio = targetWidth / layoutWidth` for resolution scaling.
+5. `pixelRatio = targetWidth / layoutWidth` for resolution scaling. Applied as a CSS `transform: scale()` on the captured content (`exportScaleStyle`), **not** via html-to-image's `pixelRatio` nor an SVG `viewBox` — WebKit applies neither to `<foreignObject>` content and paints the scene at 1× in the top-left corner. That broke every capture above 1×: 4K/8K stills, Full HD+ video and animation exports, and 1920px shares. The box keeps its rendered size so `cqw`/`cqh` still resolve correctly; both capture paths share the helper.
 6. Backgrounds may upgrade from edit-time downscaled `value` to full `sourceUrl` via `data-bg-source-url` — see [canvas.md](./canvas.md#edit-vs-export).
 
 ---
@@ -93,7 +93,7 @@ Still export helpers also build an **`AnimationCapture`** used by keyframe/video
 
 | Mode | Function | Notes |
 |---|---|---|
-| Legacy / Precise | `prepareAnimationCapture` | `toCanvas` every frame; video-media always uses this |
+| Legacy / Precise | `prepareAnimationCapture` | `toSvg` + `rasterizeNodeToCanvas` every frame; video-media always uses this |
 | Fast | `prepareFastAnimationCapture` | Bake styles; serialize FO cheaper |
 | Auto | try fast → fall back legacy | animation export default |
 

--- a/wiki/core/video-export.md
+++ b/wiki/core/video-export.md
@@ -147,6 +147,7 @@ flowchart TD
 | Untransformed texture + warp | `captureProjectedElementTexture` / `warpProjectedTexture` (exported; Animate reuses) |
 | Local media box paint | `paintFrameToLocalBox` (video or stand-in `<img>`) |
 | Media buffer resolution | `mediaBufferScale` — buffer is sized at the export scale, not the CSS box |
+| Texture margin | `fittedTexturePad` — capped so the padded box fits the capture canvas |
 | Inner lighting on WebKit | `frame-inner-lighting.ts` |
 | Canvas probes / copies | `frame-canvas-utils.ts` |
 | Stack show/hide | `export-stack.ts` |


### PR DESCRIPTION
## Summary

Follow-up to #36. Two WebKit-only export bugs that #36 did not cover, both found by instrumenting the export and reading the geometry rather than guessing.

1. **Every capture above 1× rendered the scene at 1× in the top-left corner.** 4K/8K stills, video and animation exports at Full HD and up, and 1920px shares.
2. **The Animate export lost the plate's border on the right and bottom**, while left and top were perfect. That asymmetry is what identified the cause.

Both reproduce only in Safari; Chromium was unaffected throughout.

## Type of Change

- [x] fix
- [ ] refactor
- [ ] delete
- [ ] optimised
- [ ] docs

## Related Issues

Follow-up to #36.

## Changes Made

**Scaling — `lib/editor/export.ts`**

html-to-image serializes a CSS-sized SVG and relies on `drawImage`'s destination rect to scale it up. WebKit applies neither that nor an SVG `viewBox` transform to `<foreignObject>` content — it paints at 1× in the top-left of an otherwise correctly-sized canvas. In the video export the damage compounded, because the composite renderer takes its scale from the raster's width and warps the video quad by it: a tiny untilted scene in the corner beside a video oversized by exactly the pixel ratio.

Everything now rasterizes through one `rasterizeNodeToCanvas`, which uses html-to-image's `width`/`height`/`style` options to put the scale on a CSS `transform` — ordinary layout every engine rasterizes correctly. The box keeps its rendered size so `cqw`/`cqh` and percentage geometry still resolve against what the editor laid out. `prepareFastAnimationCapture`, which built its SVG the same way and was equally affected, gets the same treatment.

**Texture margin — `lib/editor/animation-export/video-media/frame-renderer.ts`**

`captureProjectedElementTexture` parks the element at `(pad, pad)` and crops `boxW × boxH` from the raster, where the margin covers whatever paints outside the border box. But the raster only covers the canvas. Measured on the failing export: a 1026×614 shell wanting 70px of margin asks for **1166px of an 1100px canvas**, cropping 1145×741 out of a 1080×675 raster. `drawImage` returns transparent for the overhanging part rather than failing — so the far edges came back empty, and the far edges are the ones holding the border and shadow. Left and top start at crop origin 0 and were never affected, which is exactly why it read as a placement bug.

`fittedTexturePad` caps the margin to what the canvas can supply (36px here, still well clear of the outline's 11px reach), plus a clamp on the crop so rounding cannot reintroduce a one-pixel transparent sliver. Nothing visible is lost — anything past the canvas edge is clipped in the real render too.

Two smaller fixes from the same investigation:

- `shadowExtentPx` now counts the border outline. The screenshot's border is an `outline` held off the edge by `outline-offset`, which layout ignores entirely, so a canvas with no shadow would crop it away.
- `composeShellWithVideo` resolves the clip radius by walking up to the plate instead of reading the media element's own, matching what the video-media compositor already did.

**Not included**

Several changes tried during diagnosis turned out to be no-ops against the real cause and were dropped rather than carried: a content-box correction to the media box (the border is an outline, so there was nothing to subtract), an axis-aligned blit path, `imageSmoothingQuality` tuning, and an antialiased `destination-in` mask replacing `ctx.clip()`. The temporary debug route and file logging used to gather the geometry are also gone.

## Screenshots / Recordings (if UI)

Verified by the author in Safari: 4K and HD Animate exports now render at full resolution with the border intact on all four sides.

## Checklist

- [x] I ran `pnpm lint`
- [x] I ran `pnpm typecheck`
- [x] I ran `pnpm test`
- [x] I did not include secrets or sensitive data
- [x] I updated docs when behavior changed
- [x] I kept this PR focused and reasonably small

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects WebKit export scaling and projected-media texture cropping.
- Routes still, share, legacy animation, and fast animation captures through output-sized SVGs whose foreignObject content is scaled with CSS.
- Caps projected texture padding to available canvas space, accounts for outlines, clamps raster crops, and resolves video clipping from the containing plate.
- Adds focused regression tests and updates the still, animation, and video export documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code failure identified.

The new raster paths preserve the clone’s layout dimensions while scaling its paint into an output-sized SVG, and the projected-texture changes keep requested crops within the available raster while maintaining consistent geometry for warping and media clipping.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/editor/export.ts | Replaces html-to-image pixel-ratio and viewBox scaling with a shared CSS-transform SVG raster path across still, share, and animation captures. |
| lib/editor/animation-export/video-media/frame-renderer.ts | Caps projected texture margins to available raster space and clamps source crops to prevent transparent right and bottom edges. |
| lib/editor/animation-export/video-media/frame-canvas-utils.ts | Extends projected decoration measurement to include outlines and their positive offsets. |
| lib/editor/animation-export/webkit-layered-frame.ts | Resolves layered video clipping from the rounded shell ancestry and converts the radius into texture-pixel units. |
| tests/lib/editor/export.test.ts | Adds focused checks for layout-preserving, top-left-anchored export scaling. |
| tests/lib/editor/animation-export/video-media.test.ts | Covers outline extents and texture-padding bounds, including the reported near-full-canvas geometry. |
| tests/lib/editor/animation-export/webkit-layered-frame.test.ts | Verifies that layered video composition obtains clipping geometry from the plate rather than only the media element. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(wiki): note the projected-texture m..."](https://github.com/shivabhattacharjee/tokokino/commit/d33af6e22af3dbcbd709ed02d7b06040b8ede371) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47359231)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved still-image and animation export rendering, especially in WebKit.
  * More accurately preserves outlines, shadows, borders, and rounded video clipping.
  * Prevents captured textures from exceeding available canvas bounds.

* **Documentation**
  * Updated export documentation to reflect the improved SVG-based rasterization and texture-margin handling.

* **Tests**
  * Added coverage for export scaling, texture padding, outlines, and rounded video clipping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->