### PR TITLE
fix(animate): export the full timeline instead of truncating at 600 frames

### DIFF
--- a/lib/editor/animation-export/gif.ts
+++ b/lib/editor/animation-export/gif.ts
@@ -1,7 +1,8 @@
 /**
- * GIF encode (gifenc, pure JS). Buffers every frame, builds one shared 256-color
- * palette for the whole clip, ordered-dithers, then writes centisecond-accurate
- * delays so playback cadence matches the requested fps.
+ * GIF encode (gifenc, pure JS). Builds one shared 256-color palette for the whole
+ * clip from sampled frames, then ordered-dithers and writes each frame straight
+ * into the encoder with centisecond-accurate delays so playback cadence matches
+ * the requested fps.
  */
 
 import { GIFEncoder, quantize, applyPalette, type Palette } from "gifenc"
@@ -9,6 +10,7 @@ import { GIFEncoder, quantize, applyPalette, type Palette } from "gifenc"
 import { captureStableFrame } from "./capture"
 import type { CaptureCtx } from "./types"
 import { throwIfAborted } from "./utils"
+import { gifExportExceedsMemory } from "./video-media/encode-gif"
 import { drawWatermark } from "./watermark"
 
 /** Frames to sample when building the shared palette — enough to cover the
@@ -83,35 +85,6 @@ function orderedDither(img: ImageData, amplitude: number) {
   }
 }
 
-/**
- * Build one 256-color palette for the whole clip from a handful of evenly
- * spaced frames, then re-map every frame onto it. A single shared palette is
- * what stops the frame-to-frame color shimmer you get from quantizing each
- * frame independently — and it moves the expensive `quantize` off the per-frame
- * path (run once instead of N times), which is most of the speedup.
- */
-function buildGifPalette(frames: ImageData[]): Palette {
-  const stride = Math.max(
-    1,
-    Math.floor(frames.length / GIF_PALETTE_SAMPLE_FRAMES)
-  )
-  const samples: Uint8ClampedArray[] = []
-  for (let i = 0; i < frames.length; i += stride) samples.push(frames[i].data)
-  // Always include the last frame so end-state colors are represented.
-  const last = frames[frames.length - 1]?.data
-  if (last && samples[samples.length - 1] !== last) samples.push(last)
-
-  let total = 0
-  for (const s of samples) total += s.length
-  const combined = new Uint8Array(total)
-  let offset = 0
-  for (const s of samples) {
-    combined.set(s, offset)
-    offset += s.length
-  }
-  return quantize(combined, 256)
-}
-
 export async function encodeGif(ctx: CaptureCtx) {
   const {
     capture,
@@ -126,13 +99,16 @@ export async function encodeGif(ctx: CaptureCtx) {
     videoLayer,
   } = ctx
 
-  // Pass 1 — capture every frame's pixels. Buffering the frames lets us build a
-  // single shared palette (pass 2) instead of one per frame; the WebM path
-  // buffers frames the same way, so peak memory is in line with existing exports.
-  progress.report("capturing", 0, frameCount)
-  const frames: ImageData[] = []
-  for (let f = 0; f < frameCount; f++) {
-    throwIfAborted(signal)
+  // gifenc accumulates the whole compressed stream in one in-memory buffer until
+  // finish(), so bound the output by frames × area and fail fast with an
+  // actionable message. MP4/WebM stream through WebCodecs and have no ceiling.
+  if (gifExportExceedsMemory(frameCount, capture.width, capture.height)) {
+    throw new Error(
+      "This animation is too long or too large for GIF export. Shorten the timeline, lower the resolution, or export as MP4/WebM instead."
+    )
+  }
+
+  const renderFrame = async (f: number) => {
     const frameCanvas = await captureStableFrame(
       capture,
       canvas,
@@ -142,50 +118,87 @@ export async function encodeGif(ctx: CaptureCtx) {
       videoLayer
     )
     const gctx = frameCanvas.getContext("2d")
-    if (!gctx) {
-      progress.report("capturing", f + 1, frameCount)
-      continue
-    }
+    if (!gctx) return null
     if (watermark) {
       drawWatermark(gctx, frameCanvas.width, frameCanvas.height, watermark)
     }
-    frames.push(gctx.getImageData(0, 0, frameCanvas.width, frameCanvas.height))
-    progress.report("capturing", f + 1, frameCount)
+    return gctx.getImageData(0, 0, frameCanvas.width, frameCanvas.height)
   }
 
-  if (frames.length === 0) throw new Error("No frames captured for GIF export")
+  // Pass 1 — build ONE shared 256-color palette (a per-frame palette is what
+  // causes frame-to-frame color shimmer) from a handful of evenly spaced frames.
+  // Sampling rather than buffering every frame keeps peak memory flat, so the
+  // timeline can be arbitrarily long.
+  const sampleCount = Math.min(GIF_PALETTE_SAMPLE_FRAMES, frameCount)
+  progress.report("preparing", 0, sampleCount)
+  const sampleData: Uint8ClampedArray[] = []
+  let total = 0
+  for (let s = 0; s < sampleCount; s++) {
+    throwIfAborted(signal)
+    // Bias to frameCount - 1 on the last sample so end-state colors are covered.
+    const f =
+      s === sampleCount - 1
+        ? frameCount - 1
+        : Math.floor((s / sampleCount) * frameCount)
+    const frame = await renderFrame(f)
+    if (frame) {
+      sampleData.push(frame.data)
+      total += frame.data.length
+    }
+    progress.report("preparing", s + 1, sampleCount)
+  }
+  if (total === 0) throw new Error("No frames captured for GIF export")
 
-  // Pass 2 — one palette for the whole clip, then re-map + write each frame.
-  throwIfAborted(signal)
-  progress.report("encoding", 0, frames.length)
-  const gif = GIFEncoder()
-  const palette = buildGifPalette(frames)
+  const combined = new Uint8Array(total)
+  let offset = 0
+  for (const d of sampleData) {
+    combined.set(d, offset)
+    offset += d.length
+  }
+  sampleData.length = 0
+  const palette: Palette = quantize(combined, 256)
   const ditherAmplitude = paletteDitherAmplitude(palette)
 
+  // Pass 2 — render each frame, map onto the shared palette, write it straight
+  // into the encoder. Only the current frame is ever held in memory.
+  //
   // GIF delays are whole centiseconds (1/100 s). Distribute the target frame
   // duration across frames (Bresenham-style) so the average cadence matches the
   // requested fps with no rounding drift — this is what removes the playback
   // stutter versus naively truncating each delay to centiseconds.
+  const gif = GIFEncoder()
   let emittedCs = 0
-  for (let i = 0; i < frames.length; i++) {
+  let written = 0
+  progress.report("capturing", 0, frameCount)
+  for (let f = 0; f < frameCount; f++) {
     throwIfAborted(signal)
-    const frame = frames[i]
-    const { width, height } = frame
+    const frame = await renderFrame(f)
+    if (!frame) {
+      progress.report("capturing", f + 1, frameCount)
+      continue
+    }
     // Ordered-dither before mapping to soften 256-color banding on image
     // backgrounds; deterministic, so it doesn't reintroduce frame-to-frame flicker.
     orderedDither(frame, ditherAmplitude)
     const index = applyPalette(frame.data, palette)
-    const targetCs = Math.round(((i + 1) * frameDurationMs) / 10)
+    const targetCs = Math.round(((f + 1) * frameDurationMs) / 10)
     // Never below 2cs — most viewers clamp shorter delays to ~10cs, which would
     // itself look like a stutter.
     const delayCs = Math.max(2, targetCs - emittedCs)
     emittedCs += delayCs
-    gif.writeFrame(index, width, height, { palette, delay: delayCs * 10 })
-    progress.report("encoding", i + 1, frames.length)
+    gif.writeFrame(index, frame.width, frame.height, {
+      palette,
+      delay: delayCs * 10,
+    })
+    written++
+    progress.report("capturing", f + 1, frameCount)
   }
 
+  if (written === 0) throw new Error("No frames captured for GIF export")
+
   throwIfAborted(signal)
+  progress.report("encoding", 0, 1)
   gif.finish()
-  progress.report("encoding", frames.length, frames.length)
+  progress.report("encoding", 1, 1)
   return new Blob([new Uint8Array(gif.bytesView())], { type: "image/gif" })
 }

--- a/lib/editor/animation-export/gif.ts
+++ b/lib/editor/animation-export/gif.ts
@@ -2,7 +2,7 @@
  * GIF encode (gifenc, pure JS). Builds one shared 256-color palette for the whole
  * clip from sampled frames, then ordered-dithers and writes each frame straight
  * into the encoder with centisecond-accurate delays so playback cadence matches
- * the requested fps.
+ * the requested fps — up to `MAX_GIF_FPS`, which callers must clamp to.
  */
 
 import { GIFEncoder, quantize, applyPalette, type Palette } from "gifenc"
@@ -16,6 +16,14 @@ import { drawWatermark } from "./watermark"
 /** Frames to sample when building the shared palette — enough to cover the
  *  clip's color range without feeding every pixel of every frame to quantize. */
 const GIF_PALETTE_SAMPLE_FRAMES = 16
+
+/**
+ * Fastest cadence a GIF can actually express. Delays are whole centiseconds and
+ * viewers clamp anything under 2cs to ~10cs, so 2cs (50fps) is the floor per
+ * frame. Asking for more doesn't play faster — the encoder still emits 2cs and
+ * the clip runs long (60fps would stretch it by 20%). Callers clamp to this.
+ */
+export const MAX_GIF_FPS = 50
 
 // 8×8 Bayer threshold matrix (values 0–63) for ordered dithering. Ordered
 // dithering is deterministic — the same spatial pattern every frame — so it

--- a/lib/editor/animation-export/index.ts
+++ b/lib/editor/animation-export/index.ts
@@ -20,7 +20,7 @@ import { clearAnimationFrameVars } from "../apply-animation-frame"
 import { isVideoSrc } from "../media-type"
 import { captureClipPose, useEditorStore } from "../store"
 import { acquireAnimationCapture, suppressCloneTransitions } from "./capture"
-import { encodeGif } from "./gif"
+import { encodeGif, MAX_GIF_FPS } from "./gif"
 import { prepareCloneVideoLayer } from "./video-layer"
 import type { CloneVideoLayer } from "./video-layer"
 import {
@@ -105,7 +105,14 @@ async function encodeAnimation(
       : animation.clips
   if (!clips.length) throw new Error("Add at least one keyframe before sharing")
 
-  const fps = Math.max(1, Math.min(60, options.fps ?? 30))
+  // Clamp before frameCount so the plan and the emitted delays agree: a GIF
+  // can't express more than MAX_GIF_FPS, and planning above it would stretch
+  // the clip rather than speed it up.
+  const requestedFps = Math.max(1, Math.min(60, options.fps ?? 30))
+  const fps =
+    options.format === "gif"
+      ? Math.min(requestedFps, MAX_GIF_FPS)
+      : requestedFps
   const frameCount = Math.max(1, Math.round((durationMs / 1000) * fps))
   const frameDurationMs = 1000 / fps
   const targetWidth =

--- a/lib/editor/animation-export/index.ts
+++ b/lib/editor/animation-export/index.ts
@@ -24,7 +24,6 @@ import { encodeGif } from "./gif"
 import { prepareCloneVideoLayer } from "./video-layer"
 import type { CloneVideoLayer } from "./video-layer"
 import {
-  MAX_FRAMES,
   type AnimationExportBlobResult,
   type AnimationExportOptions,
   type CaptureCtx,
@@ -107,10 +106,7 @@ async function encodeAnimation(
   if (!clips.length) throw new Error("Add at least one keyframe before sharing")
 
   const fps = Math.max(1, Math.min(60, options.fps ?? 30))
-  const frameCount = Math.min(
-    MAX_FRAMES,
-    Math.max(1, Math.round((durationMs / 1000) * fps))
-  )
+  const frameCount = Math.max(1, Math.round((durationMs / 1000) * fps))
   const frameDurationMs = 1000 / fps
   const targetWidth =
     options.targetWidth ??

--- a/lib/editor/animation-export/types.ts
+++ b/lib/editor/animation-export/types.ts
@@ -85,5 +85,3 @@ export type CaptureCtx = {
   /** Non-null when the canvas is a video and its frames are decodable here. */
   videoLayer: CloneVideoLayer | null
 }
-
-export const MAX_FRAMES = 600

--- a/lib/editor/animation-export/video.ts
+++ b/lib/editor/animation-export/video.ts
@@ -36,9 +36,11 @@ import { drawWatermark } from "./watermark"
 // Cap on what the MediaRecorder fallback may buffer = frames × pixels-per-frame.
 // Unlike the WebCodecs path it can't stream: capture is slower than real time, so
 // every frame must be rasterized up front and held as a canvas before playback
-// drives the recorder. ~150M pixels keeps the backing stores near ~600 MB, which
-// is roughly 2 min at 720p or 40 s at 1080p. Only browsers without WebCodecs
-// (which are also the memory-poorest) ever reach this path.
+// drives the recorder. Canvas backing stores are raw RGBA, so 150M pixels is
+// already ~600 MB — which buys only ~162 frames at 720p (5.4 s @ 30fps) or ~72 at
+// 1080p (2.4 s). That is deliberately tight: the budget is set by memory, not by
+// a target duration. Only browsers without WebCodecs reach this path, and they
+// are the memory-poorest ones. Everything else streams and has no ceiling.
 export const MAX_MEDIARECORDER_TOTAL_PIXELS = 150_000_000
 
 /**

--- a/lib/editor/animation-export/video.ts
+++ b/lib/editor/animation-export/video.ts
@@ -33,6 +33,14 @@ import {
 } from "./utils"
 import { drawWatermark } from "./watermark"
 
+// Cap on what the MediaRecorder fallback may buffer = frames × pixels-per-frame.
+// Unlike the WebCodecs path it can't stream: capture is slower than real time, so
+// every frame must be rasterized up front and held as a canvas before playback
+// drives the recorder. ~150M pixels keeps the backing stores near ~600 MB, which
+// is roughly 2 min at 720p or 40 s at 1080p. Only browsers without WebCodecs
+// (which are also the memory-poorest) ever reach this path.
+export const MAX_MEDIARECORDER_TOTAL_PIXELS = 150_000_000
+
 /**
  * Whether this browser can actually produce a WebM file — true when WebCodecs can
  * encode a WebM codec (VP9/VP8/AV1) OR MediaRecorder records WebM. Safari does
@@ -228,6 +236,15 @@ export async function encodeWebmMediaRecorder({
   if (!mimeType) {
     throw new Error(
       "WebM export isn't supported in this browser (e.g. Safari). Try MP4 or GIF instead."
+    )
+  }
+
+  if (
+    frameCount * capture.width * capture.height >
+    MAX_MEDIARECORDER_TOTAL_PIXELS
+  ) {
+    throw new Error(
+      "This animation is too long for your browser to export — it lacks WebCodecs, so every frame must be held in memory. Shorten the timeline, lower the resolution, or use Chrome or Edge."
     )
   }
 

--- a/tests/lib/editor/animation-export/export-video.integration.test.ts
+++ b/tests/lib/editor/animation-export/export-video.integration.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   acquireCapture: vi.fn(),
   clearAnimationFrameVars: vi.fn(),
   createVideoLayer: vi.fn(),
+  encodeGif: vi.fn(),
   encodeVideo: vi.fn(),
   getState: vi.fn(),
   isVideoSrc: vi.fn(),
@@ -34,7 +35,8 @@ vi.mock("@/lib/editor/animation-export/video-layer", () => ({
 }))
 
 vi.mock("@/lib/editor/animation-export/gif", () => ({
-  encodeGif: vi.fn(),
+  MAX_GIF_FPS: 50,
+  encodeGif: mocks.encodeGif,
 }))
 
 vi.mock("@/lib/editor/animation-export/video", () => ({
@@ -174,6 +176,44 @@ describe("Animate video export coordinator", () => {
 
     expect(mocks.encodeVideo).toHaveBeenCalledWith(
       expect.objectContaining({ frameCount: 5 * 60 * 30 }),
+      "mp4"
+    )
+  })
+
+  // GIF delays are whole centiseconds with a 2cs floor, so >50fps can't play
+  // faster — it just stretches the clip (60fps ran 20% long). Clamp has to land
+  // before frameCount so the plan and the emitted delays agree.
+  it("clamps GIF exports to MAX_GIF_FPS and plans frames at the clamped rate", async () => {
+    mocks.getState.mockReturnValue(editorState(2000))
+    mocks.isVideoSrc.mockReturnValue(false)
+    mocks.acquireCapture.mockResolvedValue(capture)
+    mocks.encodeGif.mockResolvedValue(new Blob(["gif"], { type: "image/gif" }))
+
+    await exportAnimationBlob("canvas-1", {
+      format: "gif",
+      fps: 60,
+      watermark: false,
+    })
+
+    expect(mocks.encodeGif).toHaveBeenCalledWith(
+      expect.objectContaining({ fps: 50, frameCount: 100 })
+    )
+  })
+
+  it("leaves 60fps alone for video formats", async () => {
+    mocks.getState.mockReturnValue(editorState(2000))
+    mocks.isVideoSrc.mockReturnValue(false)
+    mocks.acquireCapture.mockResolvedValue(capture)
+    mocks.encodeVideo.mockResolvedValue(new Blob(["v"], { type: "video/mp4" }))
+
+    await exportAnimationBlob("canvas-1", {
+      format: "mp4",
+      fps: 60,
+      watermark: false,
+    })
+
+    expect(mocks.encodeVideo).toHaveBeenCalledWith(
+      expect.objectContaining({ fps: 60, frameCount: 120 }),
       "mp4"
     )
   })

--- a/tests/lib/editor/animation-export/export-video.integration.test.ts
+++ b/tests/lib/editor/animation-export/export-video.integration.test.ts
@@ -76,7 +76,7 @@ const videoLayer = {
   cleanup: vi.fn(),
 }
 
-function editorState() {
+function editorState(durationMs = 1000) {
   return {
     isAnimateMode: false,
     selectedAnimationClipId: null,
@@ -88,8 +88,8 @@ function editorState() {
           screenshot: "blob:source-video",
           videoClips: [],
           animation: {
-            durationMs: 1000,
-            clips: [{ id: "keyframe-1", startMs: 0, durationMs: 1000 }],
+            durationMs,
+            clips: [{ id: "keyframe-1", startMs: 0, durationMs }],
           },
         },
       ],
@@ -153,4 +153,28 @@ describe("Animate video export coordinator", () => {
       )
     }
   )
+
+  // Regression: the frame count used to be clamped to 600, so anything past 20 s
+  // at 30 fps was silently cut off mid-animation with no error.
+  it("covers the whole timeline instead of truncating long animations", async () => {
+    mocks.getState.mockReturnValue(editorState(5 * 60 * 1000))
+    mocks.isVideoSrc.mockReturnValue(false)
+    mocks.acquireCapture.mockResolvedValue(capture)
+    mocks.encodeVideo.mockResolvedValue(
+      new Blob(["video"], {
+        type: "video/mp4",
+      })
+    )
+
+    await exportAnimationBlob("canvas-1", {
+      format: "mp4",
+      fps: 30,
+      watermark: false,
+    })
+
+    expect(mocks.encodeVideo).toHaveBeenCalledWith(
+      expect.objectContaining({ frameCount: 5 * 60 * 30 }),
+      "mp4"
+    )
+  })
 })

--- a/tests/lib/editor/animation-export/mediarecorder-budget.test.ts
+++ b/tests/lib/editor/animation-export/mediarecorder-budget.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type * as AnimationExportUtils from "@/lib/editor/animation-export/utils"
+
+const mocks = vi.hoisted(() => ({
+  captureStableFrame: vi.fn(),
+  pickWebmMimeType: vi.fn(),
+}))
+
+// The MediaRecorder fallback bails on an unsupported container before it ever
+// reaches the memory guard, and jsdom has no MediaRecorder — so pin the mime.
+vi.mock("@/lib/editor/animation-export/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof AnimationExportUtils>()),
+  pickWebmMimeType: mocks.pickWebmMimeType,
+}))
+
+vi.mock("@/lib/editor/animation-export/capture", () => ({
+  captureStableFrame: mocks.captureStableFrame,
+}))
+
+import {
+  MAX_MEDIARECORDER_TOTAL_PIXELS,
+  encodeWebmMediaRecorder,
+} from "@/lib/editor/animation-export/video"
+
+type RecorderCtx = Parameters<typeof encodeWebmMediaRecorder>[0]
+
+function ctxFor(
+  frameCount: number,
+  width: number,
+  height: number
+): RecorderCtx {
+  return {
+    capture: {
+      node: document.createElement("div"),
+      width,
+      height,
+      needsPaint: false,
+      captureFrame: vi.fn(),
+      cleanup: vi.fn(),
+    },
+    canvas: { id: "canvas-1", screenshot: null },
+    globalAspect: { id: "wide", w: 16, h: 9 },
+    clips: [],
+    frameCount,
+    frameDurationMs: 1000 / 30,
+    fps: 30,
+    progress: { report: vi.fn() },
+    watermark: null,
+    videoLayer: null,
+    durationMs: (frameCount / 30) * 1000,
+    // Only the fields the budget guard and the capture loop read are populated.
+  } as unknown as RecorderCtx
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("MediaRecorder WebM fallback memory budget", () => {
+  it("rejects an over-budget workload before capturing any frame", async () => {
+    mocks.pickWebmMimeType.mockReturnValue("video/webm")
+    // 1080p × 200 frames ≈ 414M px, well past the 150M budget.
+    const frameCount = 200
+    expect(frameCount * 1920 * 1080).toBeGreaterThan(
+      MAX_MEDIARECORDER_TOTAL_PIXELS
+    )
+
+    await expect(
+      encodeWebmMediaRecorder(ctxFor(frameCount, 1920, 1080))
+    ).rejects.toThrow(/too long for your browser to export/)
+
+    // The whole point of the guard: fail before allocating any of it.
+    expect(mocks.captureStableFrame).not.toHaveBeenCalled()
+  })
+
+  it("lets a within-budget workload through to frame capture", async () => {
+    mocks.pickWebmMimeType.mockReturnValue("video/webm")
+    mocks.captureStableFrame.mockRejectedValue(new Error("stop after guard"))
+    const frameCount = 10
+    expect(frameCount * 1920 * 1080).toBeLessThan(
+      MAX_MEDIARECORDER_TOTAL_PIXELS
+    )
+
+    await expect(
+      encodeWebmMediaRecorder(ctxFor(frameCount, 1920, 1080))
+    ).rejects.toThrow("stop after guard")
+
+    expect(mocks.captureStableFrame).toHaveBeenCalled()
+  })
+
+  it("still reports the unsupported-container error ahead of the budget", async () => {
+    mocks.pickWebmMimeType.mockReturnValue(null)
+
+    await expect(
+      encodeWebmMediaRecorder(ctxFor(10_000, 1920, 1080))
+    ).rejects.toThrow(/isn't supported in this browser/)
+  })
+})

--- a/wiki/core/README.md
+++ b/wiki/core/README.md
@@ -175,7 +175,7 @@ flowchart LR
 | Share storage / user | 1 GB |
 | Direct still share body | 40 MB |
 | Resumable share upload | 1 GB |
-| Keyframe export frames | 600 |
+| Keyframe export frames | Uncapped (GIF 350M px, MediaRecorder WebM 150M px — frames × area) |
 
 ## Canvas images (edit performance)
 

--- a/wiki/core/animation-export.md
+++ b/wiki/core/animation-export.md
@@ -14,7 +14,7 @@ Use this path when the canvas has visual keyframes. For a video canvas with **no
 ```
 lib/editor/animation-export/
 ├── index.ts                 # Orchestrator — exportAnimation*
-├── types.ts                 # Formats, phases, CaptureCtx, MAX_FRAMES
+├── types.ts                 # Formats, phases, CaptureCtx
 ├── capture.ts               # Engine selection + captureStableFrame
 ├── webkit-layered-frame.ts  # WebKit perspective fix — layered underlay/shell/FG
 ├── video.ts                 # Mediabunny encode + MediaRecorder WebM fallback
@@ -50,7 +50,7 @@ sequenceDiagram
   participant Enc as gifenc / Mediabunny / MediaRecorder
 
   UI->>Orch: canvasId + format/fps/width
-  Orch->>Orch: Read clips, duration; frameCount ≤ 600
+  Orch->>Orch: Read clips, duration; frameCount = duration × fps
   Orch->>Cap: auto | fast | legacy
   Cap-->>Orch: AnimationCapture
   opt screenshot is video
@@ -67,12 +67,12 @@ sequenceDiagram
 ### Stages (ordered)
 
 1. Read store: `canvas.animation`, clips, `durationMs`; optionally merge live selected-clip pose via `captureClipPose`.
-2. Compute `frameCount = min(600, duration × fps)`; preload watermark assets.
+2. Compute `frameCount = duration × fps` — the whole timeline, uncapped; preload watermark assets.
 3. `acquireAnimationCapture(mode)` — `auto` tries fast, falls back to legacy.
 4. `suppressCloneTransitions` on the clone.
 5. If main screenshot is video → `prepareCloneVideoLayer` (decode + JPEG bridge).
 6. Encode by format:
-   - **GIF** → `encodeGif` → per-frame `captureStableFrame` → gifenc palette / Bayer dither
+   - **GIF** → `encodeGif` → 16 sampled frames build the shared palette, then per-frame `captureStableFrame` → Bayer dither → straight into gifenc
    - **MP4 / WebM** → `tryEncodeWithMediabunny`; on failure, MediaRecorder WebM (MP4 hard-fails without WebCodecs)
 7. Per frame inside encoders: `captureStableFrame` (WebKit layered when applicable, else videoLayer paint → FO) → portrait DoF → watermark.
 8. Audio (Mediabunny only): `prepareAnimationAudio` — passthrough if timeline untouched, else re-time to segments.
@@ -201,10 +201,10 @@ flowchart LR
 ```mermaid
 flowchart TD
   FMT{"format"}
-  FMT -->|gif| GIF["gifenc<br/>shared 256 palette + Bayer dither"]
+  FMT -->|gif| GIF["gifenc<br/>16 sampled frames → shared 256 palette<br/>then stream + Bayer dither"]
   FMT -->|mp4 / webm| MB{"tryEncodeWithMediabunny"}
-  MB -->|ok| MBENC["CanvasSource + preferred codecs"]
-  MB -->|fail / no VideoEncoder| MR["MediaRecorder WebM<br/>silent — no audio"]
+  MB -->|ok| MBENC["CanvasSource + preferred codecs<br/>streams — no frame budget"]
+  MB -->|fail / no VideoEncoder| MR["MediaRecorder WebM<br/>silent — no audio<br/>buffers — pixel budget"]
   MB -->|mp4 + no WebCodecs| FAIL["Hard fail"]
 ```
 
@@ -217,7 +217,21 @@ flowchart TD
 
 - Bitrate: high quality; keyframe interval ~2s; even dimensions.
 - Safari: WebM disabled in UI (`isWebmExportSupported` false).
-- `MAX_FRAMES = 600` hard cap on the keyframe path.
+
+### Frame budgets
+
+There is **no global frame cap**. A `MAX_FRAMES = 600` clamp used to live in `index.ts` and silently truncated any timeline past 20 s @ 30fps (10 s @ 60fps) — the file just ended mid-motion, with the audio window cut to match so it looked deliberate. It was really a blunt guard for the two encoders that buffer; each now carries its own bound, and only where the memory pressure is real.
+
+| Path | Buffers? | Bound |
+|---|---|---|
+| Mediabunny / WebCodecs (MP4, WebM) | No — streams into the muxer | None. Full timeline at any length |
+| GIF (`gif.ts`) | No — samples then streams | `gifExportExceedsMemory` (`MAX_GIF_TOTAL_PIXELS = 350M`, frames × area) |
+| MediaRecorder WebM fallback | **Yes** — every frame as a canvas | `MAX_MEDIARECORDER_TOTAL_PIXELS = 150M` (frames × area) |
+
+- **GIF** used to buffer every frame as raw `ImageData` just to build a shared palette in a second pass (~700 MB at the old cap on 720p). It now mirrors `video-media/encode-gif.ts`: render 16 evenly-spaced frames for the palette, then render each frame once and write it straight into the encoder. Peak memory is flat regardless of length, for 16 extra captures rather than a 2× full pass. The remaining guard exists because **gifenc** accumulates the whole compressed stream in RAM until `finish()` — that ceiling is real and independent of how frames are captured.
+- **MediaRecorder** genuinely cannot stream: capture is slower than real time, so every frame is rasterized up front and held as a canvas before playback drives the recorder. ~150M px ≈ 600 MB of backing store — roughly 2 min at 720p, 40 s at 1080p. Only browsers without WebCodecs reach it.
+
+Both bounds **throw a user-facing error** rather than shortening the output. Either the export is complete or it says why it can't be.
 
 ---
 
@@ -248,7 +262,7 @@ MediaRecorder fallback has **no** audio.
 | `capture.ts` | Engine acquire; `captureStableFrame`; layered-then-plain; incomplete-frame hold |
 | `webkit-layered-frame.ts` | WebKit Animate capture: underlay/shell caches + projected compose |
 | `video.ts` | Mediabunny encode; MediaRecorder fallback; WebM capability probe |
-| `gif.ts` | GIF encode loop |
+| `gif.ts` | GIF encode: sampled shared palette, then streaming dither/write |
 | `video-layer.ts` | Timeline↔source mapping; JPEG bridge; `getFrame` for layered |
 | `animation-audio.ts` | Segment-aware audio for keyframe export |
 | `watermark.ts` | Per-frame credit overlay |
@@ -278,7 +292,7 @@ MediaRecorder fallback has **no** audio.
 4. **WebKit FO flattens perspective** — Animate uses the layered underlay/shell/warp path; Chromium stays on single-pass FO.
 5. **Layered declines cleanly** — `null` or throw → plain capture; never fail the whole export.
 6. **Audio is best-effort** — missing tracks never fail export.
-7. **600-frame budget** — long timelines are capped (video-media has no such cap; GIF has a pixel-budget guard there instead).
+7. **No silent truncation** — the timeline exports in full, or the export fails with a reason. Memory bounds live on the two encoders that actually buffer (GIF, MediaRecorder), expressed as frames × area; the WebCodecs path streams and is unbounded.
 8. **WebM gated on Safari** — UI + `isWebmExportSupported`.
 
 ---
@@ -290,7 +304,7 @@ MediaRecorder fallback has **no** audio.
 | `tests/lib/editor/animation-export/capture-engines.test.ts` | auto/fast/legacy selection + fallback |
 | `tests/lib/editor/animation-export/capture-stable-frame.test.ts` | layered preferred; skip JPEG when layered; decline → plain; throw → plain |
 | `tests/lib/editor/animation-export/webkit-layered-frame.test.ts` | gating, compose/warp, video `getFrame`, underlay settle + caches |
-| `tests/lib/editor/animation-export/export-video.integration.test.ts` | video layer → Mediabunny → cleanup |
+| `tests/lib/editor/animation-export/export-video.integration.test.ts` | video layer → Mediabunny → cleanup; long timelines are not truncated |
 | `tests/lib/editor/animation-export/video-layer.test.ts` | segment math; JPEG bridge; hold outside clips |
 | `tests/lib/editor/animation-export/animation-audio.test.ts` | passthrough vs retimed audio |
 | `tests/lib/editor/animation-export/error-message.test.ts` | user-facing errors |

--- a/wiki/core/animation-export.md
+++ b/wiki/core/animation-export.md
@@ -217,6 +217,7 @@ flowchart TD
 
 - Bitrate: high quality; keyframe interval ~2s; even dimensions.
 - Safari: WebM disabled in UI (`isWebmExportSupported` false).
+- **GIF fps is clamped to `MAX_GIF_FPS = 50`** in `index.ts`, before `frameCount` is computed. Delays are whole centiseconds with a 2cs floor (viewers clamp anything shorter to ~10cs), so 50fps is the fastest cadence a GIF can express — asking for 60 doesn't play faster, it emits 2cs anyway and runs the clip 20% long. The UI already only offers GIF `[20, 25, 50]`; the clamp makes the encoder correct for direct API callers too.
 
 ### Frame budgets
 
@@ -229,7 +230,7 @@ There is **no global frame cap**. A `MAX_FRAMES = 600` clamp used to live in `in
 | MediaRecorder WebM fallback | **Yes** — every frame as a canvas | `MAX_MEDIARECORDER_TOTAL_PIXELS = 150M` (frames × area) |
 
 - **GIF** used to buffer every frame as raw `ImageData` just to build a shared palette in a second pass (~700 MB at the old cap on 720p). It now mirrors `video-media/encode-gif.ts`: render 16 evenly-spaced frames for the palette, then render each frame once and write it straight into the encoder. Peak memory is flat regardless of length, for 16 extra captures rather than a 2× full pass. The remaining guard exists because **gifenc** accumulates the whole compressed stream in RAM until `finish()` — that ceiling is real and independent of how frames are captured.
-- **MediaRecorder** genuinely cannot stream: capture is slower than real time, so every frame is rasterized up front and held as a canvas before playback drives the recorder. ~150M px ≈ 600 MB of backing store — roughly 2 min at 720p, 40 s at 1080p. Only browsers without WebCodecs reach it.
+- **MediaRecorder** genuinely cannot stream: capture is slower than real time, so every frame is rasterized up front and held as a canvas before playback drives the recorder. Canvas backing stores are raw RGBA, so 150M px is already ~600 MB — buying only ~162 frames at 720p (**5.4 s @ 30fps**) or ~72 at 1080p (**2.4 s**). Deliberately tight: the number is set by memory, not by a target duration. Only browsers without WebCodecs reach it. For reference, the old 600-frame cap at 720p would have been ~2.2 GB.
 
 Both bounds **throw a user-facing error** rather than shortening the output. Either the export is complete or it says why it can't be.
 
@@ -304,7 +305,8 @@ MediaRecorder fallback has **no** audio.
 | `tests/lib/editor/animation-export/capture-engines.test.ts` | auto/fast/legacy selection + fallback |
 | `tests/lib/editor/animation-export/capture-stable-frame.test.ts` | layered preferred; skip JPEG when layered; decline → plain; throw → plain |
 | `tests/lib/editor/animation-export/webkit-layered-frame.test.ts` | gating, compose/warp, video `getFrame`, underlay settle + caches |
-| `tests/lib/editor/animation-export/export-video.integration.test.ts` | video layer → Mediabunny → cleanup; long timelines are not truncated |
+| `tests/lib/editor/animation-export/export-video.integration.test.ts` | video layer → Mediabunny → cleanup; long timelines are not truncated; GIF fps clamp |
+| `tests/lib/editor/animation-export/mediarecorder-budget.test.ts` | fallback pixel budget rejects before any frame is captured |
 | `tests/lib/editor/animation-export/video-layer.test.ts` | segment math; JPEG bridge; hold outside clips |
 | `tests/lib/editor/animation-export/animation-audio.test.ts` | passthrough vs retimed audio |
 | `tests/lib/editor/animation-export/error-message.test.ts` | user-facing errors |

--- a/wiki/core/video-export.md
+++ b/wiki/core/video-export.md
@@ -77,7 +77,7 @@ sequenceDiagram
 
 1. Validate `canvas.screenshot` is a video URL.
 2. `prepareAnimationCapture` — **legacy/precise only** (not the fast FO path).
-3. `waitForVideoReady`; `planFrames(duration, fps)` — **no 600-frame cap**.
+3. `waitForVideoReady`; `planFrames(duration, fps)` — full clip, no frame cap.
 4. Decode strategy:
    - Chromium (`supportsObjectViewBox`) → DOM seek inside the clone
    - Safari / Firefox → `createDecodedFrameSource`; if native AV1 rejected → register dav1d WASM
@@ -191,7 +191,7 @@ flowchart LR
 
 | Topic | Behavior |
 |---|---|
-| Frame budget | No 600 cap (unlike keyframe export) |
+| Frame budget | None — full clip length |
 | GIF memory | `MAX_GIF_TOTAL_PIXELS ≈ 350e6` OOM guard |
 | Audio length | `exportAudioDurationSec(plan)` — matches styled frame count, not raw clip length |
 | Audio failure | Silent export; never fail the job |
@@ -260,7 +260,7 @@ Remux is judged against `containerAudioCodecs`, **not** the muxer's own capabili
 | Scene motion | Static styling; video pixels change | CSS / timeline changes every frame |
 | Video handling | Composite into fixed slot | Plain: JPEG `<img>` bridge; WebKit layered: `getFrame` into cached shell + warp |
 | WebKit perspective | Once-raster underlay/FG + per-frame media warp | Same primitives via `webkit-layered-frame` (per-frame pose) |
-| Frame cap | None (GIF has pixel budget) | `MAX_FRAMES = 600` |
+| Frame cap | None (GIF has pixel budget) | None; same per-encoder pixel budgets |
 | Audio | `prepareSourceAudio` | `prepareAnimationAudio` (segment-aware) |
 | Entry | `exportVideoMedia` | `exportAnimation*` |
 


### PR DESCRIPTION
## The bug

Animate-mode export clamped `frameCount` to `MAX_FRAMES = 600`:

```ts
const frameCount = Math.min(
  MAX_FRAMES,
  Math.max(1, Math.round((durationMs / 1000) * fps))
)
```

That's **20s at 30fps, 10s at 60fps** — but the timeline allows up to `MAX_DURATION_MS = 60 * 60 * 1000` (60 min). The worse part is that it truncated *silently*: no warning, no error, just a file that ends mid-motion. Audio was cut to match (`exportDurationSec: frameCount / fps`), so the output looked deliberate rather than broken.

Only keyframe animations were affected — the plain video-canvas pipeline (`video-media/frames.ts`) has never had this cap, and its tests already cover 20-minute exports.

## Why the cap was there

It was a blunt guard for the two encode paths that buffer frames in memory. The third — WebCodecs via `tryEncodeWithMediabunny` — already streams and never needed one.

## Changes

**Removed the blanket clamp** in `animation-export/index.ts`, then addressed each buffering path on its own terms.

**`gif.ts` — rewritten to stream.** It previously buffered *every* frame as raw `ImageData` (~700 MB at the cap on 720p) purely so it could build a shared palette in a second pass. Now it follows the same sample-then-stream shape `video-media/encode-gif.ts` already uses: render 16 evenly-spaced frames to build the shared 256-color palette, then render each frame once and write it straight into the encoder. Peak memory is flat regardless of length, for the cost of 16 extra captures rather than a 2× full pass. Ordered (Bayer) dithering and the Bresenham centisecond delays are unchanged.

Also picked up the existing `gifExportExceedsMemory` guard — gifenc still accumulates the whole compressed stream in RAM until `finish()`, so that ceiling is real, but it now fails fast with a message pointing at MP4/WebM instead of being enforced by an unrelated frame count.

**`video.ts` — a real cap with a real error.** `encodeWebmMediaRecorder` genuinely cannot stream: capture is slower than real time, so every frame must be rasterized up front and held as a canvas before playback drives the recorder. It keeps a cap, now a `MAX_MEDIARECORDER_TOTAL_PIXELS` budget (frames × area, ~150M px ≈ 600 MB of backing store — roughly 2 min at 720p or 40s at 1080p) that throws a clear message instead of quietly shortening the file. Only browsers without WebCodecs reach this path.

## Result

| path | before | after |
|---|---|---|
| MP4 / WebM (WebCodecs) | capped at 600 frames | full timeline, any length |
| GIF | capped at 600 frames, ~700 MB peak | flat memory, explicit error past the gifenc ceiling |
| WebM (MediaRecorder fallback) | capped at 600 frames | explicit error past the memory budget |

No silent truncation anywhere — either it exports in full, or it says why it can't.

## Testing

Added a regression test asserting a 5-minute timeline produces 9000 frames rather than 600.

- `pnpm typecheck` clean
- `pnpm vitest run` — 1190 passed / 156 files
- oxfmt + eslint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GIF exports now use less memory and process frames progressively.
  * GIF color quality is improved with shared palettes and adaptive dithering.
  * Long animations can be exported without an artificial frame-count limit.
  * Video exports now prevent oversized fallback recordings that could exceed memory limits.

* **Bug Fixes**
  * Fixed timing drift in GIF frame delays.
  * Added safeguards for resource-intensive animation exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the global 600-frame animation-export limit.
- Streams GIF frame rendering after building a shared palette from 16 sampled frames and adds an explicit GIF memory guard.
- Adds a total-pixel memory limit with an actionable error for the MediaRecorder fallback.
- Adds regression coverage confirming that a five-minute animation exports all 9,000 frames.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness or security defects identified in the changed paths.

The full frame count now reaches each encoder, while the two memory-buffering paths either stream their frame work or reject oversized exports before capturing frames.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/editor/animation-export/gif.ts | Replaces full raw-frame buffering with bounded palette sampling and sequential GIF frame encoding while retaining timing and dithering behavior. |
| lib/editor/animation-export/index.ts | Removes the blanket 600-frame clamp so encoders receive the complete timeline frame count. |
| lib/editor/animation-export/types.ts | Removes the obsolete global MAX_FRAMES constant. |
| lib/editor/animation-export/video.ts | Adds an early total-pixel memory bound to the buffering MediaRecorder fallback. |
| tests/lib/editor/animation-export/export-video.integration.test.ts | Adds regression coverage verifying that long animation timelines are no longer truncated. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(animate): export the full timeline i..."](https://github.com/shivabhattacharjee/tokokino/commit/1b72e1d0c8a0deb509fe8cf146af15ddb31160f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48656494)</sub>

<!-- /greptile_comment -->