### PR TITLE
fix(editor): report failures instead of swallowing them

### DIFF
--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -5,18 +5,6 @@ export default function ScreenshotsLayout({
 }) {
   return (
     <div className="h-svh overflow-hidden bg-background text-foreground">
-      {/*
-        The resource-timing buffer holds 250 entries by default and silently
-        drops everything after that. A chunk-heavy editor boot can fill it,
-        costing `lib/offline/offline-shell.ts` exactly the lazily loaded chunks
-        it reads the timeline for. Raised inline so it takes effect before the
-        page's own scripts start loading.
-      */}
-      <script
-        dangerouslySetInnerHTML={{
-          __html: "performance.setResourceTimingBufferSize?.(1000)",
-        }}
-      />
       {children}
     </div>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -230,6 +230,20 @@ export default function RootLayout({
       <head>
         <link rel="preconnect" href="https://assets.tokokino.com" />
         <link rel="dns-prefetch" href="https://assets.tokokino.com" />
+        {/*
+          The resource-timing buffer holds 250 entries by default and silently
+          drops everything after that. A chunk-heavy editor boot can fill it,
+          costing `lib/offline/offline-shell.ts` exactly the lazily loaded
+          chunks it reads the timeline for. It lives here rather than in the
+          editor's own layout because React never runs a script it creates
+          during a client render, so a client navigation into /app would skip
+          it — the root layout is only ever rendered into the initial HTML.
+        */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: "performance.setResourceTimingBufferSize?.(1000)",
+          }}
+        />
       </head>
       <body>
         <NextTopLoader

--- a/app/login/login-form.tsx
+++ b/app/login/login-form.tsx
@@ -30,7 +30,9 @@ export function LoginForm({
     try {
       await onBeforeSignIn?.()
     } catch (error) {
-      console.warn("Could not save local editor state before sign-in", error)
+      // The editor's hook reports its own failure; this only guards a caller
+      // that throws, which must not swallow the sign-in itself.
+      console.error("onBeforeSignIn failed", error)
     }
     try {
       const { error } = await authClient.signIn.social({

--- a/components/editor/animate/use-animate-timeline.ts
+++ b/components/editor/animate/use-animate-timeline.ts
@@ -832,9 +832,18 @@ export function useAnimateTimeline() {
   const duplicateVideo = React.useCallback(
     (id: string) => {
       const clip = resolvedVideoClips.find((item) => item.id === id)
-      if (!clip) return
+      // A clip whose media hasn't reported a duration yet has nothing to copy,
+      // and the store drops the request — say so rather than no-op the menu.
+      if (!clip || clip.endMs - clip.startMs <= 0) {
+        toast.error("Could not duplicate this video clip")
+        return
+      }
       const newId = duplicateVideoClip(id, clip.endMs - clip.startMs)
-      if (newId) setSelectedVideoClipIds([newId])
+      if (!newId) {
+        toast.error("Could not duplicate this video clip")
+        return
+      }
+      setSelectedVideoClipIds([newId])
     },
     [duplicateVideoClip, resolvedVideoClips, setSelectedVideoClipIds]
   )
@@ -1309,7 +1318,11 @@ export function useAnimateTimeline() {
   const duplicateClip = React.useCallback(
     (id: string) => {
       const newIds = duplicateAnimationClips(resolveTargetIds(id))
-      if (newIds.length) setAnimationClipSelection(newIds)
+      if (!newIds.length) {
+        toast.error("Could not duplicate the keyframe")
+        return
+      }
+      setAnimationClipSelection(newIds)
     },
     [duplicateAnimationClips, resolveTargetIds, setAnimationClipSelection]
   )
@@ -1418,6 +1431,7 @@ export function useAnimateTimeline() {
         e.preventDefault()
         const newIds = duplicateAnimationClips(ids)
         if (newIds.length) setAnimationClipSelection(newIds)
+        else toast.error("Could not duplicate the keyframe")
       } else if (
         (e.key === "a" || e.key === "A") &&
         (e.metaKey || e.ctrlKey) &&

--- a/components/editor/canvas/use-image-file-intake.ts
+++ b/components/editor/canvas/use-image-file-intake.ts
@@ -46,12 +46,19 @@ export function useImageFileIntake(
   const runGifTranscode = React.useCallback(
     (file: File) => {
       onPreparingChange?.(true)
+      // The user agreed to a conversion in the dialog, so a fallback to the
+      // plain <img> path is a different result than the one they asked for —
+      // no timeline, no video bar. Say so rather than let them hunt for it.
+      const fallBackToImage = () => {
+        toast.error("Could not convert that GIF — added it as an image instead")
+        readRawDataUrl(file, onImage)
+      }
       transcodeGifToVideo(file)
         .then((blob) => {
           if (blob) onImage(registerObjectUrl(blob))
-          else readRawDataUrl(file, onImage)
+          else fallBackToImage()
         })
-        .catch(() => readRawDataUrl(file, onImage))
+        .catch(fallBackToImage)
         .finally(() => onPreparingChange?.(false))
     },
     [onImage, onPreparingChange]

--- a/components/editor/present-presets-section.tsx
+++ b/components/editor/present-presets-section.tsx
@@ -38,6 +38,10 @@ import {
   type CustomPresetSummary,
 } from "@/lib/editor/store"
 import { useSession } from "@/lib/auth-client"
+import {
+  liveClipCount,
+  resolvePresetAnimateIntent,
+} from "@/lib/editor/animation-presence"
 import { isVideoSrc } from "@/lib/editor/media-type"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { cn } from "@/lib/utils"
@@ -155,6 +159,7 @@ export function PresentPresetsSection({
   const customPresetsSort = useEditorStore((s) => s.customPresetsSort)
   const customPresetsLoaded = useEditorStore((s) => s.customPresetsLoaded)
   const customPresetsLoading = useEditorStore((s) => s.customPresetsLoading)
+  const customPresetsError = useEditorStore((s) => s.customPresetsError)
   const setCustomPresets = useEditorStore((s) => s.setCustomPresets)
   const clearCustomPresets = useEditorStore((s) => s.clearCustomPresets)
   const loadCustomPresets = useEditorStore((s) => s.loadCustomPresets)
@@ -265,6 +270,11 @@ export function PresentPresetsSection({
     },
     [customPresetsSort, loadCustomPresets, userId]
   )
+
+  const handleRetryCustomPresets = React.useCallback(() => {
+    if (!userId) return
+    loadCustomPresets(userId)
+  }, [loadCustomPresets, userId])
 
   const handleDeleteCustomPreset = React.useCallback(
     async (id: string) => {
@@ -475,6 +485,11 @@ export function PresentPresetsSection({
         toast.error("Videos can only use a single slot")
         return
       }
+      const intent = resolvePresetAnimateIntent(preset.type, geometry)
+      if (intent === "missing-timeline") {
+        toast.error(`"${preset.name}" has no timeline left to apply`)
+        return
+      }
       // Geometry includes a snapshot of every styling field on the canvas
       // (background, backdrop, border, shadow, overlay, portrait, padding,
       // radius, frame, text/asset/annotation layers, etc.) — not just the
@@ -491,11 +506,13 @@ export function PresentPresetsSection({
         activeSinglePresetId: null,
         activeCustomPresetId: preset.id,
       })
-      const animateClips = geometry.animation?.clips
-      const isAnimatePreset =
-        preset.type === "animate" ||
-        (Array.isArray(animateClips) && animateClips.length > 0)
-      if (isAnimatePreset) {
+      if (intent === "animate") {
+        // The remap onto live slot ids happens inside the store, so confirm the
+        // clips are really on the canvas before showing the user a timeline.
+        if (!liveClipCount(useEditorStore.getState().present)) {
+          toast.error(`Applied "${preset.name}", but its timeline was dropped`)
+          return
+        }
         // Enter Animate so the timeline is visible; store selects the last clip.
         setIsAnimateMode(true)
       }
@@ -657,6 +674,7 @@ export function PresentPresetsSection({
             customPresets={visibleCustomPresets}
             customPresetsLoading={customPresetsLoading}
             customPresetsLoaded={customPresetsLoaded}
+            customPresetsError={customPresetsError}
             isAuthPending={isAuthPending}
             userId={userId}
             isAnimateMode={isAnimateMode}
@@ -667,6 +685,7 @@ export function PresentPresetsSection({
             onApplyCustom={applyCustomPreset}
             onDeleteCustom={handleDeleteCustomPreset}
             onRenameCustom={handleRenameCustomPreset}
+            onRetryCustom={handleRetryCustomPresets}
           />
         )
 

--- a/components/editor/present-presets-section/cards.tsx
+++ b/components/editor/present-presets-section/cards.tsx
@@ -98,6 +98,7 @@ export function PresetCardsBody({
   customPresets,
   customPresetsLoading,
   customPresetsLoaded,
+  customPresetsError = false,
   isAuthPending,
   userId,
   isAnimateMode = false,
@@ -108,6 +109,7 @@ export function PresetCardsBody({
   onApplyCustom,
   onDeleteCustom,
   onRenameCustom,
+  onRetryCustom,
 }: {
   displayTab: PresetTab
   horizontal: boolean
@@ -117,6 +119,8 @@ export function PresetCardsBody({
   customPresets: CustomPresetSummary[]
   customPresetsLoading: boolean
   customPresetsLoaded: boolean
+  /** Last load failed — show that instead of an empty account. */
+  customPresetsError?: boolean
   isAuthPending: boolean
   userId: string | null
   /** When true, Custom tab is showing animate presets only. */
@@ -128,6 +132,7 @@ export function PresetCardsBody({
   onApplyCustom: (preset: CustomPresetSummary) => void
   onDeleteCustom: (id: string) => void | Promise<void>
   onRenameCustom: (id: string, name: string) => void | Promise<void>
+  onRetryCustom?: () => void
 }) {
   // Every single preset shares this row math, so run it once for the rail.
   // `null` when there are no extra slots — the common case, and the one where
@@ -188,6 +193,8 @@ export function PresetCardsBody({
             customPresetsLoading ||
             (Boolean(userId) && !customPresetsLoaded)
           }
+          failed={customPresetsError}
+          onRetry={onRetryCustom}
           loggedIn={Boolean(userId)}
           isAnimateMode={isAnimateMode}
           activeCustomPresetId={activeCustomPresetId}
@@ -246,6 +253,7 @@ function PresetCardSlot({
 function CustomPresetList({
   presets,
   loading,
+  failed = false,
   loggedIn,
   isAnimateMode = false,
   activeCustomPresetId,
@@ -255,9 +263,11 @@ function CustomPresetList({
   onApply,
   onDelete,
   onRename,
+  onRetry,
 }: {
   presets: CustomPresetSummary[]
   loading: boolean
+  failed?: boolean
   loggedIn: boolean
   isAnimateMode?: boolean
   activeCustomPresetId: string | null
@@ -267,6 +277,7 @@ function CustomPresetList({
   onApply: (preset: CustomPresetSummary) => void
   onDelete: (id: string) => void | Promise<void>
   onRename: (id: string, name: string) => void | Promise<void>
+  onRetry?: () => void
 }) {
   if (loading) {
     const aw = aspect.w || 16
@@ -299,6 +310,28 @@ function CustomPresetList({
     return (
       <div className="rounded-lg border border-dashed border-border/60 bg-secondary/20 p-4 text-center text-[12px] text-muted-foreground">
         Sign in to save and reuse your own layout presets.
+      </div>
+    )
+  }
+
+  // Ranked above the empty state: "no presets yet" would be a claim about the
+  // account that a failed request can't support.
+  if (failed) {
+    return (
+      <div className="rounded-lg border border-dashed border-destructive/50 bg-destructive/5 p-4 text-center text-[12px] text-muted-foreground">
+        Could not load your presets.
+        {onRetry ? (
+          <>
+            {" "}
+            <button
+              type="button"
+              onClick={onRetry}
+              className="font-medium text-foreground underline underline-offset-2"
+            >
+              Try again
+            </button>
+          </>
+        ) : null}
       </div>
     )
   }

--- a/components/editor/top-bar/index.tsx
+++ b/components/editor/top-bar/index.tsx
@@ -91,7 +91,7 @@ import {
 import { readImageFileAsDataUrl } from "@/lib/editor/image-resize"
 import {
   captureClipPose,
-  saveCurrentEditorDraft,
+  saveEditorDraftBeforeAuth,
   useEditorStore,
 } from "@/lib/editor/store"
 import type { CurrentDraftInfo, CustomPresetSummary } from "@/lib/editor/store"
@@ -107,6 +107,10 @@ import {
 import { randomDisplayName } from "@/lib/random-name"
 import { TemplatesDialog } from "@/components/editor/templates/templates-dialog"
 import type { Template } from "@/lib/editor/templates"
+import {
+  applyTemplate,
+  templateApplyErrorMessage,
+} from "@/lib/editor/templates/apply"
 import { captureCurrentAsTemplate } from "@/lib/editor/templates/capture"
 import { env } from "@/lib/env"
 
@@ -316,7 +320,6 @@ export function TopBar() {
     canUndo || canRedo || Boolean(currentDraft) || hasEditorContent
   const setCurrentDraft = useEditorStore((s) => s.setCurrentDraft)
   const loadDraftState = useEditorStore((s) => s.loadDraftState)
-  const loadTemplateState = useEditorStore((s) => s.loadTemplateState)
   const addCustomPreset = useEditorStore((s) => s.addCustomPreset)
   const updateCustomPresetInStore = useEditorStore((s) => s.updateCustomPreset)
   const setPresetTab = useEditorStore((s) => s.setPresetTab)
@@ -779,9 +782,7 @@ export function TopBar() {
       if (isAuthPending) return
 
       if (!session) {
-        void saveCurrentEditorDraft().catch((error) => {
-          console.warn("Could not save local editor state before auth", error)
-        })
+        void saveEditorDraftBeforeAuth()
         setShareDialog((current) => ({ ...current, open: false }))
         setAuthDialog({ open: true, action })
         return
@@ -809,9 +810,7 @@ export function TopBar() {
     if (isAuthPending) return
 
     if (!session) {
-      void saveCurrentEditorDraft().catch((error) => {
-        console.warn("Could not save local editor state before auth", error)
-      })
+      void saveEditorDraftBeforeAuth()
       setShareDialog((current) => ({ ...current, open: false }))
       setAuthDialog({ open: true, action: "save" })
       return
@@ -1171,21 +1170,17 @@ export function TopBar() {
     }
   }, [isStoringOffline, offlineShell])
 
-  const handleApplyTemplate = React.useCallback(
-    (template: Template) => {
-      try {
-        const { present, ui } = unwrapDraftState(template.state)
-        // Templates apply composition only — their screenshot media is stripped
-        // in loadTemplateState — so there are no server videos to hydrate.
-        loadTemplateState(present, ui)
-        toast.success(`Applied "${template.name}"`)
-      } catch (err) {
-        console.error(err)
-        toast.error("Could not apply template")
-      }
-    },
-    [loadTemplateState]
-  )
+  const handleApplyTemplate = React.useCallback((template: Template) => {
+    try {
+      // Templates apply composition only — their screenshot media is stripped
+      // in loadTemplateState — so there are no server videos to hydrate.
+      applyTemplate(template)
+      toast.success(`Applied "${template.name}"`)
+    } catch (err) {
+      console.error(err)
+      toast.error(templateApplyErrorMessage(err))
+    }
+  }, [])
 
   const handleCopyTemplateJson = React.useCallback(async () => {
     const slugInput =
@@ -1514,7 +1509,7 @@ export function TopBar() {
             <LoginForm
               callbackURL="/app"
               variant="dialog"
-              onBeforeSignIn={saveCurrentEditorDraft}
+              onBeforeSignIn={saveEditorDraftBeforeAuth}
             />
           </DialogContent>
         </Dialog>

--- a/lib/editor/animation-presence.ts
+++ b/lib/editor/animation-presence.ts
@@ -1,0 +1,52 @@
+import type { EditorState } from "./state-types"
+
+/**
+ * Anything that may carry a saved timeline: a canvas, a preset geometry. Only
+ * `clips` is read, and whatever else the shape carries rides along untouched.
+ */
+type AnimationCarrier = {
+  animation?: { clips?: readonly unknown[]; [key: string]: unknown } | null
+}
+
+/**
+ * Whether an animation survived being applied.
+ *
+ * Every path that loads a saved composition — templates, animate presets,
+ * drafts — hands the store an arbitrary payload that `normalizeEditorState`
+ * (and the preset slot remapper) merge against current defaults. A timeline
+ * whose shape no longer matches is reduced to zero clips rather than rejected,
+ * so the composition still lands and the only difference is an empty timeline.
+ * Callers compare the payload against the live canvas through these two helpers
+ * so that drop is reported instead of passing as a successful apply.
+ */
+export function payloadClipCount(
+  carriers: readonly (AnimationCarrier | undefined | null)[] | undefined
+) {
+  return (carriers ?? []).reduce(
+    (total, carrier) => total + (carrier?.animation?.clips?.length ?? 0),
+    0
+  )
+}
+
+/** Clips the live editor holds on the canvas the user is looking at. */
+export function liveClipCount(present: EditorState) {
+  const active = present.canvases.find((c) => c.id === present.activeCanvasId)
+  return active?.animation?.clips.length ?? 0
+}
+
+/**
+ * What a saved preset should do with Animate mode.
+ *
+ * `"missing-timeline"` is the case worth naming: a preset saved as animate whose
+ * clips are gone. Applying it would style the canvas and open Animate on an
+ * empty track — the styling makes it look like it worked, so the caller has to
+ * refuse rather than guess.
+ */
+export function resolvePresetAnimateIntent(
+  type: string | undefined,
+  geometry: AnimationCarrier
+): "style" | "animate" | "missing-timeline" {
+  const clips = payloadClipCount([geometry])
+  if (clips > 0) return "animate"
+  return type === "animate" ? "missing-timeline" : "style"
+}

--- a/lib/editor/store.tsx
+++ b/lib/editor/store.tsx
@@ -742,7 +742,11 @@ export {
   useSelectedScreenshotSlot,
   type EditorContext,
 } from "./store/use-editor"
-export { EditorProvider, saveCurrentEditorDraft } from "./store/provider"
+export {
+  EditorProvider,
+  saveCurrentEditorDraft,
+  saveEditorDraftBeforeAuth,
+} from "./store/provider"
 
 type SetPatch =
   | Partial<EditorState>
@@ -1162,6 +1166,12 @@ export type EditorStore = {
   customPresets: CustomPresetSummary[]
   customPresetsLoaded: boolean
   customPresetsLoading: boolean
+  /**
+   * Set when the last load failed. Without it a failed fetch is indistinguishable
+   * from an empty account, and the picker tells the user they have no presets
+   * saved while their presets are sitting on the server.
+   */
+  customPresetsError: boolean
   /** User id the current `customPresets` list was fetched for. */
   customPresetsForUserId: string | null
   /**
@@ -1447,6 +1457,7 @@ export const useEditorStore = create<EditorStore>((set, get) => {
     customPresets: [],
     customPresetsLoaded: false,
     customPresetsLoading: false,
+    customPresetsError: false,
     customPresetsForUserId: null,
     customPresetsSort: "latest",
     customPresetsListSort: "latest",
@@ -1458,7 +1469,11 @@ export const useEditorStore = create<EditorStore>((set, get) => {
     setActiveCustomPresetId: (id) => set({ activeCustomPresetId: id }),
     setActiveSinglePresetId: (id) => set({ activeSinglePresetId: id }),
     setCustomPresets: (presets) =>
-      set({ customPresets: presets, customPresetsLoaded: true }),
+      set({
+        customPresets: presets,
+        customPresetsLoaded: true,
+        customPresetsError: false,
+      }),
     clearCustomPresets: () => {
       customPresetsRequestToken++
       customPresetsInFlightUserId = null
@@ -1466,6 +1481,7 @@ export const useEditorStore = create<EditorStore>((set, get) => {
         customPresets: [],
         customPresetsLoaded: false,
         customPresetsLoading: false,
+        customPresetsError: false,
         customPresetsForUserId: null,
       })
     },
@@ -1473,8 +1489,11 @@ export const useEditorStore = create<EditorStore>((set, get) => {
       const state = get()
       const nextSort = sort ?? state.customPresetsSort
       const sortChanged = nextSort !== state.customPresetsSort
+      // A failed load also lands on `customPresetsLoaded` (it stops the
+      // skeleton), so it must not dedupe away the retry.
       if (
         state.customPresetsLoaded &&
+        !state.customPresetsError &&
         state.customPresetsForUserId === userId &&
         !sortChanged
       )
@@ -1493,6 +1512,7 @@ export const useEditorStore = create<EditorStore>((set, get) => {
       customPresetsInFlightUserId = userId
       set({
         customPresetsLoading: true,
+        customPresetsError: false,
         customPresetsSort: nextSort,
         // Account switch: never show the previous account's presets while the
         // new list loads. A sort change keeps the current list on screen and
@@ -1520,13 +1540,14 @@ export const useEditorStore = create<EditorStore>((set, get) => {
             customPresets: presets,
             customPresetsLoaded: true,
             customPresetsLoading: false,
+            customPresetsError: false,
             customPresetsForUserId: userId,
             // The displayed list now reflects the requested sort.
             customPresetsListSort: nextSort,
           })
         })
         .catch((err) => {
-          console.warn("Could not load custom presets", err)
+          console.error("Could not load custom presets", err)
           if (token !== customPresetsRequestToken) return
           customPresetsInFlightUserId = null
           // Keep whatever list is on screen: a failed re-sort must not erase
@@ -1541,6 +1562,9 @@ export const useEditorStore = create<EditorStore>((set, get) => {
               customPresetsListSort: rolledSort,
               customPresetsLoaded: true,
               customPresetsLoading: false,
+              // Only an empty list is a lie about the account. A failed re-sort
+              // still has real presets on screen, so it stays a plain list.
+              customPresetsError: current.customPresets.length === 0,
               customPresetsForUserId: userId,
             }
           })

--- a/lib/editor/store/provider.tsx
+++ b/lib/editor/store/provider.tsx
@@ -8,10 +8,14 @@ import type { CanvasState } from "../state-types"
 import { useEditorStore } from "../store"
 import { TEMPLATES } from "../templates"
 import {
+  applyTemplate,
+  templateApplyErrorMessage,
+  templateApplyReplacedState,
+} from "../templates/apply"
+import {
   ANIMATION_UNSUPPORTED_MESSAGE,
   isAnimationUnsupportedViewport,
 } from "../templates/catalog"
-import { unwrapDraftState } from "@/lib/schemas/draft"
 
 import {
   applyEditorDraft,
@@ -21,6 +25,24 @@ import {
   readEditorDraft,
   writeEditorDraft,
 } from "./draft-persistence"
+
+/**
+ * Autosave runs on every store change, so a broken IndexedDB (quota, private
+ * mode, corrupt object store) would fire endlessly. Report the first failure of
+ * a run and stay quiet until a save succeeds again — silence is what makes this
+ * one dangerous: the user keeps editing, closes the tab, and the work is gone.
+ */
+let autosaveFailureReported = false
+
+function reportAutosaveFailure(error: unknown) {
+  console.error("Unable to save editor draft", error)
+  if (autosaveFailureReported) return
+  autosaveFailureReported = true
+  toast.error("Couldn't save your work in this browser", {
+    description: "Save the project to your account to keep it.",
+    duration: 10000,
+  })
+}
 
 function isEditableKeyboardTarget(target: EventTarget | null) {
   if (!(target instanceof HTMLElement)) return false
@@ -50,7 +72,8 @@ function stripTemplateParam() {
 /**
  * Apply a URL template as a fresh unsaved project and strip the query param so
  * a refresh doesn't re-apply it over the user's subsequent edits. Returns
- * whether a template was applied.
+ * whether the store now holds template state — a failed apply that already
+ * replaced it still counts, so the stored draft isn't restored on top.
  */
 function applyPendingTemplate(): boolean {
   const template = pendingTemplateFromUrl()
@@ -61,11 +84,14 @@ function applyPendingTemplate(): boolean {
     return false
   }
   try {
-    const { present, ui } = unwrapDraftState(template.state)
-    useEditorStore.getState().loadTemplateState(present, ui)
+    applyTemplate(template)
   } catch (error) {
-    console.warn("Unable to apply template from URL", error)
-    return false
+    console.error("Unable to apply template from URL", error)
+    // Strip either way: the same link would fail the same way on reload, and
+    // leaving it in place implies a template the editor isn't actually showing.
+    stripTemplateParam()
+    toast.error(templateApplyErrorMessage(error))
+    return templateApplyReplacedState(error)
   }
   stripTemplateParam()
   toast.success(`Applied "${template.name}"`)
@@ -102,9 +128,11 @@ export function EditorProvider({ children }: { children: React.ReactNode }) {
       }
       void writeEditorDraft(
         createEditorDraftSnapshot(useEditorStore.getState())
-      ).catch((error) => {
-        console.warn("Unable to save editor draft", error)
-      })
+      )
+        .then(() => {
+          autosaveFailureReported = false
+        })
+        .catch(reportAutosaveFailure)
     }
 
     const scheduleSave = () => {
@@ -131,7 +159,10 @@ export function EditorProvider({ children }: { children: React.ReactNode }) {
         startAutosave()
       })
       .catch((error) => {
-        console.warn("Unable to restore editor draft", error)
+        console.error("Unable to restore editor draft", error)
+        // An unreadable draft opens what looks like a brand-new project. Left
+        // unsaid, the user assumes their last session was never saved.
+        toast.error("Couldn't restore your last project from this browser")
         startAutosave()
       })
 
@@ -280,4 +311,21 @@ export function EditorProvider({ children }: { children: React.ReactNode }) {
 export async function saveCurrentEditorDraft() {
   if (!isBrowserIndexedDbAvailable()) return
   await writeEditorDraft(createEditorDraftSnapshot(useEditorStore.getState()))
+}
+
+/**
+ * Stash the project before an auth flow navigates the tab away. Sign-in is the
+ * one moment the user is promised their work will still be here afterwards, so
+ * a failed stash has to be said out loud — they can still copy or export first.
+ */
+export async function saveEditorDraftBeforeAuth() {
+  try {
+    await saveCurrentEditorDraft()
+  } catch (error) {
+    console.error("Could not save local editor state before auth", error)
+    toast.error("Couldn't save your work before signing in", {
+      description: "Export or copy the canvas first if you need to keep it.",
+      duration: 10000,
+    })
+  }
 }

--- a/lib/editor/store/provider.tsx
+++ b/lib/editor/store/provider.tsx
@@ -33,6 +33,21 @@ import {
  * one dangerous: the user keeps editing, closes the tab, and the work is gone.
  */
 let autosaveFailureReported = false
+let latestAutosaveToken = 0
+
+const beginAutosave = () => ++latestAutosaveToken
+
+/**
+ * Writes are not serialized — the debounce can start a second one while the
+ * first is still in flight, and `pagehide` fires one outright. An older write
+ * settling after a newer one failed says nothing about the state the user is
+ * now in, so only the newest write may re-arm the warning; otherwise a single
+ * broken run would toast on every failure that follows a late success.
+ */
+function reportAutosaveSuccess(token: number) {
+  if (token !== latestAutosaveToken) return
+  autosaveFailureReported = false
+}
 
 function reportAutosaveFailure(error: unknown) {
   console.error("Unable to save editor draft", error)
@@ -126,12 +141,11 @@ export function EditorProvider({ children }: { children: React.ReactNode }) {
         window.clearTimeout(saveTimer)
         saveTimer = null
       }
+      const token = beginAutosave()
       void writeEditorDraft(
         createEditorDraftSnapshot(useEditorStore.getState())
       )
-        .then(() => {
-          autosaveFailureReported = false
-        })
+        .then(() => reportAutosaveSuccess(token))
         .catch(reportAutosaveFailure)
     }
 

--- a/lib/editor/templates/apply.ts
+++ b/lib/editor/templates/apply.ts
@@ -1,0 +1,69 @@
+import { isDraftStateLike, unwrapDraftState } from "@/lib/schemas/draft"
+
+import { liveClipCount, payloadClipCount } from "../animation-presence"
+import { useEditorStore } from "../store"
+import type { Template } from "./types"
+
+/** An apply that failed in a way worth showing the user verbatim. */
+export class TemplateApplyError extends Error {
+  /** Whether the editor state was already replaced when this was thrown. */
+  readonly stateReplaced: boolean
+
+  constructor(message: string, stateReplaced: boolean) {
+    super(message)
+    this.name = "TemplateApplyError"
+    this.stateReplaced = stateReplaced
+  }
+}
+
+/** True when the failed apply left the template's state in the editor. */
+export function templateApplyReplacedState(error: unknown) {
+  return error instanceof TemplateApplyError && error.stateReplaced
+}
+
+/**
+ * Apply a template as a fresh unsaved project.
+ *
+ * Loading is lossy by design (see `animation-presence`): a template whose
+ * animation no longer matches the shape the store expects loads as a still
+ * composition — canvas styled, clips gone, and nothing to distinguish it from a
+ * template that never had an animation. Check the clips both before and after
+ * the load and throw, so the caller reports a failure instead of a success
+ * toast over a silently dead timeline.
+ */
+export function applyTemplate(template: Template) {
+  if (!isDraftStateLike(template.state)) {
+    throw new TemplateApplyError(
+      `"${template.name}" is missing its canvas.`,
+      false
+    )
+  }
+  const { present, ui } = unwrapDraftState(template.state)
+  const isAnimation = template.category === "animation"
+  // Caught before the load so a template that never had a usable animation
+  // leaves the user's current project alone.
+  if (
+    isAnimation &&
+    !(ui.isAnimateMode && payloadClipCount(present.canvases))
+  ) {
+    throw new TemplateApplyError(
+      `"${template.name}" is missing its animation and can't be applied.`,
+      false
+    )
+  }
+
+  useEditorStore.getState().loadTemplateState(present, ui)
+
+  if (isAnimation && !liveClipCount(useEditorStore.getState().present)) {
+    throw new TemplateApplyError(
+      `Applied "${template.name}", but its animation could not be loaded.`,
+      true
+    )
+  }
+}
+
+export function templateApplyErrorMessage(error: unknown) {
+  return error instanceof TemplateApplyError
+    ? error.message
+    : "Could not apply template"
+}

--- a/tests/app/app/layout.test.tsx
+++ b/tests/app/app/layout.test.tsx
@@ -68,14 +68,20 @@ describe("app/layout (root)", () => {
   // read rather than rendered: what matters is only where the tag sits.
   const source = readFileSync(join(process.cwd(), "app", "layout.tsx"), "utf8")
 
-  it("raises the resource-timing buffer from <head>", () => {
+  it("raises the resource-timing buffer from a script in <head>", () => {
+    const headStart = source.indexOf("<head>")
+    const headEnd = source.indexOf("</head>")
+    expect(headStart).toBeGreaterThan(-1)
+    expect(headEnd).toBeGreaterThan(headStart)
+    const head = source.slice(headStart, headEnd)
+
     // Offline shell capture reads performance.getEntriesByType("resource") to
     // find lazily loaded chunks; the default 250-entry buffer would drop them.
-    const head = source.slice(
-      source.indexOf("<head>"),
-      source.indexOf("</head>")
+    // Pin the whole payload, not a mention of the API: a raised buffer that
+    // isn't inside an executed <script>, or is raised to some smaller number,
+    // loses the same chunks it was added to keep.
+    expect(head).toMatch(
+      /<script\b[^>]*?__html:\s*"performance\.setResourceTimingBufferSize\?\.\(1000\)"[^>]*?\/>/
     )
-
-    expect(head).toContain("setResourceTimingBufferSize")
   })
 })

--- a/tests/app/app/layout.test.tsx
+++ b/tests/app/app/layout.test.tsx
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 
@@ -40,27 +43,39 @@ describe("app/app/layout", () => {
     )
 
     const shell = screen.getByTestId("a").parentElement as HTMLElement
-    // The shell also renders the resource-timing script, so compare only the
-    // children it was handed.
-    const rendered = [...shell.children].filter(
-      (child) => child.tagName !== "SCRIPT"
-    )
-    expect(rendered).toHaveLength(2)
-    expect(rendered[0]).toHaveAttribute("data-testid", "a")
-    expect(rendered[1]).toHaveAttribute("data-testid", "b")
+    expect(shell.children).toHaveLength(2)
+    expect(shell.children[0]).toHaveAttribute("data-testid", "a")
+    expect(shell.children[1]).toHaveAttribute("data-testid", "b")
   })
 
-  it("raises the resource-timing buffer before the page scripts load", () => {
+  it("renders no script of its own", () => {
+    // React never executes a script it creates during a client render, so a
+    // route layout — re-created on every client navigation into /app — is the
+    // one place this app's inline setup script must not live. It belongs in the
+    // root layout's <head> (asserted below).
     const { container } = render(
       <ScreenshotsLayout>
         <span>child</span>
       </ScreenshotsLayout>
     )
 
+    expect(container.querySelector("script")).toBeNull()
+  })
+})
+
+describe("app/layout (root)", () => {
+  // The root layout pulls next/font, global CSS and every provider, so it is
+  // read rather than rendered: what matters is only where the tag sits.
+  const source = readFileSync(join(process.cwd(), "app", "layout.tsx"), "utf8")
+
+  it("raises the resource-timing buffer from <head>", () => {
     // Offline shell capture reads performance.getEntriesByType("resource") to
     // find lazily loaded chunks; the default 250-entry buffer would drop them.
-    const script = container.querySelector("script")
-    expect(script?.innerHTML).toContain("setResourceTimingBufferSize")
-    expect(container.firstElementChild?.firstElementChild).toBe(script)
+    const head = source.slice(
+      source.indexOf("<head>"),
+      source.indexOf("</head>")
+    )
+
+    expect(head).toContain("setResourceTimingBufferSize")
   })
 })

--- a/tests/components/editor/custom-preset-card.test.tsx
+++ b/tests/components/editor/custom-preset-card.test.tsx
@@ -32,6 +32,7 @@ function renderCards(
 ) {
   const onRenameCustom = vi.fn()
   const onDeleteCustom = vi.fn()
+  const onRetryCustom = vi.fn()
   render(
     <PresetCardsBody
       displayTab="custom"
@@ -51,10 +52,11 @@ function renderCards(
       onApplyCustom={vi.fn()}
       onDeleteCustom={onDeleteCustom}
       onRenameCustom={onRenameCustom}
+      onRetryCustom={onRetryCustom}
       {...overrides}
     />
   )
-  return { onRenameCustom, onDeleteCustom }
+  return { onRenameCustom, onDeleteCustom, onRetryCustom }
 }
 
 afterEach(() => vi.clearAllMocks())
@@ -127,5 +129,35 @@ describe("CustomPresetCard — options menu", () => {
     await user.click(within(alert).getByRole("button", { name: "Delete" }))
 
     expect(onDeleteCustom).toHaveBeenCalledWith("preset_1")
+  })
+})
+
+describe("CustomPresetList — failed load", () => {
+  it("says the load failed instead of claiming the account is empty", () => {
+    renderCards({ customPresets: [], customPresetsError: true })
+
+    expect(screen.getByText(/Could not load your presets/)).toBeInTheDocument()
+    expect(screen.queryByText(/No custom presets yet/)).not.toBeInTheDocument()
+  })
+
+  it("retries on demand", async () => {
+    const { onRetryCustom } = renderCards({
+      customPresets: [],
+      customPresetsError: true,
+    })
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole("button", { name: "Try again" }))
+
+    expect(onRetryCustom).toHaveBeenCalledTimes(1)
+  })
+
+  it("still shows the empty state when the load simply found nothing", () => {
+    renderCards({ customPresets: [], customPresetsError: false })
+
+    expect(screen.getByText(/No custom presets yet/)).toBeInTheDocument()
+    expect(
+      screen.queryByText(/Could not load your presets/)
+    ).not.toBeInTheDocument()
   })
 })

--- a/tests/components/editor/image-file-intake.test.tsx
+++ b/tests/components/editor/image-file-intake.test.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type * as MediaType from "@/lib/editor/media-type"
+
+/**
+ * GIF intake. The user is asked to confirm a conversion to video, so a silent
+ * fall back to a plain <img> hands them something they didn't ask for — no
+ * timeline, no video bar — with nothing said about it.
+ */
+const media = vi.hoisted(() => ({
+  transcodeGifToVideo: vi.fn(),
+  registerObjectUrl: vi.fn(() => "blob:converted"),
+}))
+
+const toast = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }))
+
+vi.mock("@/lib/editor/gif-to-video", () => ({
+  transcodeGifToVideo: media.transcodeGifToVideo,
+}))
+vi.mock("sonner", () => ({ toast }))
+vi.mock("@/lib/editor/media-type", async (importOriginal) => ({
+  ...(await importOriginal<typeof MediaType>()),
+  registerObjectUrl: media.registerObjectUrl,
+}))
+
+import { useImageFileIntake } from "@/components/editor/canvas/use-image-file-intake"
+
+const gif = () =>
+  new File([new Uint8Array([1, 2, 3])], "demo.gif", {
+    type: "image/gif",
+  })
+
+function setup() {
+  const onImage = vi.fn()
+  const { result } = renderHook(() => useImageFileIntake(onImage))
+  act(() => result.current.readFile(gif()))
+  return { onImage, result }
+}
+
+afterEach(() => vi.clearAllMocks())
+
+describe("GIF intake", () => {
+  it("uses the converted video when the transcode works", async () => {
+    media.transcodeGifToVideo.mockResolvedValue(new Blob(["webm"]))
+    const { onImage, result } = setup()
+
+    await act(async () => result.current.confirmGifTranscode())
+
+    await waitFor(() => expect(onImage).toHaveBeenCalledWith("blob:converted"))
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it("says so when the conversion falls back to a plain image", async () => {
+    media.transcodeGifToVideo.mockResolvedValue(null)
+    const { result } = setup()
+
+    await act(async () => result.current.confirmGifTranscode())
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Could not convert that GIF — added it as an image instead"
+      )
+    )
+  })
+
+  it("says so when the conversion throws", async () => {
+    media.transcodeGifToVideo.mockRejectedValue(new Error("no WebCodecs"))
+    const { result } = setup()
+
+    await act(async () => result.current.confirmGifTranscode())
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Could not convert that GIF — added it as an image instead"
+      )
+    )
+  })
+})

--- a/tests/lib/editor/animation-presence.test.ts
+++ b/tests/lib/editor/animation-presence.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  liveClipCount,
+  payloadClipCount,
+  resolvePresetAnimateIntent,
+} from "@/lib/editor/animation-presence"
+import { createCanvas, DEFAULT_STATE } from "@/lib/editor/store/defaults"
+import type { AnimationClip, EditorState } from "@/lib/editor/state-types"
+
+const clip = (id: string): AnimationClip => ({
+  id,
+  startMs: 0,
+  durationMs: 1000,
+  target: { scope: "all" },
+  effects: [],
+})
+
+describe("payloadClipCount", () => {
+  it("counts clips across every carrier", () => {
+    expect(
+      payloadClipCount([
+        { animation: { clips: [clip("a"), clip("b")] } },
+        { animation: { clips: [clip("c")] } },
+      ])
+    ).toBe(3)
+  })
+
+  it("reads zero from payloads a normaliser would silently empty", () => {
+    expect(payloadClipCount(undefined)).toBe(0)
+    expect(payloadClipCount([])).toBe(0)
+    expect(payloadClipCount([undefined, null])).toBe(0)
+    expect(payloadClipCount([{}])).toBe(0)
+    expect(payloadClipCount([{ animation: { clips: [] } }])).toBe(0)
+  })
+
+  it("accepts the real payloads its callers hand it", () => {
+    const canvas = {
+      ...createCanvas("a"),
+      animation: { durationMs: 4000, clips: [clip("one")] },
+    }
+    const presetGeometry = {
+      canvasTilt: { rx: 0, ry: 0, rz: 0 },
+      canvasScale: 100,
+      slots: [],
+      animation: { durationMs: 4000, clips: [clip("two")], sourceSlotIds: [] },
+    }
+
+    expect(payloadClipCount([canvas])).toBe(1)
+    expect(payloadClipCount([presetGeometry])).toBe(1)
+  })
+
+  it("counts a timeline the store's normaliser would refuse", () => {
+    // `clips` that isn't an array survives the count but not the load — the
+    // mismatch these helpers exist to surface. Arrives as it does in reality:
+    // parsed JSON nobody has validated.
+    const payload: unknown = JSON.parse(
+      '[{"animation":{"clips":{"length":3}}}]'
+    )
+
+    expect(
+      payloadClipCount(payload as Parameters<typeof payloadClipCount>[0])
+    ).toBe(3)
+  })
+})
+
+describe("liveClipCount", () => {
+  const stateWith = (
+    canvases: EditorState["canvases"],
+    activeCanvasId: string
+  ): EditorState => ({ ...DEFAULT_STATE, canvases, activeCanvasId })
+
+  it("counts only the canvas the user is looking at", () => {
+    const active = {
+      ...createCanvas("a"),
+      animation: { durationMs: 5000, clips: [clip("one"), clip("two")] },
+    }
+    const other = {
+      ...createCanvas("b"),
+      animation: { durationMs: 5000, clips: [clip("three")] },
+    }
+
+    expect(liveClipCount(stateWith([active, other], "a"))).toBe(2)
+    expect(liveClipCount(stateWith([active, other], "b"))).toBe(1)
+  })
+
+  it("is zero for a canvas with no timeline", () => {
+    const canvas = createCanvas("a")
+    expect(liveClipCount(stateWith([canvas], "a"))).toBe(0)
+    expect(liveClipCount(stateWith([canvas], "missing"))).toBe(0)
+  })
+})
+
+describe("resolvePresetAnimateIntent", () => {
+  const withClips = { animation: { durationMs: 4000, clips: [clip("a")] } }
+
+  it("animates a preset that still has its timeline", () => {
+    expect(resolvePresetAnimateIntent("animate", withClips)).toBe("animate")
+  })
+
+  it("animates a style-typed preset that carries clips anyway", () => {
+    // Predates the animate type; the clips are what actually decide.
+    expect(resolvePresetAnimateIntent("style", withClips)).toBe("animate")
+  })
+
+  it("flags an animate preset whose timeline is gone", () => {
+    expect(resolvePresetAnimateIntent("animate", {})).toBe("missing-timeline")
+    expect(
+      resolvePresetAnimateIntent("animate", {
+        animation: { durationMs: 4000, clips: [] },
+      })
+    ).toBe("missing-timeline")
+  })
+
+  it("leaves an ordinary style preset alone", () => {
+    expect(resolvePresetAnimateIntent("style", {})).toBe("style")
+    expect(resolvePresetAnimateIntent(undefined, {})).toBe("style")
+  })
+})

--- a/tests/lib/editor/store/custom-presets-load.test.ts
+++ b/tests/lib/editor/store/custom-presets-load.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useEditorStore } from "@/lib/editor/store"
+import type { CustomPresetSummary } from "@/lib/editor/store"
+
+/**
+ * A failed preset load used to land on `customPresetsLoaded` with an empty list,
+ * which the picker renders as "No custom presets yet" — telling the user their
+ * saved presets don't exist. `customPresetsError` keeps the two apart.
+ */
+const store = useEditorStore
+
+const PRESET: CustomPresetSummary = {
+  id: "preset_1",
+  name: "Brave Coffee Hamster",
+  slotCount: 1,
+  type: "style",
+  geometry: {
+    canvasTilt: { rx: 0, ry: 0, rz: 0 },
+    canvasScale: 100,
+    slots: [],
+  },
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+const okResponse = (presets: CustomPresetSummary[]) =>
+  ({ ok: true, json: async () => ({ presets }) }) as Response
+
+beforeEach(() => {
+  store.getState().clearCustomPresets()
+  vi.spyOn(console, "error").mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("loadCustomPresets", () => {
+  it("flags an error instead of reporting an empty account", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")))
+
+    store.getState().loadCustomPresets("user_1")
+    await flush()
+
+    expect(store.getState().customPresetsError).toBe(true)
+    expect(store.getState().customPresets).toEqual([])
+    // Still "loaded" so the skeleton stops — the error flag is what the list
+    // reads to avoid claiming the account is empty.
+    expect(store.getState().customPresetsLoaded).toBe(true)
+    expect(store.getState().customPresetsLoading).toBe(false)
+  })
+
+  it("flags an error for a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500 })
+    )
+
+    store.getState().loadCustomPresets("user_1")
+    await flush()
+
+    expect(store.getState().customPresetsError).toBe(true)
+  })
+
+  it("lets a retry through after a failure", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(okResponse([PRESET]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    store.getState().loadCustomPresets("user_1")
+    await flush()
+    expect(store.getState().customPresetsError).toBe(true)
+
+    // Same user, same sort: the load dedupe must not swallow the retry.
+    store.getState().loadCustomPresets("user_1")
+    await flush()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(store.getState().customPresetsError).toBe(false)
+    expect(store.getState().customPresets).toEqual([PRESET])
+  })
+
+  it("keeps a loaded list on a failed re-sort without claiming an error", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okResponse([PRESET]))
+      .mockRejectedValueOnce(new Error("offline"))
+    vi.stubGlobal("fetch", fetchMock)
+
+    store.getState().loadCustomPresets("user_1")
+    await flush()
+
+    store.getState().loadCustomPresets("user_1", "oldest")
+    await flush()
+
+    expect(store.getState().customPresets).toEqual([PRESET])
+    expect(store.getState().customPresetsError).toBe(false)
+    expect(store.getState().customPresetsSort).toBe("latest")
+  })
+
+  it("clears the error flag when the list is dropped", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")))
+
+    store.getState().loadCustomPresets("user_1")
+    await flush()
+    expect(store.getState().customPresetsError).toBe(true)
+
+    store.getState().clearCustomPresets()
+    expect(store.getState().customPresetsError).toBe(false)
+  })
+})

--- a/tests/lib/editor/store/duplicate-refusals.test.ts
+++ b/tests/lib/editor/store/duplicate-refusals.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { useEditorStore } from "@/lib/editor/store"
+
+/**
+ * The timeline's Duplicate actions can decline, and the UI now reports that
+ * instead of leaving the menu looking broken. These pin the store contract the
+ * toasts read: an empty id list / a null id is the refusal signal.
+ */
+const store = useEditorStore
+
+const clips = () => {
+  const state = store.getState().present
+  return state.canvases.find((c) => c.id === state.activeCanvasId)!.animation!
+    .clips
+}
+
+describe("duplicateAnimationClips refusals", () => {
+  beforeEach(() => store.getState().reset())
+
+  it("duplicates a real keyframe", () => {
+    const id = store.getState().addAnimationClip()
+
+    const newIds = store.getState().duplicateAnimationClips([id])
+
+    expect(newIds).toHaveLength(1)
+    expect(clips()).toHaveLength(2)
+  })
+
+  it("returns nothing for an empty selection", () => {
+    expect(store.getState().duplicateAnimationClips([])).toEqual([])
+  })
+
+  it("returns nothing for ids that are not on this canvas", () => {
+    store.getState().addAnimationClip()
+
+    expect(store.getState().duplicateAnimationClips(["ghost"])).toEqual([])
+    expect(clips()).toHaveLength(1)
+  })
+
+  it("returns nothing when the canvas does not exist", () => {
+    const id = store.getState().addAnimationClip()
+
+    expect(store.getState().duplicateAnimationClips([id], "missing")).toEqual(
+      []
+    )
+  })
+})
+
+describe("duplicateVideoClip refusals", () => {
+  beforeEach(() => store.getState().reset())
+
+  it("duplicates a section of known length", () => {
+    store.getState().updateVideoClip("video-main", { endMs: 5_000 })
+
+    expect(
+      store.getState().duplicateVideoClip("video-main", 5_000)
+    ).toBeTruthy()
+  })
+
+  it("returns null for a section whose media has no duration yet", () => {
+    store.getState().updateVideoClip("video-main", { endMs: 5_000 })
+
+    expect(store.getState().duplicateVideoClip("video-main", 0)).toBeNull()
+  })
+
+  it("returns null for a section that is not there", () => {
+    store.getState().updateVideoClip("video-main", { endMs: 5_000 })
+
+    expect(store.getState().duplicateVideoClip("ghost", 5_000)).toBeNull()
+  })
+})

--- a/tests/lib/editor/store/editor-draft-reporting.test.tsx
+++ b/tests/lib/editor/store/editor-draft-reporting.test.tsx
@@ -155,6 +155,31 @@ describe("editor autosave", () => {
     expect(persistence.writeEditorDraft).toHaveBeenCalled()
     expect(toast.error).not.toHaveBeenCalled()
   })
+
+  it("keeps quiet when a slow earlier save lands after a newer one failed", async () => {
+    await mountWithHealthyAutosave()
+
+    // Writes overlap: the debounce can start a second one while the first is
+    // still in flight. Here the older write is the one that eventually
+    // succeeds, so it must not be read as "saving works again".
+    let settleSlowSave = () => {}
+    persistence.writeEditorDraft.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        settleSlowSave = resolve
+      })
+    )
+    await editUntilSaved()
+
+    persistence.writeEditorDraft.mockRejectedValue(new Error("QuotaExceeded"))
+    await editUntilSaved()
+    expect(toast.error).toHaveBeenCalledTimes(1)
+
+    settleSlowSave()
+    await vi.advanceTimersByTimeAsync(0)
+
+    await editUntilSaved()
+    expect(toast.error).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe("saveEditorDraftBeforeAuth", () => {

--- a/tests/lib/editor/store/editor-draft-reporting.test.tsx
+++ b/tests/lib/editor/store/editor-draft-reporting.test.tsx
@@ -1,0 +1,190 @@
+import { render } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+/**
+ * Local persistence is the only thing standing between a user and losing their
+ * work, so every failure in it has to be visible. These cover the three that
+ * used to be `console.warn` and nothing else: autosave, restore-on-open, and the
+ * stash taken right before an auth redirect navigates the tab away.
+ */
+const persistence = vi.hoisted(() => ({
+  isBrowserIndexedDbAvailable: vi.fn(() => true),
+  readEditorDraft: vi.fn(async () => null),
+  writeEditorDraft: vi.fn(async () => {}),
+  createEditorDraftSnapshot: vi.fn(() => ({ snapshot: true })),
+  applyEditorDraft: vi.fn(() => ({})),
+  EDITOR_DRAFT_SAVE_DELAY_MS: 250,
+}))
+
+const toast = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+  info: vi.fn(),
+  loading: vi.fn(),
+}))
+
+vi.mock("@/lib/editor/store/draft-persistence", () => persistence)
+vi.mock("sonner", () => ({ toast }))
+
+import {
+  EditorProvider,
+  saveEditorDraftBeforeAuth,
+} from "@/lib/editor/store/provider"
+import { useEditorStore } from "@/lib/editor/store"
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {})
+  persistence.isBrowserIndexedDbAvailable.mockReturnValue(true)
+  persistence.readEditorDraft.mockResolvedValue(null)
+  persistence.writeEditorDraft.mockResolvedValue(undefined)
+  useEditorStore.getState().reset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.restoreAllMocks()
+})
+
+describe("editor draft restore", () => {
+  it("tells the user when the stored project could not be read", async () => {
+    persistence.readEditorDraft.mockRejectedValueOnce(new Error("corrupt"))
+
+    render(
+      <EditorProvider>
+        <div />
+      </EditorProvider>
+    )
+    await flush()
+
+    // Without this the editor just opens empty, which reads as "nothing was
+    // ever saved" rather than "your project is here but unreadable".
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't restore your last project from this browser"
+    )
+  })
+
+  it("says nothing when there is simply no stored project", async () => {
+    render(
+      <EditorProvider>
+        <div />
+      </EditorProvider>
+    )
+    await flush()
+
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+})
+
+describe("editor autosave", () => {
+  let padding = 0
+  // Fake timers own setTimeout here, so the debounce is driven forward rather
+  // than waited on; advanceTimersByTimeAsync also drains the promise chain.
+  const editUntilSaved = async () => {
+    padding = (padding + 8) % 200
+    useEditorStore.getState().setPadding(padding)
+    await vi.advanceTimersByTimeAsync(persistence.EDITOR_DRAFT_SAVE_DELAY_MS)
+    await vi.advanceTimersByTimeAsync(0)
+  }
+
+  /**
+   * "Already reported" lives for the lifetime of the module, which is the point
+   * — one warning per broken run, not one per edit. Each test therefore opens
+   * with a save that works, so it starts from the same healthy state no matter
+   * what ran before it.
+   */
+  const mountWithHealthyAutosave = async () => {
+    render(
+      <EditorProvider>
+        <div />
+      </EditorProvider>
+    )
+    await vi.advanceTimersByTimeAsync(0)
+    await editUntilSaved()
+    toast.error.mockClear()
+  }
+
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it("reports a failing autosave once, not on every keystroke", async () => {
+    await mountWithHealthyAutosave()
+    persistence.writeEditorDraft.mockRejectedValue(new Error("QuotaExceeded"))
+
+    await editUntilSaved()
+    await editUntilSaved()
+    await editUntilSaved()
+
+    expect(persistence.writeEditorDraft.mock.calls.length).toBeGreaterThan(1)
+    expect(toast.error).toHaveBeenCalledTimes(1)
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't save your work in this browser",
+      expect.objectContaining({
+        description: "Save the project to your account to keep it.",
+      })
+    )
+  })
+
+  it("reports again once saving recovers and breaks a second time", async () => {
+    await mountWithHealthyAutosave()
+    persistence.writeEditorDraft.mockRejectedValue(new Error("QuotaExceeded"))
+
+    await editUntilSaved()
+    expect(toast.error).toHaveBeenCalledTimes(1)
+
+    persistence.writeEditorDraft.mockResolvedValue(undefined)
+    await editUntilSaved()
+    expect(toast.error).toHaveBeenCalledTimes(1)
+
+    persistence.writeEditorDraft.mockRejectedValue(new Error("QuotaExceeded"))
+    await editUntilSaved()
+    expect(toast.error).toHaveBeenCalledTimes(2)
+  })
+
+  it("stays quiet while saving works", async () => {
+    render(
+      <EditorProvider>
+        <div />
+      </EditorProvider>
+    )
+    await vi.advanceTimersByTimeAsync(0)
+
+    await editUntilSaved()
+
+    expect(persistence.writeEditorDraft).toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+})
+
+describe("saveEditorDraftBeforeAuth", () => {
+  it("warns instead of letting the redirect take the work with it", async () => {
+    persistence.writeEditorDraft.mockRejectedValueOnce(new Error("nope"))
+
+    // Must not reject: the sign-in has to continue either way.
+    await expect(saveEditorDraftBeforeAuth()).resolves.toBeUndefined()
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't save your work before signing in",
+      expect.objectContaining({
+        description: "Export or copy the canvas first if you need to keep it.",
+      })
+    )
+  })
+
+  it("says nothing when the stash succeeds", async () => {
+    await saveEditorDraftBeforeAuth()
+
+    expect(persistence.writeEditorDraft).toHaveBeenCalledTimes(1)
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it("is a no-op where IndexedDB is unavailable", async () => {
+    persistence.isBrowserIndexedDbAvailable.mockReturnValue(false)
+
+    await saveEditorDraftBeforeAuth()
+
+    expect(persistence.writeEditorDraft).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+})

--- a/tests/lib/editor/template-apply.test.ts
+++ b/tests/lib/editor/template-apply.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  applyTemplate,
+  TemplateApplyError,
+  templateApplyErrorMessage,
+  templateApplyReplacedState,
+} from "@/lib/editor/templates/apply"
+import { useEditorStore } from "@/lib/editor/store"
+import { createCanvas, DEFAULT_STATE } from "@/lib/editor/store/defaults"
+import type { AnimationClip, CanvasState } from "@/lib/editor/state-types"
+import type { Template } from "@/lib/editor/templates"
+import { DRAFT_SCHEMA_VERSION } from "@/lib/schemas/draft"
+
+const clip = (id: string): AnimationClip => ({
+  id,
+  startMs: 0,
+  durationMs: 1200,
+  target: { scope: "all" },
+  effects: [],
+})
+
+function makeTemplate(
+  overrides: {
+    category?: Template["category"]
+    canvas?: Partial<CanvasState>
+    isAnimateMode?: boolean
+    /** Replaces the whole payload — for the malformed cases. */
+    state?: unknown
+  } = {}
+): Template {
+  const canvas = { ...createCanvas("tpl-canvas"), ...overrides.canvas }
+  return {
+    id: "product-reveal",
+    name: "Product Reveal",
+    category: overrides.category ?? "animation",
+    thumbnail: "https://assets.example.com/templates/product-reveal.jpg",
+    state: (overrides.state ?? {
+      schemaVersion: DRAFT_SCHEMA_VERSION,
+      present: {
+        ...DEFAULT_STATE,
+        canvases: [canvas],
+        activeCanvasId: canvas.id,
+      },
+      ui: { isAnimateMode: overrides.isAnimateMode ?? true },
+    }) as Template["state"],
+  }
+}
+
+const animated = () =>
+  makeTemplate({
+    canvas: {
+      animation: { durationMs: 4000, clips: [clip("a"), clip("b")] },
+    },
+  })
+
+function activeCanvas() {
+  const { present } = useEditorStore.getState()
+  return present.canvases.find((c) => c.id === present.activeCanvasId)
+}
+
+beforeEach(() => {
+  useEditorStore.getState().reset()
+})
+
+describe("applyTemplate", () => {
+  it("applies an animation template and keeps its clips", () => {
+    applyTemplate(animated())
+
+    expect(activeCanvas()?.animation?.clips).toHaveLength(2)
+    expect(useEditorStore.getState().isAnimateMode).toBe(true)
+  })
+
+  it("applies an image template without touching the timeline", () => {
+    applyTemplate(
+      makeTemplate({
+        category: "image",
+        isAnimateMode: false,
+        canvas: { padding: 96 },
+      })
+    )
+
+    expect(activeCanvas()?.padding).toBe(96)
+    expect(activeCanvas()?.animation?.clips).toHaveLength(0)
+  })
+
+  it("refuses an animation template with no clips, leaving the project alone", () => {
+    useEditorStore.getState().setPadding(37)
+
+    expect(() => applyTemplate(makeTemplate())).toThrow(TemplateApplyError)
+    // Pre-flight failure: the user's canvas must survive untouched.
+    expect(activeCanvas()?.padding).toBe(37)
+  })
+
+  it("refuses an animation template that never enters Animate mode", () => {
+    const template = makeTemplate({
+      isAnimateMode: false,
+      canvas: { animation: { durationMs: 4000, clips: [clip("a")] } },
+    })
+
+    expect(() => applyTemplate(template)).toThrow(/missing its animation/)
+  })
+
+  it("reports a load that dropped the animation, and says state was replaced", () => {
+    const canvas = createCanvas("tpl-canvas")
+    // A timeline the payload still counts (`clips.length`) but the store's
+    // normaliser refuses (not an array) — it empties it instead of rejecting
+    // the template, which is the drop this check exists to catch.
+    const template = makeTemplate({
+      state: {
+        schemaVersion: DRAFT_SCHEMA_VERSION,
+        present: {
+          ...DEFAULT_STATE,
+          canvases: [
+            {
+              ...canvas,
+              animation: { durationMs: 4000, clips: { length: 2 } },
+            },
+          ],
+          activeCanvasId: canvas.id,
+        },
+        ui: { isAnimateMode: true },
+      },
+    })
+
+    let caught: unknown
+    try {
+      applyTemplate(template)
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(TemplateApplyError)
+    expect(templateApplyReplacedState(caught)).toBe(true)
+    expect(activeCanvas()?.animation?.clips).toHaveLength(0)
+  })
+
+  it("refuses a payload with no canvases", () => {
+    const template = makeTemplate({ state: { schemaVersion: 1, present: {} } })
+
+    expect(() => applyTemplate(template)).toThrow(/missing its canvas/)
+  })
+})
+
+describe("templateApplyErrorMessage", () => {
+  it("passes a template failure through verbatim", () => {
+    expect(
+      templateApplyErrorMessage(new TemplateApplyError("Timeline gone", true))
+    ).toBe("Timeline gone")
+  })
+
+  it("falls back for anything else", () => {
+    expect(templateApplyErrorMessage(new Error("boom"))).toBe(
+      "Could not apply template"
+    )
+  })
+})


### PR DESCRIPTION
Applying an animation template from `/showcase` shows **Applied "Product Reveal"** whether or not the animation actually arrived. That turned out to be one instance of a pattern: a load or apply fails partway, the styling still lands, and the editor reports success. This fixes the cases where the user is left with a wrong result and nothing said about it.

## Why the timeline can vanish without an error

`normalizeEditorState` (and the preset slot remapper) merge an unknown payload against current defaults. A timeline whose shape no longer matches is reduced to `clips: []` rather than rejected — so the composition applies, the canvas looks right, and the only difference is an empty track. Nothing throws, so nothing was reported.

The drop is only visible by comparing what the payload carried against what the store ended up with. `lib/editor/animation-presence.ts` holds that comparison (`payloadClipCount` / `liveClipCount` / `resolvePresetAnimateIntent`) and templates and presets both use it.

## What changed

**Templates** — new `lib/editor/templates/apply.ts` is the single apply path for both callers. It rejects a payload with no canvases (which otherwise silently reset to a blank project and toasted success), refuses an animation template that no longer carries clips *before* the load so the user's current project is untouched, and re-checks after the load to catch the normaliser drop. The `?template=` deep link previously caught failures with a bare `console.warn` — no toast at all, the old draft still on screen, and a URL claiming a template that wasn't applied.

**Custom presets** — an animate preset whose geometry has no clips left dropped the user into Animate mode staring at an empty track, with the styling it did apply making it look successful. It's now refused, and after `applyPresetSnapshot` the clips are confirmed to have survived the remap onto live slot ids.

**Preset list** — a failed `GET /api/presets` set `customPresetsLoaded: true` with an empty list, and the picker rendered *"No custom presets yet. Use Save → Save as preset…"* — a claim about the account that a failed request can't support. New `customPresetsError` renders "Could not load your presets / Try again", and the load dedupe no longer swallows that retry. A failed *re-sort* stays a plain list: those presets are real.

**Local drafts** — the most damaging one. Autosave to IndexedDB failing (quota, private mode) was `console.warn` only: the user keeps editing, closes the tab, work is gone. It now warns once per broken run and goes quiet again once a save succeeds. Restore failures ("your last project is here but unreadable") and the stash taken right before an auth redirect are reported too.

**GIF import** — the user confirms a conversion to video in a dialog; a fallback to the plain `<img>` path gave them something else entirely (no timeline, no video bar) without a word.

**Timeline** — Duplicate on a keyframe or a video section could be refused by the store (unknown id, media with no duration yet) and the menu just did nothing.

**Console error** — separate first commit: the inline resource-timing script lived in the `/app` route layout, which React re-creates on client navigation. React never executes a script it creates client-side, so it only ran on a hard load and logged `Encountered a script tag while rendering React component` otherwise. Moved to the root layout's `<head>`, which renders once into the initial HTML and now covers every entry path.

## Deliberately left alone

Throwing here would break working features rather than surface bugs: capability probes and format fallbacks (`image-resize`, `crop-source`, tainted-canvas paths), the per-frame samplers in `apply-animation-frame.ts` (a throw kills playback and export), and `commitCanvasEffect`'s `return base` paths — those fire when an edit targets a canvas whose keyframe isn't selected, which is correct in bulk edit. The inspector's own async work (auto-gradient sampling, background upload, tweet loading) already surfaces its failures.

## Tests

1188 passing. New: `animation-presence`, `template-apply`, `custom-presets-load`, `editor-draft-reporting` (autosave reported once, again after a recovery, silent when healthy), `duplicate-refusals`, `image-file-intake`. Updated: `custom-preset-card` (failed load vs. genuinely empty) and the layout test.

`pnpm typecheck`, `pnpm lint`, `pnpm test` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer custom preset loading errors with a “Try again” option.
  * Improved template application validation and error messages, especially for animated templates.
  * Added notifications when GIF conversion fails, with image fallback support.
  * Added clearer feedback when animation or video duplication is unavailable.
  * Editor drafts are now saved more reliably before authentication and report failures visibly.

* **Bug Fixes**
  * Improved handling of missing animation timelines and failed template loads.
  * Increased resource-timing capacity during initial page loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves editor failure reporting and recovery behavior.
- Centralizes template validation and reports missing or dropped animation timelines.
- Distinguishes failed custom-preset loads from genuinely empty accounts and enables retries.
- Reports draft persistence, GIF conversion, and timeline duplication failures.
- Moves resource-timing initialization into the root document head.
- Fixes autosave warning suppression so stale successful writes cannot falsely signal recovery.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported stale-autosave-success issue is fixed because only the latest-started write can reset failure suppression, and no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/editor/store/provider.tsx | Adds visible draft-persistence failures and correctly limits autosave recovery to the newest scheduled write. |
| lib/editor/templates/apply.ts | Introduces a shared template application path that validates canvas and animation preservation. |
| lib/editor/store.tsx | Tracks custom-preset loading failures separately from valid empty results and permits retries. |
| components/editor/present-presets-section.tsx | Rejects animation presets with missing timelines and verifies clips survive preset application. |
| components/editor/canvas/use-image-file-intake.ts | Notifies users when GIF conversion falls back to a static image. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(editor): only let the newest autosav..."](https://github.com/shivabhattacharjee/tokokino/commit/2329ddfde8642812352d662e31266d6f711f470d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47911065)</sub>

<!-- /greptile_comment -->