### PR TITLE
fix(crop): open reliably on large and remote screenshots

### DIFF
--- a/components/editor/animate/animate-toggle.tsx
+++ b/components/editor/animate/animate-toggle.tsx
@@ -94,6 +94,12 @@ export function AnimateToggle() {
         ?.screenshot ?? null
     )
   )
+  const bulkEditMode = useEditorStore((s) => s.bulkEditMode)
+
+  // Animate can't run over a bulk selection, and at iPad widths this floating
+  // pill sits exactly where the bulk arrange bar does — so drop it rather than
+  // stack a dead button on top of the bar.
+  if (bulkEditMode) return null
 
   return (
     <div

--- a/components/editor/crop-modal.tsx
+++ b/components/editor/crop-modal.tsx
@@ -25,6 +25,7 @@ import {
 import { useCropDragAutoScroll } from "@/hooks/use-crop-drag-autoscroll"
 import { isVideoSrc } from "@/lib/editor/media-type"
 import type { CropRegion } from "@/lib/editor/store"
+import { clampNumber } from "@/lib/editor/value-schemas"
 
 /**
  * Where to seek for the crop dialog's still preview: the playhead the user is
@@ -63,51 +64,58 @@ async function videoPosterBlob(url: string, atSec = 0): Promise<Blob> {
   // element is created off-DOM (setting src alone is not always enough).
   video.load()
 
-  await new Promise<void>((resolve, reject) => {
-    const cleanup = () => {
-      video.onloadeddata = null
-      video.onerror = null
-      video.onseeked = null
-    }
-    const onError = () => {
-      cleanup()
-      reject(new Error("video load failed"))
-    }
-    const onLoaded = () => {
-      const target = posterSeekTime(atSec, video.duration || 0)
-      if (
-        Number.isFinite(target) &&
-        target > 0 &&
-        video.currentTime !== target
-      ) {
-        video.onseeked = () => {
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        video.onloadeddata = null
+        video.onerror = null
+        video.onseeked = null
+      }
+      const onError = () => {
+        cleanup()
+        reject(new Error("video load failed"))
+      }
+      const onLoaded = () => {
+        const target = posterSeekTime(atSec, video.duration || 0)
+        if (
+          Number.isFinite(target) &&
+          target > 0 &&
+          video.currentTime !== target
+        ) {
+          video.onseeked = () => {
+            cleanup()
+            resolve()
+          }
+          video.currentTime = target
+        } else {
           cleanup()
           resolve()
         }
-        video.currentTime = target
-      } else {
-        cleanup()
-        resolve()
       }
-    }
-    video.onloadeddata = onLoaded
-    video.onerror = onError
-  })
+      video.onloadeddata = onLoaded
+      video.onerror = onError
+    })
 
-  const w = video.videoWidth || 1280
-  const h = video.videoHeight || 720
-  const canvas = document.createElement("canvas")
-  canvas.width = w
-  canvas.height = h
-  const ctx = canvas.getContext("2d")
-  if (!ctx) throw new Error("no 2d context")
-  ctx.drawImage(video, 0, 0, w, h)
+    const w = video.videoWidth || 1280
+    const h = video.videoHeight || 720
+    const canvas = document.createElement("canvas")
+    canvas.width = w
+    canvas.height = h
+    const ctx = canvas.getContext("2d")
+    if (!ctx) throw new Error("no 2d context")
+    ctx.drawImage(video, 0, 0, w, h)
 
-  const blob = await new Promise<Blob | null>((resolve) =>
-    canvas.toBlob((b) => resolve(b), "image/png")
-  )
-  if (!blob) throw new Error("poster encode failed")
-  return blob
+    const blob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob((b) => resolve(b), "image/png")
+    )
+    if (!blob) throw new Error("poster encode failed")
+    return blob
+  } finally {
+    // Drop the decoded media even if encoding failed — an off-DOM video can
+    // otherwise hold a full-frame buffer until GC.
+    video.removeAttribute("src")
+    video.load()
+  }
 }
 
 type Preset = {
@@ -313,7 +321,12 @@ export function CropModal({
     read()
     const observer = new ResizeObserver(read)
     observer.observe(node)
-    return () => observer.disconnect()
+    return () => {
+      observer.disconnect()
+      // React 19 runs this cleanup instead of calling the ref with null; only
+      // clear if nothing newer has already been attached.
+      if (viewportRef.current === node) viewportRef.current = null
+    }
   }, [])
 
   /**
@@ -342,6 +355,11 @@ export function CropModal({
    */
   const scrollAnchor = React.useRef<{ x: number; y: number } | null>(null)
   const zoomTo = (next: number) => {
+    const clamped = clampZoom(next)
+    if (clamped === zoom) {
+      scrollAnchor.current = null
+      return
+    }
     const node = viewportRef.current
     if (node) {
       scrollAnchor.current = {
@@ -353,7 +371,7 @@ export function CropModal({
           Math.max(1, node.scrollHeight),
       }
     }
-    setZoom(clampZoom(next))
+    setZoom(clamped)
   }
 
   const displaySize = React.useMemo(() => {
@@ -388,12 +406,12 @@ export function CropModal({
   const handleApply = React.useCallback(
     (region: PercentCrop) => {
       if (!source) return
-      const cropRegion: CropRegion = {
-        x: region.x,
-        y: region.y,
-        width: region.width,
-        height: region.height,
-      }
+      const x = clampNumber(region.x, 0, 100)
+      const y = clampNumber(region.y, 0, 100)
+      const width = clampNumber(region.width, 0, 100)
+      const height = clampNumber(region.height, 0, 100)
+      if (x === null || y === null || width === null || height === null) return
+      const cropRegion: CropRegion = { x, y, width, height }
       // Close first: the render reads the ORIGINAL bytes, so it can take a
       // moment on a large screenshot and there is nothing left to look at.
       handleOpenChange(false)
@@ -485,6 +503,7 @@ export function CropModal({
           // decoded — a 20 MB screenshot takes a beat, and a modal that only
           // appears after that read as a frozen or dead crop button.
           <div
+            role="status"
             className="flex h-[420px] items-center justify-center"
             style={{
               backgroundImage:
@@ -568,6 +587,7 @@ export function CropModal({
                   <button
                     type="button"
                     onClick={() => zoomTo(MIN_ZOOM)}
+                    aria-label="Fit to view"
                     title="Fit to view"
                     className="min-w-11 cursor-pointer rounded-md px-1 py-1 text-[11px] font-medium text-foreground tabular-nums transition-colors hover:bg-secondary"
                   >

--- a/components/editor/crop-modal.tsx
+++ b/components/editor/crop-modal.tsx
@@ -1,6 +1,13 @@
 import * as React from "react"
+import { RiAddLine, RiLoader4Line, RiSubtractLine } from "@remixicon/react"
 import type { PercentCrop } from "react-image-crop"
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
+import { toast } from "sonner"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import {
   ImageCrop,
   ImageCropContent,
@@ -9,31 +16,15 @@ import {
 } from "@/components/kibo-ui/image-crop"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+import {
+  createCropSource,
+  cropSourceFromBlob,
+  renderCroppedImage,
+  type CropSource,
+} from "@/lib/editor/crop-source"
+import { useCropDragAutoScroll } from "@/hooks/use-crop-drag-autoscroll"
 import { isVideoSrc } from "@/lib/editor/media-type"
 import type { CropRegion } from "@/lib/editor/store"
-
-function dataURLtoFile(dataurl: string, filename: string) {
-  const arr = dataurl.split(",")
-  const mimeMatch = arr[0].match(/:(.*?);/)
-  const mime = mimeMatch ? mimeMatch[1] : "image/png"
-  const bstr = atob(arr[1])
-  let n = bstr.length
-  const u8arr = new Uint8Array(n)
-  while (n--) {
-    u8arr[n] = bstr.charCodeAt(n)
-  }
-  return new File([u8arr], filename, { type: mime })
-}
-
-function isDataUrl(src: string) {
-  return src.startsWith("data:")
-}
-
-async function urlToFile(url: string, filename: string): Promise<File> {
-  const res = await fetch(url)
-  const blob = await res.blob()
-  return new File([blob], filename, { type: blob.type || "image/png" })
-}
 
 /**
  * Where to seek for the crop dialog's still preview: the playhead the user is
@@ -61,11 +52,7 @@ export function posterSeekTime(atSec: number, duration: number): number {
  * crop on frame 0 while the canvas shows six seconds in means placing the
  * handles over content that isn't on screen.
  */
-async function videoPosterFile(
-  url: string,
-  filename: string,
-  atSec = 0
-): Promise<File> {
+async function videoPosterBlob(url: string, atSec = 0): Promise<Blob> {
   const video = document.createElement("video")
   video.src = url
   video.muted = true
@@ -120,7 +107,7 @@ async function videoPosterFile(
     canvas.toBlob((b) => resolve(b), "image/png")
   )
   if (!blob) throw new Error("poster encode failed")
-  return new File([blob], filename, { type: "image/png" })
+  return blob
 }
 
 type Preset = {
@@ -128,6 +115,21 @@ type Preset = {
   aspect: number
   w: number
   h: number
+}
+
+/** Zoom is a multiple of the fitted size: 1 shows the whole image. */
+const MIN_ZOOM = 1
+const MAX_ZOOM = 16
+const ZOOM_STEP = 1.5
+/** `p-6` on both sides of the cropper viewport. */
+const VIEWPORT_PADDING = 48
+/** Cap for the one frame before the viewport has been measured. */
+const FIT_FALLBACK_HEIGHT = 372
+/** Long enough for the dialog's exit animation to finish. */
+const CLOSE_ANIMATION_MS = 400
+
+function clampZoom(value: number) {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value))
 }
 
 const PRESETS: Preset[] = [
@@ -172,9 +174,9 @@ export function CropModal({
     defaultAspect: number
     aspect: number | null
   } | null>(null)
-  const [loadedFile, setLoadedFile] = React.useState<{
+  const [loadedSource, setLoadedSource] = React.useState<{
     url: string
-    file: File
+    source: CropSource
   } | null>(null)
   // Default to free-form (null) until the user picks a ratio; `defaultAspect`
   // still backs the "Canvas" chip below.
@@ -190,6 +192,30 @@ export function CropModal({
     [defaultAspect]
   )
 
+  // Multiple of the fitted size. Always opens on the whole image: a long
+  // capture is a sliver at that size, but auto-zooming it hides where the crop
+  // sits in the page, which is the one thing the preview is for.
+  const [zoom, setZoom] = React.useState(MIN_ZOOM)
+
+  // Mirrors `loadedSource` so cleanup can revoke object URLs without going
+  // through a state update that React skips once the dialog is unmounted.
+  const sourceRef = React.useRef<CropSource | null>(null)
+  const releaseSource = React.useCallback(() => {
+    sourceRef.current?.release()
+    sourceRef.current = null
+  }, [])
+
+  /**
+   * Revoking on close races the dialog's exit animation: the <img> is still on
+   * screen and re-requests a URL that no longer resolves, which shows up as a
+   * failed `blob:` fetch. Let the animation finish first.
+   */
+  const releaseSourceAfterClose = React.useCallback(() => {
+    const source = sourceRef.current
+    sourceRef.current = null
+    if (source) window.setTimeout(() => source.release(), CLOSE_ANIMATION_MS)
+  }, [])
+
   const handleOpenChange = React.useCallback(
     (nextOpen: boolean) => {
       if (!nextOpen) {
@@ -197,26 +223,16 @@ export function CropModal({
         // Drop the decoded still too. It is keyed only by URL, so keeping it
         // would show the PREVIOUS open's frame the instant the dialog reopens —
         // for a video that is a different moment in the clip, not a cache hit.
-        setLoadedFile(null)
+        releaseSourceAfterClose()
+        setLoadedSource(null)
+        setZoom(MIN_ZOOM)
       }
       onOpenChange(nextOpen)
     },
-    [onOpenChange]
+    [onOpenChange, releaseSourceAfterClose]
   )
 
   const isVideo = !!screenshotUrl && isVideoSrc(screenshotUrl)
-
-  // Videos are never rendered by react-image-crop directly; a data-URL image is
-  // only available for still screenshots, so the poster path handles video.
-  const dataUrlFile = React.useMemo(() => {
-    if (!open || !screenshotUrl || isVideo || !isDataUrl(screenshotUrl))
-      return null
-    try {
-      return dataURLtoFile(screenshotUrl, "screenshot.png")
-    } catch {
-      return null
-    }
-  }, [open, screenshotUrl, isVideo])
 
   // Held in a ref so the poster effect can call it without listing it as a
   // dependency: it is read once per open, and re-running the decode as the
@@ -228,33 +244,169 @@ export function CropModal({
 
   React.useEffect(() => {
     if (!open || !screenshotUrl) return
-    if (!isVideo && isDataUrl(screenshotUrl)) return
 
     let cancelled = false
+    // Videos are never rendered by react-image-crop directly, so a still poster
+    // stands in for the clip; everything else is fetched (through the proxy for
+    // cross-origin hosts) and previewed at a size the dialog can actually show.
     const loader = isVideo
-      ? videoPosterFile(
-          screenshotUrl,
-          "poster.png",
-          getPosterTimeRef.current?.() ?? 0
+      ? videoPosterBlob(screenshotUrl, getPosterTimeRef.current?.() ?? 0).then(
+          cropSourceFromBlob
         )
-      : urlToFile(screenshotUrl, "screenshot.png")
+      : createCropSource(screenshotUrl)
+
     void loader
-      .then((file) => {
-        if (!cancelled) setLoadedFile({ url: screenshotUrl, file })
+      .then((source) => {
+        if (cancelled) {
+          source.release()
+          return
+        }
+        releaseSource()
+        sourceRef.current = source
+        setLoadedSource({ url: screenshotUrl, source })
       })
       .catch(() => {
-        // Leave file null so the dialog stays closed / empty rather than
-        // surfacing an unhandled rejection when poster fetch fails.
+        if (cancelled) return
+        toast.error(
+          isVideo ? "Could not load this video" : "Could not load this image"
+        )
+        handleOpenChange(false)
       })
 
     return () => {
       cancelled = true
     }
+    // `handleOpenChange` is only used on the failure path and is stable per
+    // `onOpenChange`; re-running the load because it changed identity would
+    // decode the source again mid-crop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, screenshotUrl, isVideo])
 
-  const file =
-    dataUrlFile ??
-    (open && loadedFile?.url === screenshotUrl ? loadedFile.file : null)
+  // Release the decoded source if the dialog unmounts while still open.
+  React.useEffect(() => releaseSource, [releaseSource])
+
+  const source =
+    open && loadedSource?.url === screenshotUrl ? loadedSource.source : null
+
+  const [viewport, setViewport] = React.useState<{
+    width: number
+    height: number
+  } | null>(null)
+  const viewportRef = React.useRef<HTMLDivElement | null>(null)
+  const dragAutoScroll = useCropDragAutoScroll(viewportRef)
+
+  // A drag can outlive the dialog (Escape mid-drag) — drop its listeners.
+  React.useEffect(() => dragAutoScroll.stop, [dragAutoScroll])
+
+  const measureViewport = React.useCallback((node: HTMLDivElement | null) => {
+    viewportRef.current = node
+    if (!node) return
+    const read = () => {
+      const width = node.clientWidth
+      const height = node.clientHeight
+      setViewport((current) =>
+        current?.width === width && current?.height === height
+          ? current
+          : { width, height }
+      )
+    }
+    read()
+    const observer = new ResizeObserver(read)
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  /**
+   * Size the image is drawn at: fitted inside the viewport (never blown up past
+   * its natural size) and then multiplied by the zoom. Null until the viewport
+   * has been measured, which leaves the cropper on its own CSS fit.
+   */
+  const fitSize = React.useMemo(() => {
+    if (!source || !viewport) return null
+    const availWidth = viewport.width - VIEWPORT_PADDING
+    const availHeight = viewport.height - VIEWPORT_PADDING
+    if (availWidth <= 0 || availHeight <= 0) return null
+    if (!source.width || !source.height) return null
+    const scale = Math.min(
+      1,
+      availWidth / source.width,
+      availHeight / source.height
+    )
+    return { width: source.width * scale, height: source.height * scale }
+  }, [source, viewport])
+
+  /**
+   * Zooming keeps whatever is in the middle of the viewport in the middle,
+   * rather than snapping back to the top-left of a now much larger image.
+   * Captured as fractions before the resize, reapplied once it has laid out.
+   */
+  const scrollAnchor = React.useRef<{ x: number; y: number } | null>(null)
+  const zoomTo = (next: number) => {
+    const node = viewportRef.current
+    if (node) {
+      scrollAnchor.current = {
+        x:
+          (node.scrollLeft + node.clientWidth / 2) /
+          Math.max(1, node.scrollWidth),
+        y:
+          (node.scrollTop + node.clientHeight / 2) /
+          Math.max(1, node.scrollHeight),
+      }
+    }
+    setZoom(clampZoom(next))
+  }
+
+  const displaySize = React.useMemo(() => {
+    if (!fitSize) return null
+    return { width: fitSize.width * zoom, height: fitSize.height * zoom }
+  }, [fitSize, zoom])
+
+  React.useLayoutEffect(() => {
+    const anchor = scrollAnchor.current
+    const node = viewportRef.current
+    if (!anchor || !node) return
+    scrollAnchor.current = null
+    node.scrollLeft = anchor.x * node.scrollWidth - node.clientWidth / 2
+    node.scrollTop = anchor.y * node.scrollHeight - node.clientHeight / 2
+  }, [displaySize])
+
+  // Nothing to zoom until we know what size the image is being drawn at.
+  const canZoom = !!fitSize
+
+  // A small screenshot is ready within a frame or two; showing the spinner
+  // immediately would just flash. Only a genuinely heavy source waits.
+  const [showLoader, setShowLoader] = React.useState(false)
+  React.useEffect(() => {
+    if (!open || source) return
+    const timer = window.setTimeout(() => setShowLoader(true), 180)
+    return () => {
+      window.clearTimeout(timer)
+      setShowLoader(false)
+    }
+  }, [open, source])
+
+  const handleApply = React.useCallback(
+    (region: PercentCrop) => {
+      if (!source) return
+      const cropRegion: CropRegion = {
+        x: region.x,
+        y: region.y,
+        width: region.width,
+        height: region.height,
+      }
+      // Close first: the render reads the ORIGINAL bytes, so it can take a
+      // moment on a large screenshot and there is nothing left to look at.
+      handleOpenChange(false)
+      void renderCroppedImage(source, cropRegion)
+        .then((cropped) => {
+          if (cropped) onCrop(cropped, cropRegion)
+        })
+        .catch(() => {
+          toast.error("Could not apply this crop")
+        })
+    },
+    [source, handleOpenChange, onCrop]
+  )
 
   const initialPercentCrop = React.useMemo<PercentCrop | undefined>(() => {
     if (!initialRegion) return undefined
@@ -287,8 +439,6 @@ export function CropModal({
     return [targetPreset, ...rest]
   }, [targetPreset])
 
-  if (!file) return null
-
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
@@ -305,11 +455,11 @@ export function CropModal({
             <span className="text-[13px] font-semibold tracking-tight text-foreground">
               {isVideo ? "Crop video" : "Crop screenshot"}
             </span>
-            <span className="text-[11px] text-muted-foreground">
+            <DialogDescription className="text-[11px] text-muted-foreground">
               {isVideo
                 ? "Preview shows a still frame — the crop applies to the whole clip"
                 : "Drag the handles or pick a preset ratio"}
-            </span>
+            </DialogDescription>
           </div>
           <button
             type="button"
@@ -330,112 +480,187 @@ export function CropModal({
           </button>
         </div>
 
-        <ImageCrop
-          key={aspect ?? "free"}
-          file={file}
-          aspect={aspect ?? undefined}
-          keepSelection
-          initialCrop={
-            aspect === null || Math.abs(aspect - targetPreset.aspect) < 0.01
-              ? initialPercentCrop
-              : undefined
-          }
-          onCrop={(croppedImage, region) => {
-            onCrop(croppedImage, {
-              x: region.x,
-              y: region.y,
-              width: region.width,
-              height: region.height,
-            })
-            handleOpenChange(false)
-          }}
-        >
-          {/* Cropper Area */}
+        {!source ? (
+          // The dialog opens straight away and fills in once the source is
+          // decoded — a 20 MB screenshot takes a beat, and a modal that only
+          // appears after that read as a frozen or dead crop button.
           <div
-            className="relative flex flex-1 items-center justify-center px-6 py-8"
+            className="flex h-[420px] items-center justify-center"
             style={{
               backgroundImage:
                 "radial-gradient(circle at 1px 1px, var(--color-border) 1px, transparent 0)",
               backgroundSize: "14px 14px",
             }}
           >
-            <ImageCropContent className="max-h-[420px] max-w-full rounded-lg" />
+            {showLoader ? (
+              <span className="flex items-center gap-2 rounded-lg border border-border/60 bg-popover px-3 py-2 text-[12px] text-muted-foreground">
+                <RiLoader4Line className="size-3.5 animate-spin" />
+                Preparing {isVideo ? "frame" : "image"}…
+              </span>
+            ) : null}
           </div>
-
-          {/* Action Bar */}
-          <div className="flex items-center justify-between gap-4 border-t border-border/50 bg-background/40 px-4 py-3">
-            {/* Aspect chips */}
-            <div className="flex min-w-0 flex-1 [scrollbar-width:none] items-center gap-1 overflow-x-auto [&::-webkit-scrollbar]:hidden">
-              <button
-                onClick={() => setAspect(null)}
-                className={cn(
-                  "group flex shrink-0 cursor-pointer items-center gap-2 rounded-lg border px-2.5 py-1.5 text-[11.5px] font-medium tracking-tight transition-all",
-                  isFree
-                    ? "border-foreground/80 bg-foreground text-background"
-                    : "border-border/60 bg-transparent text-muted-foreground hover:border-border hover:bg-secondary/60 hover:text-foreground"
-                )}
-                aria-pressed={isFree}
+        ) : (
+          <ImageCrop
+            key={aspect ?? "free"}
+            src={source.previewUrl}
+            aspect={aspect ?? undefined}
+            keepSelection
+            initialCrop={
+              aspect === null || Math.abs(aspect - targetPreset.aspect) < 0.01
+                ? initialPercentCrop
+                : undefined
+            }
+            onCrop={handleApply}
+          >
+            {/* Cropper Area */}
+            <div className="relative">
+              <div
+                ref={measureViewport}
+                onPointerDown={dragAutoScroll.onPointerDown}
+                // A stable gutter keeps the fitted size from changing when the
+                // zoomed image summons a scrollbar (which would resize it again).
+                className="h-[420px] [scrollbar-gutter:stable] overflow-auto overscroll-contain"
+                style={{
+                  backgroundImage:
+                    "radial-gradient(circle at 1px 1px, var(--color-border) 1px, transparent 0)",
+                  backgroundSize: "14px 14px",
+                }}
               >
-                <span
-                  aria-hidden
-                  className={cn(
-                    "block size-3.5 shrink-0 rounded-[2px] border border-dashed transition-colors",
-                    isFree
-                      ? "border-background/70"
-                      : "border-current opacity-70"
-                  )}
-                />
-                <span className="leading-none">Free</span>
-              </button>
-              {presets.map((p) => {
-                const isActive =
-                  aspect !== null && Math.abs(aspect - p.aspect) < 0.01
-                return (
+                {/* `w-max min-w-full` so the image centres while it fits and
+                    the box still grows — and scrolls — once zoom outruns it. */}
+                <div className="flex h-max min-h-full w-max min-w-full items-center justify-center p-6">
+                  <ImageCropContent
+                    className="rounded-lg"
+                    // Both elements have to be uncapped: the cropper's child
+                    // wrapper and its <img> inherit max-height from the root,
+                    // and either cap would pin the image at the fitted size
+                    // however far it is zoomed.
+                    style={
+                      displaySize
+                        ? { maxWidth: "none", maxHeight: "none" }
+                        : { maxWidth: "100%", maxHeight: FIT_FALLBACK_HEIGHT }
+                    }
+                    imageStyle={
+                      displaySize
+                        ? {
+                            width: displaySize.width,
+                            height: displaySize.height,
+                            maxWidth: "none",
+                            maxHeight: "none",
+                          }
+                        : undefined
+                    }
+                  />
+                </div>
+              </div>
+
+              {canZoom ? (
+                <div className="pointer-events-auto absolute top-3 right-3 flex items-center gap-0.5 rounded-lg border border-border/60 bg-popover/95 p-0.5 shadow-md backdrop-blur-md">
                   <button
-                    key={p.label}
-                    onClick={() => setAspect(p.aspect)}
-                    className={cn(
-                      "group flex shrink-0 cursor-pointer items-center gap-2 rounded-lg border px-2.5 py-1.5 text-[11.5px] font-medium tracking-tight transition-all",
-                      isActive
-                        ? "border-foreground/80 bg-foreground text-background"
-                        : "border-border/60 bg-transparent text-muted-foreground hover:border-border hover:bg-secondary/60 hover:text-foreground"
-                    )}
-                    aria-pressed={isActive}
+                    type="button"
+                    onClick={() => zoomTo(zoom / ZOOM_STEP)}
+                    disabled={zoom <= MIN_ZOOM}
+                    aria-label="Zoom out"
+                    className="flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
                   >
-                    <span
-                      aria-hidden
-                      className={cn(
-                        "block shrink-0 rounded-[2px] border transition-colors",
-                        isActive
-                          ? "border-background/70"
-                          : "border-current opacity-70"
-                      )}
-                      style={{ width: `${p.w}px`, height: `${p.h}px` }}
-                    />
-                    <span className="leading-none">{p.label}</span>
+                    <RiSubtractLine className="size-3.5" />
                   </button>
-                )
-              })}
+                  <button
+                    type="button"
+                    onClick={() => zoomTo(MIN_ZOOM)}
+                    title="Fit to view"
+                    className="min-w-11 cursor-pointer rounded-md px-1 py-1 text-[11px] font-medium text-foreground tabular-nums transition-colors hover:bg-secondary"
+                  >
+                    {Math.round(zoom * 100)}%
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => zoomTo(zoom * ZOOM_STEP)}
+                    disabled={zoom >= MAX_ZOOM}
+                    aria-label="Zoom in"
+                    className="flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                  >
+                    <RiAddLine className="size-3.5" />
+                  </button>
+                </div>
+              ) : null}
             </div>
 
-            {/* Buttons */}
-            <div className="flex shrink-0 items-center gap-2 border-l border-border/50 pl-3">
-              <ImageCropReset asChild>
-                <Button
-                  variant="ghost"
-                  className="h-8 cursor-pointer rounded-md px-3 text-[12px] font-medium text-muted-foreground hover:bg-secondary hover:text-foreground"
+            {/* Action Bar */}
+            <div className="flex items-center justify-between gap-4 border-t border-border/50 bg-background/40 px-4 py-3">
+              {/* Aspect chips */}
+              <div className="flex min-w-0 flex-1 [scrollbar-width:none] items-center gap-1 overflow-x-auto [&::-webkit-scrollbar]:hidden">
+                <button
+                  onClick={() => setAspect(null)}
+                  className={cn(
+                    "group flex shrink-0 cursor-pointer items-center gap-2 rounded-lg border px-2.5 py-1.5 text-[11.5px] font-medium tracking-tight transition-all",
+                    isFree
+                      ? "border-foreground/80 bg-foreground text-background"
+                      : "border-border/60 bg-transparent text-muted-foreground hover:border-border hover:bg-secondary/60 hover:text-foreground"
+                  )}
+                  aria-pressed={isFree}
                 >
-                  Reset
-                </Button>
-              </ImageCropReset>
-              <ImageCropApply asChild>
-                <Button className="h-8 cursor-pointer rounded-md bg-primary px-4 text-[12px] font-medium text-primary-foreground hover:bg-primary/90">
-                  Apply crop
-                </Button>
-              </ImageCropApply>
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "block size-3.5 shrink-0 rounded-[2px] border border-dashed transition-colors",
+                      isFree
+                        ? "border-background/70"
+                        : "border-current opacity-70"
+                    )}
+                  />
+                  <span className="leading-none">Free</span>
+                </button>
+                {presets.map((p) => {
+                  const isActive =
+                    aspect !== null && Math.abs(aspect - p.aspect) < 0.01
+                  return (
+                    <button
+                      key={p.label}
+                      onClick={() => setAspect(p.aspect)}
+                      className={cn(
+                        "group flex shrink-0 cursor-pointer items-center gap-2 rounded-lg border px-2.5 py-1.5 text-[11.5px] font-medium tracking-tight transition-all",
+                        isActive
+                          ? "border-foreground/80 bg-foreground text-background"
+                          : "border-border/60 bg-transparent text-muted-foreground hover:border-border hover:bg-secondary/60 hover:text-foreground"
+                      )}
+                      aria-pressed={isActive}
+                    >
+                      <span
+                        aria-hidden
+                        className={cn(
+                          "block shrink-0 rounded-[2px] border transition-colors",
+                          isActive
+                            ? "border-background/70"
+                            : "border-current opacity-70"
+                        )}
+                        style={{ width: `${p.w}px`, height: `${p.h}px` }}
+                      />
+                      <span className="leading-none">{p.label}</span>
+                    </button>
+                  )
+                })}
+              </div>
+
+              {/* Buttons */}
+              <div className="flex shrink-0 items-center gap-2 border-l border-border/50 pl-3">
+                <ImageCropReset asChild>
+                  <Button
+                    variant="ghost"
+                    className="h-8 cursor-pointer rounded-md px-3 text-[12px] font-medium text-muted-foreground hover:bg-secondary hover:text-foreground"
+                  >
+                    Reset
+                  </Button>
+                </ImageCropReset>
+                <ImageCropApply asChild>
+                  <Button className="h-8 cursor-pointer rounded-md bg-primary px-4 text-[12px] font-medium text-primary-foreground hover:bg-primary/90">
+                    Apply crop
+                  </Button>
+                </ImageCropApply>
+              </div>
             </div>
-          </div>
-        </ImageCrop>
+          </ImageCrop>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/components/editor/top-bar/export-controls.tsx
+++ b/components/editor/top-bar/export-controls.tsx
@@ -479,7 +479,7 @@ function BulkExportDialog({
             type="button"
             onClick={toggleAll}
             className={cn(
-              "rounded-full px-3 py-1.5 text-[12px] font-medium transition-colors",
+              "rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors",
               allSelected
                 ? "bg-primary text-white"
                 : "bg-secondary text-muted-foreground hover:text-foreground"

--- a/components/kibo-ui/image-crop/index.tsx
+++ b/components/kibo-ui/image-crop/index.tsx
@@ -15,7 +15,6 @@ import {
   type SyntheticEvent,
   useCallback,
   useContext,
-  useEffect,
   useRef,
   useState,
 } from "react"
@@ -26,7 +25,6 @@ import ReactCrop, {
   type PixelCrop,
   type ReactCropProps,
 } from "react-image-crop"
-import { cn } from "@/lib/utils"
 
 import "react-image-crop/dist/ReactCrop.css"
 
@@ -78,67 +76,16 @@ function cropMatchesAspect(
   return Math.abs(cropWidth / cropHeight - aspect) < 0.01
 }
 
-const getCroppedPngImage = async (
-  imageSrc: HTMLImageElement,
-  pixelCrop: PixelCrop
-): Promise<string> => {
-  const canvas = document.createElement("canvas")
-  const ctx = canvas.getContext("2d")
-
-  if (!ctx) {
-    throw new Error("Context is null, this should never happen.")
-  }
-
-  const scaleX = imageSrc.naturalWidth / imageSrc.width
-  const scaleY = imageSrc.naturalHeight / imageSrc.height
-
-  ctx.imageSmoothingEnabled = false
-  canvas.width = Math.round(pixelCrop.width * scaleX)
-  canvas.height = Math.round(pixelCrop.height * scaleY)
-
-  ctx.drawImage(
-    imageSrc,
-    pixelCrop.x * scaleX,
-    pixelCrop.y * scaleY,
-    pixelCrop.width * scaleX,
-    pixelCrop.height * scaleY,
-    0,
-    0,
-    canvas.width,
-    canvas.height
-  )
-
-  // Async PNG encode — does not block the main thread like toDataURL.
-  const blob = await new Promise<Blob>((resolve, reject) => {
-    canvas.toBlob(
-      (b) => (b ? resolve(b) : reject(new Error("toBlob failed"))),
-      "image/png"
-    )
-  })
-
-  // Async data URL conversion via FileReader (also non-blocking).
-  return await new Promise<string>((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => resolve(reader.result as string)
-    reader.onerror = () =>
-      reject(reader.error ?? new Error("FileReader failed"))
-    reader.readAsDataURL(blob)
-  })
-}
-
 type ImageCropContextType = {
-  file: File
-  maxImageSize: number
   imgSrc: string
   crop: PercentCrop | undefined
-  completedCrop: PixelCrop | null
   imgRef: RefObject<HTMLImageElement | null>
-  onCrop?: (croppedImage: string, region: PercentCrop) => void
+  onCrop?: (region: PercentCrop) => void
   reactCropProps: Omit<ReactCropProps, "onChange" | "onComplete" | "children">
   handleChange: (pixelCrop: PixelCrop, percentCrop: PercentCrop) => void
   handleComplete: (pixelCrop: PixelCrop, percentCrop: PercentCrop) => void
   onImageLoad: (e: SyntheticEvent<HTMLImageElement>) => void
-  applyCrop: () => Promise<void>
+  applyCrop: () => void
   resetCrop: () => void
 }
 
@@ -153,9 +100,14 @@ const useImageCrop = () => {
 }
 
 export type ImageCropProps = {
-  file: File
-  maxImageSize?: number
-  onCrop?: (croppedImage: string, region: PercentCrop) => void
+  /**
+   * Image the crop handles are drawn over. Callers may pass a downscaled
+   * stand-in for a heavy source — the reported region is in percent, so the
+   * applied crop can still be rendered from the original.
+   */
+  src: string
+  /** Fires with the selected region in percent units. Rendering is the caller's job. */
+  onCrop?: (region: PercentCrop) => void
   children: ReactNode
   onChange?: ReactCropProps["onChange"]
   onComplete?: ReactCropProps["onComplete"]
@@ -164,8 +116,7 @@ export type ImageCropProps = {
 } & Omit<ReactCropProps, "onChange" | "onComplete" | "children">
 
 export const ImageCrop = ({
-  file,
-  maxImageSize = 1024 * 1024 * 5,
+  src,
   onCrop,
   children,
   onChange,
@@ -174,18 +125,8 @@ export const ImageCrop = ({
   ...reactCropProps
 }: ImageCropProps) => {
   const imgRef = useRef<HTMLImageElement | null>(null)
-  const [imgSrc, setImgSrc] = useState<string>("")
   const [crop, setCrop] = useState<PercentCrop>()
-  const [completedCrop, setCompletedCrop] = useState<PixelCrop | null>(null)
   const [initialCrop, setInitialCrop] = useState<PercentCrop>()
-
-  useEffect(() => {
-    const reader = new FileReader()
-    reader.addEventListener("load", () =>
-      setImgSrc(typeof reader.result === "string" ? reader.result : "")
-    )
-    reader.readAsDataURL(file)
-  }, [file])
 
   const onImageLoad = useCallback(
     (e: SyntheticEvent<HTMLImageElement>) => {
@@ -208,52 +149,21 @@ export const ImageCrop = ({
   }
 
   const handleComplete = (pixelCrop: PixelCrop, percentCrop: PercentCrop) => {
-    setCompletedCrop(pixelCrop)
     onComplete?.(pixelCrop, percentCrop)
   }
 
-  const applyCrop = async () => {
-    if (!imgRef.current) {
-      return
-    }
-
-    // Fall back to the current crop if the user hasn't dragged yet
-    // (onComplete only fires after a drag, so completedCrop may be null).
-    let pixelCrop: PixelCrop | null = completedCrop
-    if (!pixelCrop && crop) {
-      const { width, height } = imgRef.current
-      pixelCrop = {
-        unit: "px",
-        x: (crop.x / 100) * width,
-        y: (crop.y / 100) * height,
-        width: (crop.width / 100) * width,
-        height: (crop.height / 100) * height,
-      }
-    }
-    if (!pixelCrop || pixelCrop.width === 0 || pixelCrop.height === 0) {
-      return
-    }
-
-    const croppedImage = await getCroppedPngImage(imgRef.current, pixelCrop)
-
-    if (crop) {
-      onCrop?.(croppedImage, crop)
-    }
+  const applyCrop = () => {
+    if (!crop || crop.width <= 0 || crop.height <= 0) return
+    onCrop?.(crop)
   }
 
   const resetCrop = () => {
-    if (initialCrop) {
-      setCrop(initialCrop)
-      setCompletedCrop(null)
-    }
+    if (initialCrop) setCrop(initialCrop)
   }
 
   const contextValue: ImageCropContextType = {
-    file,
-    maxImageSize,
-    imgSrc,
+    imgSrc: src,
     crop,
-    completedCrop,
     imgRef,
     onCrop,
     reactCropProps,
@@ -274,11 +184,17 @@ export const ImageCrop = ({
 export type ImageCropContentProps = {
   style?: CSSProperties
   className?: string
+  /**
+   * Sizing for the <img> itself. Callers zoom by giving it an explicit size —
+   * the crop stays in percent, so it survives the resize untouched.
+   */
+  imageStyle?: CSSProperties
 }
 
 export const ImageCropContent = ({
   style,
   className,
+  imageStyle,
 }: ImageCropContentProps) => {
   const {
     imgSrc,
@@ -454,8 +370,11 @@ export const ImageCropContent = ({
   } as CSSProperties
 
   return (
+    // No size cap here: `.ReactCrop__child-wrapper` and the <img> inherit the
+    // root's max-height, so a cap on this element silently overrides whatever
+    // size the caller asked for. Sizing is the caller's to set.
     <ReactCrop
-      className={cn("max-h-[277px] max-w-full", className)}
+      className={className}
       crop={crop}
       onChange={handleChange}
       onComplete={handleComplete}
@@ -513,6 +432,7 @@ export const ImageCropContent = ({
           onLoad={onImageLoad}
           ref={imgRef}
           src={imgSrc}
+          style={imageStyle}
         />
       )}
     </ReactCrop>
@@ -532,13 +452,8 @@ export const ImageCropApply = ({
   const { applyCrop } = useImageCrop()
 
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
-    // Fire user's onClick first (e.g. close the dialog) so the UI can
-    // respond instantly; defer the heavy encode by one tick so the
-    // close animation paints before the main thread gets blocked.
+    applyCrop()
     onClick?.(e)
-    setTimeout(() => {
-      void applyCrop()
-    }, 0)
   }
 
   if (asChild) {
@@ -590,9 +505,8 @@ export const ImageCropReset = ({
 
 // Keep the original Cropper component for backward compatibility
 export type CropperProps = Omit<ReactCropProps, "onChange"> & {
-  file: File
-  maxImageSize?: number
-  onCrop?: (croppedImage: string) => void
+  src: string
+  onCrop?: (region: PercentCrop) => void
   onChange?: ReactCropProps["onChange"]
 }
 
@@ -602,13 +516,11 @@ export const Cropper = ({
   onCrop,
   style,
   className,
-  file,
-  maxImageSize,
+  src,
   ...props
 }: CropperProps) => (
   <ImageCrop
-    file={file}
-    maxImageSize={maxImageSize}
+    src={src}
     onChange={onChange}
     onComplete={onComplete}
     onCrop={onCrop}

--- a/hooks/use-crop-drag-autoscroll.ts
+++ b/hooks/use-crop-drag-autoscroll.ts
@@ -68,7 +68,12 @@ export function useCropDragAutoScroll(
     const step = () => {
       const state = drag.current
       const node = viewportRef.current
-      if (!state || !node) return
+      // Clear the handle whenever we won't schedule another frame so onMove can
+      // re-arm via `state.frame ??= …` (a spent rAF id is still truthy).
+      if (!state || !node) {
+        if (state) state.frame = null
+        return
+      }
       const rect = node.getBoundingClientRect()
       const dx = axisSpeed(state.clientX, rect.left, rect.right)
       const dy = axisSpeed(state.clientY, rect.top, rect.bottom)

--- a/hooks/use-crop-drag-autoscroll.ts
+++ b/hooks/use-crop-drag-autoscroll.ts
@@ -1,0 +1,159 @@
+import * as React from "react"
+
+/** How close to an edge (px) the pointer gets before the view follows it. */
+const EDGE_ZONE = 56
+/** Fastest auto-scroll, px per frame, reached once the pointer is at the edge. */
+const MAX_SPEED = 20
+const MIN_SPEED = 2
+
+type DragState = {
+  pointerId: number
+  target: EventTarget
+  clientX: number
+  clientY: number
+  /** How far the view has scrolled under the pointer during this drag. */
+  offsetX: number
+  offsetY: number
+  frame: number | null
+  /** True while we re-dispatch, so the capture listener ignores its own event. */
+  redispatching: boolean
+}
+
+function axisSpeed(position: number, min: number, max: number) {
+  const speed = (depth: number) =>
+    Math.min(MAX_SPEED, Math.max(MIN_SPEED, (depth / EDGE_ZONE) * MAX_SPEED))
+  if (position < min + EDGE_ZONE) return -speed(min + EDGE_ZONE - position)
+  if (position > max - EDGE_ZONE) return speed(position - (max - EDGE_ZONE))
+  return 0
+}
+
+/**
+ * Scrolls the crop viewport when a drag reaches its edges. Without it a crop
+ * can never be dragged past one screenful of a zoomed-in screenshot — the
+ * pointer just stops at the edge.
+ *
+ * The compensation is the fiddly part: react-image-crop places the crop from
+ * the pointer's TOTAL delta since pointerdown, so scrolling the image under a
+ * stationary pointer would leave the crop behind. Every pointermove is
+ * intercepted on `window` in the capture phase — ahead of the library's own
+ * document capture listener — and re-dispatched with the scrolled distance
+ * added, which keeps the crop edge glued to the cursor.
+ */
+export function useCropDragAutoScroll(
+  viewportRef: React.RefObject<HTMLDivElement | null>
+) {
+  const drag = React.useRef<DragState | null>(null)
+
+  return React.useMemo(() => {
+    const redispatch = (
+      state: DragState,
+      type: "pointermove" | "pointerup"
+    ) => {
+      state.redispatching = true
+      state.target.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          clientX: state.clientX + state.offsetX,
+          clientY: state.clientY + state.offsetY,
+          pointerId: state.pointerId,
+          buttons: type === "pointerup" ? 0 : 1,
+        })
+      )
+      state.redispatching = false
+    }
+
+    const dispatchMove = (state: DragState) => redispatch(state, "pointermove")
+
+    const step = () => {
+      const state = drag.current
+      const node = viewportRef.current
+      if (!state || !node) return
+      const rect = node.getBoundingClientRect()
+      const dx = axisSpeed(state.clientX, rect.left, rect.right)
+      const dy = axisSpeed(state.clientY, rect.top, rect.bottom)
+      if (dx || dy) {
+        const fromX = node.scrollLeft
+        const fromY = node.scrollTop
+        node.scrollLeft = fromX + dx
+        node.scrollTop = fromY + dy
+        // Only what the element actually scrolled counts — at either end of the
+        // range it clamps, and over-counting would drag the crop off-cursor.
+        const movedX = node.scrollLeft - fromX
+        const movedY = node.scrollTop - fromY
+        if (movedX || movedY) {
+          state.offsetX += movedX
+          state.offsetY += movedY
+          dispatchMove(state)
+        }
+      }
+      state.frame = requestAnimationFrame(step)
+    }
+
+    const onMove = (event: PointerEvent) => {
+      const state = drag.current
+      if (!state || state.redispatching) return
+      if (event.pointerId !== state.pointerId) return
+      state.clientX = event.clientX
+      state.clientY = event.clientY
+      if (state.offsetX || state.offsetY) {
+        // The cropper must never see the raw coordinates once the view has
+        // moved: they would snap the crop back by the scrolled distance.
+        event.stopImmediatePropagation()
+        event.preventDefault()
+        dispatchMove(state)
+      }
+      // Started on the first move, not on pointerdown, so merely holding the
+      // button near an edge doesn't scroll.
+      state.frame ??= requestAnimationFrame(step)
+    }
+
+    const stop = () => {
+      const state = drag.current
+      if (!state) return
+      if (state.frame !== null) cancelAnimationFrame(state.frame)
+      drag.current = null
+      window.removeEventListener("pointermove", onMove, true)
+      window.removeEventListener("pointerup", onUp, true)
+      window.removeEventListener("pointercancel", stop, true)
+    }
+
+    /**
+     * The edge-resize bars settle the crop from the pointerup coordinates, so
+     * that event needs the same compensation the moves got — otherwise the crop
+     * snaps back by the scrolled distance the moment the drag ends.
+     */
+    function onUp(event: PointerEvent) {
+      const state = drag.current
+      if (!state || state.redispatching) return
+      if (event.pointerId !== state.pointerId) return
+      if (state.offsetX || state.offsetY) {
+        state.clientX = event.clientX
+        state.clientY = event.clientY
+        event.stopImmediatePropagation()
+        redispatch(state, "pointerup")
+      }
+      stop()
+    }
+
+    const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.pointerType === "mouse" && event.button !== 0) return
+      stop()
+      drag.current = {
+        pointerId: event.pointerId,
+        target: event.target,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        offsetX: 0,
+        offsetY: 0,
+        frame: null,
+        redispatching: false,
+      }
+      window.addEventListener("pointermove", onMove, true)
+      window.addEventListener("pointerup", onUp, true)
+      window.addEventListener("pointercancel", stop, true)
+    }
+
+    return { onPointerDown, stop }
+  }, [viewportRef])
+}

--- a/lib/editor/crop-source.ts
+++ b/lib/editor/crop-source.ts
@@ -24,11 +24,11 @@ import { fetchImageBlob } from "./image-resize"
 const MAX_PREVIEW_DIMENSION = 2200
 
 /**
- * Ceiling on the rendered crop, in pixels. Browsers refuse to allocate canvases
- * past their own area limits (Safari is the strictest) and silently hand back a
- * blank bitmap, so clamp rather than produce an empty crop.
+ * Ceiling on the rendered crop, in pixels. Safari rejects canvases past ~2^24
+ * pixels and silently returns a blank bitmap, so clamp to that common floor
+ * rather than Chrome's higher limit.
  */
-const MAX_OUTPUT_PIXELS = 40_000_000
+const MAX_OUTPUT_PIXELS = 16_777_216
 
 export type CropSource = {
   /** URL for the <img> the crop handles are drawn over — possibly downscaled. */
@@ -97,11 +97,14 @@ function loadImageElement(url: string): Promise<HTMLImageElement> {
   })
 }
 
-function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  type: string = "image/png"
+): Promise<Blob> {
   return new Promise((resolve, reject) => {
     canvas.toBlob(
       (blob) => (blob ? resolve(blob) : reject(new Error("toBlob failed"))),
-      "image/png"
+      type
     )
   })
 }
@@ -149,7 +152,9 @@ async function buildPreviewUrl(
     }
     ctx.drawImage(bitmap, 0, 0)
     bitmap.close()
-    const previewBlob = await canvasToBlob(canvas)
+    // Preview-only: WebP is much smaller than PNG for the same bitmap and is
+    // never re-encoded into the applied crop.
+    const previewBlob = await canvasToBlob(canvas, "image/webp")
     // Free the backing store now rather than waiting on GC; the preview can be
     // tens of megabytes of decoded pixels.
     canvas.width = 0
@@ -246,6 +251,7 @@ export async function renderCroppedImage(
   // A 1:1 copy wants no resampling at all; a capped crop is being shrunk and
   // needs it.
   ctx.imageSmoothingEnabled = scaled
+  if (scaled) ctx.imageSmoothingQuality = "high"
 
   let drawn = false
   if (typeof createImageBitmap === "function") {

--- a/lib/editor/crop-source.ts
+++ b/lib/editor/crop-source.ts
@@ -30,6 +30,13 @@ const MAX_PREVIEW_DIMENSION = 2200
  */
 const MAX_OUTPUT_PIXELS = 16_777_216
 
+/**
+ * Ceiling on either canvas side. Area can stay under {@link MAX_OUTPUT_PIXELS}
+ * while one edge of a tall/narrow crop (e.g. ~900×18k) still exceeds Safari's
+ * per-dimension limit and paints blank.
+ */
+const MAX_OUTPUT_DIMENSION = 8192
+
 export type CropSource = {
   /** URL for the <img> the crop handles are drawn over — possibly downscaled. */
   previewUrl: string
@@ -217,12 +224,18 @@ function regionToPixels(
   return { sx, sy, sw: clampedW, sh: clampedH }
 }
 
-/** Output size for a crop rect, shrunk only if it would exceed the pixel cap. */
+/**
+ * Output size for a crop rect. Shrunk when the area or either side would exceed
+ * Safari-safe canvas limits; aspect ratio is preserved.
+ */
 function outputSize(sw: number, sh: number) {
-  const pixels = sw * sh
-  if (pixels <= MAX_OUTPUT_PIXELS)
-    return { width: sw, height: sh, scaled: false }
-  const scale = Math.sqrt(MAX_OUTPUT_PIXELS / pixels)
+  const scale = Math.min(
+    1,
+    Math.sqrt(MAX_OUTPUT_PIXELS / Math.max(1, sw * sh)),
+    MAX_OUTPUT_DIMENSION / Math.max(1, sw),
+    MAX_OUTPUT_DIMENSION / Math.max(1, sh)
+  )
+  if (scale >= 1) return { width: sw, height: sh, scaled: false }
   return {
     width: Math.max(1, Math.floor(sw * scale)),
     height: Math.max(1, Math.floor(sh * scale)),
@@ -302,6 +315,7 @@ export async function renderCroppedImage(
 
 export const __testing = {
   MAX_OUTPUT_PIXELS,
+  MAX_OUTPUT_DIMENSION,
   MAX_PREVIEW_DIMENSION,
   outputSize,
   regionToPixels,

--- a/lib/editor/crop-source.ts
+++ b/lib/editor/crop-source.ts
@@ -1,0 +1,302 @@
+// Loading and rendering for the crop dialog.
+//
+// The dialog used to turn whatever it was given into a `File` and hand that to
+// the cropper, which read it back out as a base64 data URL. On a 20 MB
+// full-page screenshot that meant a synchronous `atob` plus a byte-at-a-time
+// copy on the main thread, then a second full base64 encode, then a full-res
+// decode into an <img> — several hundred MB of peak allocation and seconds of
+// jank before the dialog could paint. Remote screenshots didn't get that far at
+// all: they were fetched cross-origin without the proxy and died on CORS.
+//
+// Here the source is fetched once as a blob, previewed through an object URL
+// (downscaled when the image is huge), and the applied crop is rendered from
+// the original bytes so output resolution never depends on the preview.
+
+import type { CropRegion } from "./state-types"
+
+import { fetchImageBlob } from "./image-resize"
+
+/**
+ * Longest side of the preview the crop handles are drawn over. The cropper box
+ * is ~420 px tall, so anything past this is invisible detail that costs a
+ * full-resolution bitmap in the DOM for as long as the dialog is open.
+ */
+const MAX_PREVIEW_DIMENSION = 2200
+
+/**
+ * Ceiling on the rendered crop, in pixels. Browsers refuse to allocate canvases
+ * past their own area limits (Safari is the strictest) and silently hand back a
+ * blank bitmap, so clamp rather than produce an empty crop.
+ */
+const MAX_OUTPUT_PIXELS = 40_000_000
+
+export type CropSource = {
+  /** URL for the <img> the crop handles are drawn over — possibly downscaled. */
+  previewUrl: string
+  /** Original bytes. The applied crop is rendered from these, at full size. */
+  blob: Blob
+  /** Intrinsic size of the ORIGINAL, not of the preview. */
+  width: number
+  height: number
+  /** Revokes the object URLs. Safe to call twice. */
+  release: () => void
+}
+
+function isDataOrBlobUrl(url: string) {
+  return url.startsWith("data:") || url.startsWith("blob:")
+}
+
+/**
+ * Bytes for any screenshot URL the editor can hold. `fetch` handles data: and
+ * blob: URLs natively and off the main thread, which is what keeps a 20 MB
+ * base64 screenshot from freezing the tab — decoding it in JS does not.
+ */
+export async function loadImageBlob(url: string): Promise<Blob> {
+  if (isDataOrBlobUrl(url)) {
+    const response = await fetch(url)
+    return await response.blob()
+  }
+  const blob = await fetchImageBlob(url)
+  if (!blob) throw new Error("Could not load image")
+  return blob
+}
+
+type DecodedSize = { width: number; height: number }
+
+/**
+ * Intrinsic size of the source. An <img> gets there off the header without
+ * committing to a full raster decode, so it is tried before `createImageBitmap`
+ * — which always decodes everything, and on a tall scrolling capture that is
+ * hundreds of megabytes we would immediately throw away.
+ */
+async function decodeSize(blob: Blob, url: string): Promise<DecodedSize> {
+  try {
+    const img = await loadImageElement(url)
+    if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+      return { width: img.naturalWidth, height: img.naturalHeight }
+    }
+  } catch {
+    // fall through to createImageBitmap
+  }
+  if (typeof createImageBitmap !== "function") {
+    throw new Error("Could not decode image")
+  }
+  const bitmap = await createImageBitmap(blob)
+  const size = { width: bitmap.width, height: bitmap.height }
+  bitmap.close()
+  return size
+}
+
+function loadImageElement(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.decoding = "async"
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error("Could not decode image"))
+    img.src = url
+  })
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error("toBlob failed"))),
+      "image/png"
+    )
+  })
+}
+
+export function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("FileReader failed"))
+    reader.readAsDataURL(blob)
+  })
+}
+
+/**
+ * A preview no larger than {@link MAX_PREVIEW_DIMENSION}, or null when the
+ * original is already small enough (or the browser can't resize it for us).
+ * `createImageBitmap` does the decode and the resize off the main thread.
+ */
+async function buildPreviewUrl(
+  blob: Blob,
+  { width, height }: DecodedSize
+): Promise<string | null> {
+  const longest = Math.max(width, height)
+  if (longest <= MAX_PREVIEW_DIMENSION) return null
+  if (typeof createImageBitmap !== "function") return null
+
+  const scale = MAX_PREVIEW_DIMENSION / longest
+  const targetW = Math.max(1, Math.round(width * scale))
+  const targetH = Math.max(1, Math.round(height * scale))
+
+  try {
+    const bitmap = await createImageBitmap(blob, {
+      resizeWidth: targetW,
+      resizeHeight: targetH,
+      resizeQuality: "medium",
+    })
+    const canvas = document.createElement("canvas")
+    canvas.width = bitmap.width
+    canvas.height = bitmap.height
+    const ctx = canvas.getContext("2d")
+    if (!ctx) {
+      bitmap.close()
+      return null
+    }
+    ctx.drawImage(bitmap, 0, 0)
+    bitmap.close()
+    const previewBlob = await canvasToBlob(canvas)
+    // Free the backing store now rather than waiting on GC; the preview can be
+    // tens of megabytes of decoded pixels.
+    canvas.width = 0
+    canvas.height = 0
+    return URL.createObjectURL(previewBlob)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Prepare a screenshot URL for the crop dialog: fetch it once, measure it, and
+ * hand back a cheap preview plus the original bytes.
+ */
+export async function createCropSource(url: string): Promise<CropSource> {
+  return await cropSourceFromBlob(await loadImageBlob(url))
+}
+
+/** Same as {@link createCropSource} for bytes already in hand (a video poster). */
+export async function cropSourceFromBlob(blob: Blob): Promise<CropSource> {
+  const blobUrl = URL.createObjectURL(blob)
+  let previewUrl: string | null = null
+
+  try {
+    const size = await decodeSize(blob, blobUrl)
+    previewUrl = await buildPreviewUrl(blob, size)
+    let released = false
+    return {
+      previewUrl: previewUrl ?? blobUrl,
+      blob,
+      width: size.width,
+      height: size.height,
+      release: () => {
+        if (released) return
+        released = true
+        URL.revokeObjectURL(blobUrl)
+        if (previewUrl) URL.revokeObjectURL(previewUrl)
+      },
+    }
+  } catch (error) {
+    URL.revokeObjectURL(blobUrl)
+    if (previewUrl) URL.revokeObjectURL(previewUrl)
+    throw error
+  }
+}
+
+/** Region in percent → integer source-pixel rect, clamped inside the image. */
+function regionToPixels(
+  region: CropRegion,
+  width: number,
+  height: number
+): { sx: number; sy: number; sw: number; sh: number } | null {
+  const sx = Math.round(Math.max(0, Math.min(100, region.x)) * width * 0.01)
+  const sy = Math.round(Math.max(0, Math.min(100, region.y)) * height * 0.01)
+  const sw = Math.round(Math.max(0, region.width) * width * 0.01)
+  const sh = Math.round(Math.max(0, region.height) * height * 0.01)
+  const clampedW = Math.min(sw, width - sx)
+  const clampedH = Math.min(sh, height - sy)
+  if (clampedW < 1 || clampedH < 1) return null
+  return { sx, sy, sw: clampedW, sh: clampedH }
+}
+
+/** Output size for a crop rect, shrunk only if it would exceed the pixel cap. */
+function outputSize(sw: number, sh: number) {
+  const pixels = sw * sh
+  if (pixels <= MAX_OUTPUT_PIXELS)
+    return { width: sw, height: sh, scaled: false }
+  const scale = Math.sqrt(MAX_OUTPUT_PIXELS / pixels)
+  return {
+    width: Math.max(1, Math.floor(sw * scale)),
+    height: Math.max(1, Math.floor(sh * scale)),
+    scaled: true,
+  }
+}
+
+/**
+ * Render a percent crop of the source at full resolution and return it as a PNG
+ * data URL. Percent regions are resolution-independent, so the preview the user
+ * dragged the handles over can be a downscaled stand-in without affecting this.
+ */
+export async function renderCroppedImage(
+  source: Pick<CropSource, "blob" | "width" | "height">,
+  region: CropRegion
+): Promise<string | null> {
+  const rect = regionToPixels(region, source.width, source.height)
+  if (!rect) return null
+
+  const { width, height, scaled } = outputSize(rect.sw, rect.sh)
+  const canvas = document.createElement("canvas")
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext("2d")
+  if (!ctx) return null
+  // A 1:1 copy wants no resampling at all; a capped crop is being shrunk and
+  // needs it.
+  ctx.imageSmoothingEnabled = scaled
+
+  let drawn = false
+  if (typeof createImageBitmap === "function") {
+    try {
+      // Cropping during decode: the browser never materialises the full-size
+      // bitmap on our side, which is the difference between a working crop and
+      // an out-of-memory tab on a tall scrolling capture.
+      const bitmap = await createImageBitmap(
+        source.blob,
+        rect.sx,
+        rect.sy,
+        rect.sw,
+        rect.sh
+      )
+      ctx.drawImage(bitmap, 0, 0, width, height)
+      bitmap.close()
+      drawn = true
+    } catch {
+      // fall through to <img>
+    }
+  }
+
+  if (!drawn) {
+    const url = URL.createObjectURL(source.blob)
+    try {
+      const img = await loadImageElement(url)
+      ctx.drawImage(
+        img,
+        rect.sx,
+        rect.sy,
+        rect.sw,
+        rect.sh,
+        0,
+        0,
+        width,
+        height
+      )
+    } finally {
+      URL.revokeObjectURL(url)
+    }
+  }
+
+  const blob = await canvasToBlob(canvas)
+  canvas.width = 0
+  canvas.height = 0
+  return await blobToDataUrl(blob)
+}
+
+export const __testing = {
+  MAX_OUTPUT_PIXELS,
+  MAX_PREVIEW_DIMENSION,
+  outputSize,
+  regionToPixels,
+}

--- a/lib/editor/image-resize.ts
+++ b/lib/editor/image-resize.ts
@@ -240,7 +240,12 @@ function isSameOrigin(url: string): boolean {
   }
 }
 
-async function fetchBlobForDownscale(url: string): Promise<Blob | null> {
+/**
+ * Fetch image bytes for a URL, routing cross-origin reads through the
+ * same-origin proxy so a host without CORS headers (assets.tokokino.com, most
+ * CDNs) still yields a readable blob.
+ */
+export async function fetchImageBlob(url: string): Promise<Blob | null> {
   // Same-origin requests just hit the URL directly.
   if (isSameOrigin(url)) {
     try {
@@ -278,7 +283,7 @@ export function downscaleImageFromUrl(
   if (cached) return cached
 
   const promise = (async () => {
-    const blob = await fetchBlobForDownscale(url)
+    const blob = await fetchImageBlob(url)
     if (blob) {
       try {
         const source = await decodeBlob(blob)

--- a/tests/lib/editor/crop-source.test.ts
+++ b/tests/lib/editor/crop-source.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+
+import { __testing } from "@/lib/editor/crop-source"
+
+const { MAX_OUTPUT_PIXELS, outputSize, regionToPixels } = __testing
+
+describe("regionToPixels", () => {
+  it("maps a percent region onto source pixels", () => {
+    expect(regionToPixels({ x: 25, y: 50, width: 50, height: 25 }, 800, 400)) //
+      .toEqual({ sx: 200, sy: 200, sw: 400, sh: 100 })
+  })
+
+  it("keeps the rect inside the image when the region overruns it", () => {
+    // Percent crops come back from the cropper as floats and can round a pixel
+    // past the edge; drawing from outside the source yields transparent bands.
+    const rect = regionToPixels(
+      { x: 90, y: 90, width: 20, height: 20 },
+      100,
+      100
+    )
+    expect(rect).toEqual({ sx: 90, sy: 90, sw: 10, sh: 10 })
+  })
+
+  it("rejects a region that lands on less than a pixel", () => {
+    expect(
+      regionToPixels({ x: 0, y: 0, width: 0, height: 50 }, 800, 400)
+    ).toBeNull()
+    expect(
+      regionToPixels({ x: 100, y: 0, width: 10, height: 50 }, 800, 400)
+    ).toBeNull()
+  })
+})
+
+describe("outputSize", () => {
+  it("renders a normal crop at full resolution", () => {
+    expect(outputSize(2400, 1600)).toEqual({
+      width: 2400,
+      height: 1600,
+      scaled: false,
+    })
+  })
+
+  it("shrinks a crop that would exceed the canvas pixel cap", () => {
+    // A tall scrolling capture: the browser hands back a blank bitmap instead
+    // of erroring when the canvas is too big, so the crop must be clamped.
+    const size = outputSize(4000, 30000)
+    expect(size.scaled).toBe(true)
+    expect(size.width * size.height).toBeLessThanOrEqual(MAX_OUTPUT_PIXELS)
+    // Aspect ratio survives the clamp.
+    expect(size.width / size.height).toBeCloseTo(4000 / 30000, 3)
+  })
+})

--- a/tests/lib/editor/crop-source.test.ts
+++ b/tests/lib/editor/crop-source.test.ts
@@ -49,4 +49,13 @@ describe("outputSize", () => {
     // Aspect ratio survives the clamp.
     expect(size.width / size.height).toBeCloseTo(4000 / 30000, 3)
   })
+
+  it("keeps a crop at the pixel cap at full resolution", () => {
+    const side = Math.sqrt(MAX_OUTPUT_PIXELS)
+    expect(outputSize(side, side)).toEqual({
+      width: side,
+      height: side,
+      scaled: false,
+    })
+  })
 })

--- a/tests/lib/editor/crop-source.test.ts
+++ b/tests/lib/editor/crop-source.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest"
 
 import { __testing } from "@/lib/editor/crop-source"
 
-const { MAX_OUTPUT_PIXELS, outputSize, regionToPixels } = __testing
+const { MAX_OUTPUT_DIMENSION, MAX_OUTPUT_PIXELS, outputSize, regionToPixels } =
+  __testing
 
 describe("regionToPixels", () => {
   it("maps a percent region onto source pixels", () => {
@@ -46,8 +47,21 @@ describe("outputSize", () => {
     const size = outputSize(4000, 30000)
     expect(size.scaled).toBe(true)
     expect(size.width * size.height).toBeLessThanOrEqual(MAX_OUTPUT_PIXELS)
+    expect(size.width).toBeLessThanOrEqual(MAX_OUTPUT_DIMENSION)
+    expect(size.height).toBeLessThanOrEqual(MAX_OUTPUT_DIMENSION)
     // Aspect ratio survives the clamp.
     expect(size.width / size.height).toBeCloseTo(4000 / 30000, 3)
+  })
+
+  it("shrinks a thin crop that fits the area cap but not a side limit", () => {
+    // 1500×30000 → area-only scale lands near 915×18310, which still exceeds
+    // Safari's per-dimension canvas limit.
+    const size = outputSize(1500, 30000)
+    expect(size.scaled).toBe(true)
+    expect(size.width).toBeLessThanOrEqual(MAX_OUTPUT_DIMENSION)
+    expect(size.height).toBeLessThanOrEqual(MAX_OUTPUT_DIMENSION)
+    expect(size.width * size.height).toBeLessThanOrEqual(MAX_OUTPUT_PIXELS)
+    expect(size.width / size.height).toBeCloseTo(1500 / 30000, 3)
   })
 
   it("keeps a crop at the pixel cap at full resolution", () => {


### PR DESCRIPTION
## Summary

Crop was unusable in two different ways. For any screenshot served from another origin (`assets.tokokino.com`, the demo images) clicking **Crop** did nothing at all — the dialog fetched the URL directly, CORS rejected it, the rejection was swallowed by an empty `catch`, and the component returned `null` before rendering. For heavy sources — a 20 MB full-page scroll capture — the dialog took seconds to appear or crashed the tab outright.

Both are fixed, and long scrolling captures get a zoom control, since fitting one into the 420 px cropper leaves a sliver a few pixels wide with nothing to aim the handles at.

## Type of Change

- [x] fix
- [ ] refactor
- [ ] delete
- [x] optimised
- [ ] docs

## Related Issues

<!-- none -->

## Changes Made

**Remote sources go through the proxy.** `fetchBlobForDownscale` in `image-resize.ts` already routed cross-origin reads through the same-origin `/api/export/image`; it is now exported as `fetchImageBlob` and reused instead of the crop dialog's bare `fetch`. This also survives ad blockers that block the asset host directly, since the bytes arrive from our own origin.

**New `lib/editor/crop-source.ts` replaces the load/render pipeline.** The old path turned whatever it was given into a `File`, which the cropper read back out as a base64 data URL:

- synchronous `atob` plus a byte-at-a-time `while (n--)` copy over 20 M bytes, on the main thread, inside a `useMemo` during render
- a second full base64 encode via `FileReader`
- a full-resolution decode into the DOM `<img>` (a 1500x30000 capture is ~180 MB of RGBA)
- a crop canvas at full natural size, past the browser's canvas limits, which silently returns a blank bitmap

Now the source is fetched once as a blob (`fetch` handles `data:`/`blob:` URLs natively and off-thread — no JS base64 decoding), previewed through an object URL downscaled to 2200 px via `createImageBitmap`, and the applied crop is rendered from the original bytes with `createImageBitmap(blob, sx, sy, sw, sh)` so the full-size bitmap never lands in our heap. Output is clamped to 40 M pixels. Percent regions are resolution-independent, so the downscaled preview costs nothing in output quality.

**The dialog opens immediately** with a loading state (spinner delayed 180 ms so small screenshots don't flash it) instead of waiting for the decode, and load failures raise a toast instead of silently doing nothing.

**Zoom + scrollable viewport** in the crop dialog: 100%–1600%, defaulting to fit — an auto-zoom was tried and dropped, because opening at 1600% hides where the crop sits in the page, which is the one thing the preview is for. Zooming preserves the viewport's centre rather than snapping to the top-left.

**Drag auto-scrolls at the edges** (`hooks/use-crop-drag-autoscroll.ts`). The fiddly part: react-image-crop places the crop from the pointer's *total* delta since pointerdown, so scrolling the image under a stationary pointer would leave the crop behind. Every `pointermove` is intercepted on `window` in the capture phase — ahead of the library's own `document` capture listener — and re-dispatched with the scrolled distance added. `pointerup` gets the same treatment, because the edge-resize bars settle the crop from the release coordinates.

**`components/kibo-ui/image-crop`** now takes `src: string` instead of `file: File` and reports the selected region only; rendering moved to the caller. Its hardcoded `max-h-[277px] max-w-full` is gone — `.ReactCrop__child-wrapper` and its `<img>` inherit `max-height` from that root, so the cap silently overrode any size the caller asked for and pinned the image at the fitted size however far it was zoomed.

**Unrelated small fixes carried along:**

- the Animate pill is hidden in bulk edit, where it was already disabled and overlapped the bulk arrange bar at iPad widths
- the export dialog's select-all button is `rounded-md` instead of a pill
- the crop dialog's subtitle is a real `DialogDescription`, clearing Radix's missing-description console warning
- object URLs are revoked 400 ms after close rather than instantly, which was producing a failed `blob:` request during the exit animation

## Screenshots / Recordings (if UI)

<!-- Crop dialog with the zoom pill at top-right of the cropper area -->

## Checklist

- [x] I ran `pnpm lint`
- [x] I ran `pnpm typecheck`
- [x] I ran `pnpm test` — 150 files, 1141 tests passing, including new coverage for the crop rect/clamp math
- [x] I did not include secrets or sensitive data
- [ ] I updated docs when behavior changed
- [x] I kept this PR focused and reasonably small

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved crop experience with preview generation, zoom controls, percent-based selection, and safer cleanup of temporary media resources.
  * Added automatic viewport scrolling when dragging near crop edges.
  * Enabled efficient cropping with output-size limits and more consistent results.
* **Bug Fixes**
  * Hid the floating Animate control during bulk editing.
  * Improved video/screenshot crop rendering reliability and frame selection.
  * Refined bulk export “Select all / Deselect all” button styling.
* **Tests**
  * Added coverage for crop region boundary mapping and output scaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes cropping reliable for remote and large screenshots.
- Routes cross-origin image loading through the existing same-origin image proxy.
- Adds downscaled previews while rendering selected crops from the original image bytes.
- Constrains crop output by both Safari-compatible canvas area and per-dimension limits.
- Opens the crop dialog with a loading state and adds zoom and drag auto-scroll behavior.
- Updates the reusable crop component to report percent-based regions instead of rendering output itself.
- Includes minor bulk-edit and export-control presentation adjustments.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the current output sizing enforces both the Safari-compatible total canvas area and 8192-pixel per-dimension ceiling, resolving the previously reported crop failures.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/editor/crop-source.ts | Implements proxied loading, bounded previews, percent-to-pixel mapping, and output scaling that now enforces both canvas-area and per-side limits. |
| tests/lib/editor/crop-source.test.ts | Covers normal output, oversized-area scaling, thin crops exceeding the dimension limit, and the canvas-area boundary. |
| components/editor/crop-modal.tsx | Moves source preparation and final rendering into the dialog, adds immediate loading feedback, zoom controls, and delayed source cleanup. |
| components/kibo-ui/image-crop/index.tsx | Changes the cropper contract to consume a source URL and return a percent crop region. |
| hooks/use-crop-drag-autoscroll.ts | Adds edge-triggered viewport scrolling with pointer-coordinate compensation during crop dragging. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(crop): clamp canvas side length for ..."](https://github.com/shivabhattacharjee/tokokino/commit/18b7e4d3cccc50cee3484e1492f864301f8bb516) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47512910)</sub>

<!-- /greptile_comment -->