### PR TITLE
feat: 3D shapes library in the inspector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ pack
 # local export debug dumps
 debug/
 .env.local
+shapes/

--- a/components/editor/inspector.tsx
+++ b/components/editor/inspector.tsx
@@ -9,6 +9,7 @@ import {
   RiMoonClearLine,
   RiPaletteLine,
   RiRotateLockLine,
+  RiShapesLine,
   RiSunLine,
   RiTwitterXLine,
 } from "@remixicon/react"
@@ -25,6 +26,7 @@ import { PaddingSection } from "./inspector/padding-section"
 import { PositionSection } from "./inspector/position-section"
 import { Section } from "./inspector/primitives"
 import { ShadowSection } from "./inspector/shadow-section"
+import { ShapesSection } from "./inspector/shapes-section"
 import { TiltSection } from "./inspector/tilt-section"
 import { TweetSection } from "./inspector/tweet-section"
 
@@ -102,6 +104,11 @@ export function Inspector({
 
           <Section icon={RiSunLine} title="Backdrop">
             <BackdropSection />
+          </Section>
+          <div className="my-3 h-px bg-border/50" />
+
+          <Section icon={RiShapesLine} title="Shapes">
+            <ShapesSection />
           </Section>
           <div className="my-3 h-px bg-border/50" />
 

--- a/components/editor/inspector/shapes-section.tsx
+++ b/components/editor/inspector/shapes-section.tsx
@@ -1,0 +1,174 @@
+"use client"
+
+import * as React from "react"
+
+import { ShimmerImage } from "@/components/ui/shimmer-image"
+import { SHAPE_LIBRARY } from "@/lib/editor/presets"
+import type { ShapeEntry } from "@/lib/editor/state-types"
+import { useEditor } from "@/lib/editor/store"
+import { cn } from "@/lib/utils"
+
+const shapeLoadedCache = new Set<string>()
+
+export function ShapesSection() {
+  const {
+    addAsset,
+    setSelectedAssetId,
+    setSelectedTextId,
+    setSelectedScreenshotSlotId,
+    setIsScreenshotSelected,
+    setActiveTool,
+  } = useEditor()
+
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+  const callbacksRef = React.useRef<Map<Element, () => void>>(new Map())
+  const [observer, setObserver] = React.useState<IntersectionObserver | null>(
+    null
+  )
+
+  React.useEffect(() => {
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue
+          const cb = callbacksRef.current.get(entry.target)
+          if (cb) {
+            cb()
+            callbacksRef.current.delete(entry.target)
+            obs.unobserve(entry.target)
+          }
+        }
+      },
+      { root: scrollRef.current, rootMargin: "200px" }
+    )
+    setObserver(obs)
+    const callbacks = callbacksRef.current
+    return () => {
+      obs.disconnect()
+      callbacks.clear()
+    }
+  }, [])
+
+  const observe = React.useCallback(
+    (el: Element, cb: () => void) => {
+      if (!observer) return
+      callbacksRef.current.set(el, cb)
+      observer.observe(el)
+    },
+    [observer]
+  )
+
+  const unobserve = React.useCallback(
+    (el: Element) => {
+      callbacksRef.current.delete(el)
+      observer?.unobserve(el)
+    },
+    [observer]
+  )
+
+  // Mirrors the toolbar's image-upload path so a shape behaves exactly like any
+  // other asset once it lands on the canvas.
+  const handleAdd = React.useCallback(
+    (shape: ShapeEntry) => {
+      const id = addAsset(shape.full)
+      setSelectedAssetId(id)
+      setSelectedTextId(null)
+      setSelectedScreenshotSlotId(null)
+      setIsScreenshotSelected(false)
+      setActiveTool("pointer")
+    },
+    [
+      addAsset,
+      setSelectedAssetId,
+      setSelectedTextId,
+      setSelectedScreenshotSlotId,
+      setIsScreenshotSelected,
+      setActiveTool,
+    ]
+  )
+
+  if (!SHAPE_LIBRARY.length) return null
+
+  return (
+    <div className="space-y-2">
+      <p className="px-1 text-[11px] text-muted-foreground">
+        Click a shape to drop it on the canvas.
+      </p>
+      <div
+        ref={scrollRef}
+        className="max-h-[268px] overflow-y-auto overscroll-contain [contain:layout_paint]"
+      >
+        <div className="grid grid-cols-3 gap-2 px-1 py-1">
+          {SHAPE_LIBRARY.map((shape) => (
+            <ShapeThumb
+              key={shape.id}
+              shape={shape}
+              observe={observe}
+              unobserve={unobserve}
+              onAdd={handleAdd}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const ShapeThumb = React.memo(function ShapeThumb({
+  shape,
+  observe,
+  unobserve,
+  onAdd,
+}: {
+  shape: ShapeEntry
+  observe: (el: Element, cb: () => void) => void
+  unobserve: (el: Element) => void
+  onAdd: (shape: ShapeEntry) => void
+}) {
+  const ref = React.useRef<HTMLButtonElement>(null)
+  const wasCached = shapeLoadedCache.has(shape.id)
+  const [visible, setVisible] = React.useState(wasCached)
+  const [loaded, setLoaded] = React.useState(wasCached)
+
+  React.useEffect(() => {
+    if (visible) return
+    const el = ref.current
+    if (!el) return
+    observe(el, () => setVisible(true))
+    return () => unobserve(el)
+  }, [observe, unobserve, visible])
+
+  const handleClick = React.useCallback(() => onAdd(shape), [onAdd, shape])
+  const handleLoad = React.useCallback(() => {
+    shapeLoadedCache.add(shape.id)
+    setLoaded(true)
+  }, [shape.id])
+
+  return (
+    <button
+      ref={ref}
+      onClick={handleClick}
+      title={`Add ${shape.name}`}
+      className="relative aspect-square cursor-pointer overflow-hidden rounded-md border border-border/60 bg-secondary/30 transition-colors [contain:layout_style_paint] hover:border-foreground/30"
+    >
+      {visible ? (
+        <ShimmerImage
+          src={shape.thumb}
+          alt={shape.name}
+          loading="lazy"
+          decoding="async"
+          onLoad={handleLoad}
+          className={cn(
+            "h-full w-full object-contain p-1",
+            !loaded && "opacity-0"
+          )}
+        />
+      ) : null}
+      {(!visible || !loaded) && (
+        <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <span className="size-3 animate-spin rounded-full border-2 border-neutral-300 border-t-neutral-600" />
+        </span>
+      )}
+    </button>
+  )
+})

--- a/lib/editor/presets.ts
+++ b/lib/editor/presets.ts
@@ -1,8 +1,10 @@
 import BACKGROUND_DATA from "./backgrounds-data.json"
+import SHAPE_DATA from "./shapes-data.json"
 import type {
   BackgroundCategory,
   GradientCategory,
   ScreenshotPosition,
+  ShapeEntry,
 } from "./state-types"
 
 export const ANNOTATION_COLORS = [
@@ -421,6 +423,8 @@ export const SOLID_PRESETS = [
 ]
 
 export const BACKGROUND_LIBRARY: BackgroundCategory[] = BACKGROUND_DATA
+
+export const SHAPE_LIBRARY: ShapeEntry[] = SHAPE_DATA
 
 export const DEFAULT_IMAGE_BACKGROUND_ENTRY =
   BACKGROUND_LIBRARY[0]?.items[0] ?? null

--- a/lib/editor/shapes-data.json
+++ b/lib/editor/shapes-data.json
@@ -1,0 +1,956 @@
+[
+  {
+    "id": "free-1-cone1-transparent",
+    "name": "Free 1",
+    "full": "https://assets.tokokino.com/Shapes/free-1-cone1-transparent.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-1-cone1-transparent.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 158332
+  },
+  {
+    "id": "free-2-cube6-transparent",
+    "name": "Free 2",
+    "full": "https://assets.tokokino.com/Shapes/free-2-cube6-transparent.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-2-cube6-transparent.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 296068
+  },
+  {
+    "id": "free-3-holo-38",
+    "name": "Free 3",
+    "full": "https://assets.tokokino.com/Shapes/free-3-holo-38.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-3-holo-38.webp",
+    "width": 864,
+    "height": 1080,
+    "bytes": 55026
+  },
+  {
+    "id": "free-4-holo-7",
+    "name": "Free 4",
+    "full": "https://assets.tokokino.com/Shapes/free-4-holo-7.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-4-holo-7.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 114308
+  },
+  {
+    "id": "free-5-1-8",
+    "name": "Free 5",
+    "full": "https://assets.tokokino.com/Shapes/free-5-1-8.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-5-1-8.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 51478
+  },
+  {
+    "id": "free-6-3-11",
+    "name": "Free 6",
+    "full": "https://assets.tokokino.com/Shapes/free-6-3-11.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-6-3-11.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 398696
+  },
+  {
+    "id": "free-7-chrome8",
+    "name": "Free 7",
+    "full": "https://assets.tokokino.com/Shapes/free-7-chrome8.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-7-chrome8.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 55754
+  },
+  {
+    "id": "free-8-chrome51",
+    "name": "Free 8",
+    "full": "https://assets.tokokino.com/Shapes/free-8-chrome51.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-8-chrome51.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 68736
+  },
+  {
+    "id": "free-9-white-view-2",
+    "name": "Free 9",
+    "full": "https://assets.tokokino.com/Shapes/free-9-white-view-2.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-9-white-view-2.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 63296
+  },
+  {
+    "id": "free-10-white-view-35",
+    "name": "Free 10",
+    "full": "https://assets.tokokino.com/Shapes/free-10-white-view-35.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-10-white-view-35.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 42640
+  },
+  {
+    "id": "free-11-cyan-pink-view-3",
+    "name": "Free 11",
+    "full": "https://assets.tokokino.com/Shapes/free-11-cyan-pink-view-3.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-11-cyan-pink-view-3.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 189106
+  },
+  {
+    "id": "free-12-orange-pink-view-12-4",
+    "name": "Free 12",
+    "full": "https://assets.tokokino.com/Shapes/free-12-orange-pink-view-12-4.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-12-orange-pink-view-12-4.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 77712
+  },
+  {
+    "id": "free-13-black-118",
+    "name": "Free 13",
+    "full": "https://assets.tokokino.com/Shapes/free-13-black-118.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-13-black-118.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 43318
+  },
+  {
+    "id": "free-14-black-4",
+    "name": "Free 14",
+    "full": "https://assets.tokokino.com/Shapes/free-14-black-4.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-14-black-4.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 47078
+  },
+  {
+    "id": "free-15-4-35",
+    "name": "Free 15",
+    "full": "https://assets.tokokino.com/Shapes/free-15-4-35.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-15-4-35.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 53882
+  },
+  {
+    "id": "free-16-4-46",
+    "name": "Free 16",
+    "full": "https://assets.tokokino.com/Shapes/free-16-4-46.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-16-4-46.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 51634
+  },
+  {
+    "id": "free-17-37",
+    "name": "Free 17",
+    "full": "https://assets.tokokino.com/Shapes/free-17-37.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-17-37.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 266180
+  },
+  {
+    "id": "free-18-65-1",
+    "name": "Free 18",
+    "full": "https://assets.tokokino.com/Shapes/free-18-65-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-18-65-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 145170
+  },
+  {
+    "id": "free-19-49",
+    "name": "Free 19",
+    "full": "https://assets.tokokino.com/Shapes/free-19-49.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-19-49.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 302620
+  },
+  {
+    "id": "free-20-67-1",
+    "name": "Free 20",
+    "full": "https://assets.tokokino.com/Shapes/free-20-67-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-20-67-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 121658
+  },
+  {
+    "id": "free-21-3-46-1",
+    "name": "Free 21",
+    "full": "https://assets.tokokino.com/Shapes/free-21-3-46-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-21-3-46-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 38924
+  },
+  {
+    "id": "free-22-2-10-1",
+    "name": "Free 22",
+    "full": "https://assets.tokokino.com/Shapes/free-22-2-10-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-22-2-10-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 56766
+  },
+  {
+    "id": "free-23-c16-3",
+    "name": "Free 23",
+    "full": "https://assets.tokokino.com/Shapes/free-23-c16-3.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-23-c16-3.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 146462
+  },
+  {
+    "id": "free-24-l20-1",
+    "name": "Free 24",
+    "full": "https://assets.tokokino.com/Shapes/free-24-l20-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-24-l20-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 97282
+  },
+  {
+    "id": "free-25-l23-1",
+    "name": "Free 25",
+    "full": "https://assets.tokokino.com/Shapes/free-25-l23-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-25-l23-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 114452
+  },
+  {
+    "id": "free-26-l13-1",
+    "name": "Free 26",
+    "full": "https://assets.tokokino.com/Shapes/free-26-l13-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-26-l13-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 69578
+  },
+  {
+    "id": "free-27-s30-1",
+    "name": "Free 27",
+    "full": "https://assets.tokokino.com/Shapes/free-27-s30-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-27-s30-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 55860
+  },
+  {
+    "id": "free-28-s56-1",
+    "name": "Free 28",
+    "full": "https://assets.tokokino.com/Shapes/free-28-s56-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-28-s56-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 55184
+  },
+  {
+    "id": "free-29-p59-1",
+    "name": "Free 29",
+    "full": "https://assets.tokokino.com/Shapes/free-29-p59-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-29-p59-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 115864
+  },
+  {
+    "id": "free-30-p90-1",
+    "name": "Free 30",
+    "full": "https://assets.tokokino.com/Shapes/free-30-p90-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-30-p90-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 99168
+  },
+  {
+    "id": "free-31-g55-1",
+    "name": "Free 31",
+    "full": "https://assets.tokokino.com/Shapes/free-31-g55-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-31-g55-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 62114
+  },
+  {
+    "id": "free-32-g91-1",
+    "name": "Free 32",
+    "full": "https://assets.tokokino.com/Shapes/free-32-g91-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-32-g91-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 124748
+  },
+  {
+    "id": "free-33-h36-1",
+    "name": "Free 33",
+    "full": "https://assets.tokokino.com/Shapes/free-33-h36-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-33-h36-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 135450
+  },
+  {
+    "id": "free-34-h1-1",
+    "name": "Free 34",
+    "full": "https://assets.tokokino.com/Shapes/free-34-h1-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-34-h1-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 73522
+  },
+  {
+    "id": "free-35-hh27-1",
+    "name": "Free 35",
+    "full": "https://assets.tokokino.com/Shapes/free-35-hh27-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-35-hh27-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 119890
+  },
+  {
+    "id": "free-36-hh12-1",
+    "name": "Free 36",
+    "full": "https://assets.tokokino.com/Shapes/free-36-hh12-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-36-hh12-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 170000
+  },
+  {
+    "id": "free-37-rectangle-34",
+    "name": "Free 37",
+    "full": "https://assets.tokokino.com/Shapes/free-37-rectangle-34.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-37-rectangle-34.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 404434
+  },
+  {
+    "id": "free-38-rectangle-46",
+    "name": "Free 38",
+    "full": "https://assets.tokokino.com/Shapes/free-38-rectangle-46.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-38-rectangle-46.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 693242
+  },
+  {
+    "id": "free-39-rectangle-34",
+    "name": "Free 39",
+    "full": "https://assets.tokokino.com/Shapes/free-39-rectangle-34.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-39-rectangle-34.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 75452
+  },
+  {
+    "id": "free-40-rectangle-48",
+    "name": "Free 40",
+    "full": "https://assets.tokokino.com/Shapes/free-40-rectangle-48.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-40-rectangle-48.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 111734
+  },
+  {
+    "id": "free-41-rectangle-34",
+    "name": "Free 41",
+    "full": "https://assets.tokokino.com/Shapes/free-41-rectangle-34.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-41-rectangle-34.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 102570
+  },
+  {
+    "id": "free-42-rectangle-48",
+    "name": "Free 42",
+    "full": "https://assets.tokokino.com/Shapes/free-42-rectangle-48.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-42-rectangle-48.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 177314
+  },
+  {
+    "id": "free-43-rectangle-34",
+    "name": "Free 43",
+    "full": "https://assets.tokokino.com/Shapes/free-43-rectangle-34.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-43-rectangle-34.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 173096
+  },
+  {
+    "id": "free-44-rectangle-48",
+    "name": "Free 44",
+    "full": "https://assets.tokokino.com/Shapes/free-44-rectangle-48.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-44-rectangle-48.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 53276
+  },
+  {
+    "id": "free-45-a2-1",
+    "name": "Free 45",
+    "full": "https://assets.tokokino.com/Shapes/free-45-a2-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-45-a2-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 89964
+  },
+  {
+    "id": "free-46-a98-1",
+    "name": "Free 46",
+    "full": "https://assets.tokokino.com/Shapes/free-46-a98-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-46-a98-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 152854
+  },
+  {
+    "id": "free-47-48",
+    "name": "Free 47",
+    "full": "https://assets.tokokino.com/Shapes/free-47-48.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-47-48.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 329052
+  },
+  {
+    "id": "free-48-47",
+    "name": "Free 48",
+    "full": "https://assets.tokokino.com/Shapes/free-48-47.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-48-47.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 410828
+  },
+  {
+    "id": "free-49-r10",
+    "name": "Free 49",
+    "full": "https://assets.tokokino.com/Shapes/free-49-r10.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-49-r10.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 106364
+  },
+  {
+    "id": "free-50-r55",
+    "name": "Free 50",
+    "full": "https://assets.tokokino.com/Shapes/free-50-r55.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-50-r55.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 71012
+  },
+  {
+    "id": "free-51-r8",
+    "name": "Free 51",
+    "full": "https://assets.tokokino.com/Shapes/free-51-r8.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-51-r8.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 122192
+  },
+  {
+    "id": "free-52-r22",
+    "name": "Free 52",
+    "full": "https://assets.tokokino.com/Shapes/free-52-r22.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-52-r22.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 112984
+  },
+  {
+    "id": "free-53-a51",
+    "name": "Free 53",
+    "full": "https://assets.tokokino.com/Shapes/free-53-a51.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-53-a51.webp",
+    "width": 1000,
+    "height": 1000,
+    "bytes": 167376
+  },
+  {
+    "id": "free-54-a77",
+    "name": "Free 54",
+    "full": "https://assets.tokokino.com/Shapes/free-54-a77.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-54-a77.webp",
+    "width": 1000,
+    "height": 1000,
+    "bytes": 47346
+  },
+  {
+    "id": "free-55-g8-1",
+    "name": "Free 55",
+    "full": "https://assets.tokokino.com/Shapes/free-55-g8-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-55-g8-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 60928
+  },
+  {
+    "id": "free-56-g70-1",
+    "name": "Free 56",
+    "full": "https://assets.tokokino.com/Shapes/free-56-g70-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/free-56-g70-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 182632
+  },
+  {
+    "id": "holo-1",
+    "name": "Holo 1",
+    "full": "https://assets.tokokino.com/Shapes/holo-1.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-1.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 69538
+  },
+  {
+    "id": "holo-2",
+    "name": "Holo 2",
+    "full": "https://assets.tokokino.com/Shapes/holo-2.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-2.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 86216
+  },
+  {
+    "id": "holo-3",
+    "name": "Holo 3",
+    "full": "https://assets.tokokino.com/Shapes/holo-3.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-3.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 76968
+  },
+  {
+    "id": "holo-4",
+    "name": "Holo 4",
+    "full": "https://assets.tokokino.com/Shapes/holo-4.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-4.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 77700
+  },
+  {
+    "id": "holo-5",
+    "name": "Holo 5",
+    "full": "https://assets.tokokino.com/Shapes/holo-5.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-5.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 101722
+  },
+  {
+    "id": "holo-6",
+    "name": "Holo 6",
+    "full": "https://assets.tokokino.com/Shapes/holo-6.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-6.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 74106
+  },
+  {
+    "id": "holo-7",
+    "name": "Holo 7",
+    "full": "https://assets.tokokino.com/Shapes/holo-7.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-7.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 82838
+  },
+  {
+    "id": "holo-8",
+    "name": "Holo 8",
+    "full": "https://assets.tokokino.com/Shapes/holo-8.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-8.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 68686
+  },
+  {
+    "id": "holo-9",
+    "name": "Holo 9",
+    "full": "https://assets.tokokino.com/Shapes/holo-9.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-9.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 58364
+  },
+  {
+    "id": "holo-10",
+    "name": "Holo 10",
+    "full": "https://assets.tokokino.com/Shapes/holo-10.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-10.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 73914
+  },
+  {
+    "id": "holo-11",
+    "name": "Holo 11",
+    "full": "https://assets.tokokino.com/Shapes/holo-11.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-11.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 68654
+  },
+  {
+    "id": "holo-12",
+    "name": "Holo 12",
+    "full": "https://assets.tokokino.com/Shapes/holo-12.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-12.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 96142
+  },
+  {
+    "id": "holo-13",
+    "name": "Holo 13",
+    "full": "https://assets.tokokino.com/Shapes/holo-13.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-13.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 55954
+  },
+  {
+    "id": "holo-14",
+    "name": "Holo 14",
+    "full": "https://assets.tokokino.com/Shapes/holo-14.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-14.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 69090
+  },
+  {
+    "id": "holo-15",
+    "name": "Holo 15",
+    "full": "https://assets.tokokino.com/Shapes/holo-15.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-15.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 114016
+  },
+  {
+    "id": "holo-16",
+    "name": "Holo 16",
+    "full": "https://assets.tokokino.com/Shapes/holo-16.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-16.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 91996
+  },
+  {
+    "id": "holo-17",
+    "name": "Holo 17",
+    "full": "https://assets.tokokino.com/Shapes/holo-17.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-17.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 89792
+  },
+  {
+    "id": "holo-18",
+    "name": "Holo 18",
+    "full": "https://assets.tokokino.com/Shapes/holo-18.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-18.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 84840
+  },
+  {
+    "id": "holo-19",
+    "name": "Holo 19",
+    "full": "https://assets.tokokino.com/Shapes/holo-19.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-19.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 85658
+  },
+  {
+    "id": "holo-20",
+    "name": "Holo 20",
+    "full": "https://assets.tokokino.com/Shapes/holo-20.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-20.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 80096
+  },
+  {
+    "id": "holo-21",
+    "name": "Holo 21",
+    "full": "https://assets.tokokino.com/Shapes/holo-21.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-21.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 95172
+  },
+  {
+    "id": "holo-22",
+    "name": "Holo 22",
+    "full": "https://assets.tokokino.com/Shapes/holo-22.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-22.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 47516
+  },
+  {
+    "id": "holo-23",
+    "name": "Holo 23",
+    "full": "https://assets.tokokino.com/Shapes/holo-23.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-23.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 56760
+  },
+  {
+    "id": "holo-24",
+    "name": "Holo 24",
+    "full": "https://assets.tokokino.com/Shapes/holo-24.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-24.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 48908
+  },
+  {
+    "id": "holo-25",
+    "name": "Holo 25",
+    "full": "https://assets.tokokino.com/Shapes/holo-25.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-25.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 52098
+  },
+  {
+    "id": "holo-26",
+    "name": "Holo 26",
+    "full": "https://assets.tokokino.com/Shapes/holo-26.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-26.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 85422
+  },
+  {
+    "id": "holo-27",
+    "name": "Holo 27",
+    "full": "https://assets.tokokino.com/Shapes/holo-27.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-27.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 62402
+  },
+  {
+    "id": "holo-28",
+    "name": "Holo 28",
+    "full": "https://assets.tokokino.com/Shapes/holo-28.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-28.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 67686
+  },
+  {
+    "id": "holo-29",
+    "name": "Holo 29",
+    "full": "https://assets.tokokino.com/Shapes/holo-29.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-29.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 59608
+  },
+  {
+    "id": "holo-30",
+    "name": "Holo 30",
+    "full": "https://assets.tokokino.com/Shapes/holo-30.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-30.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 130756
+  },
+  {
+    "id": "holo-31",
+    "name": "Holo 31",
+    "full": "https://assets.tokokino.com/Shapes/holo-31.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-31.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 97698
+  },
+  {
+    "id": "holo-32",
+    "name": "Holo 32",
+    "full": "https://assets.tokokino.com/Shapes/holo-32.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-32.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 131584
+  },
+  {
+    "id": "holo-33",
+    "name": "Holo 33",
+    "full": "https://assets.tokokino.com/Shapes/holo-33.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-33.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 62882
+  },
+  {
+    "id": "holo-34",
+    "name": "Holo 34",
+    "full": "https://assets.tokokino.com/Shapes/holo-34.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-34.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 51240
+  },
+  {
+    "id": "holo-35",
+    "name": "Holo 35",
+    "full": "https://assets.tokokino.com/Shapes/holo-35.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-35.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 55654
+  },
+  {
+    "id": "holo-36",
+    "name": "Holo 36",
+    "full": "https://assets.tokokino.com/Shapes/holo-36.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-36.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 114622
+  },
+  {
+    "id": "holo-37",
+    "name": "Holo 37",
+    "full": "https://assets.tokokino.com/Shapes/holo-37.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-37.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 74188
+  },
+  {
+    "id": "holo-38",
+    "name": "Holo 38",
+    "full": "https://assets.tokokino.com/Shapes/holo-38.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-38.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 74554
+  },
+  {
+    "id": "holo-39",
+    "name": "Holo 39",
+    "full": "https://assets.tokokino.com/Shapes/holo-39.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-39.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 39132
+  },
+  {
+    "id": "holo-40",
+    "name": "Holo 40",
+    "full": "https://assets.tokokino.com/Shapes/holo-40.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-40.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 64814
+  },
+  {
+    "id": "holo-41",
+    "name": "Holo 41",
+    "full": "https://assets.tokokino.com/Shapes/holo-41.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-41.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 48718
+  },
+  {
+    "id": "holo-42",
+    "name": "Holo 42",
+    "full": "https://assets.tokokino.com/Shapes/holo-42.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-42.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 76870
+  },
+  {
+    "id": "holo-43",
+    "name": "Holo 43",
+    "full": "https://assets.tokokino.com/Shapes/holo-43.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-43.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 65040
+  },
+  {
+    "id": "holo-44",
+    "name": "Holo 44",
+    "full": "https://assets.tokokino.com/Shapes/holo-44.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-44.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 86010
+  },
+  {
+    "id": "holo-45",
+    "name": "Holo 45",
+    "full": "https://assets.tokokino.com/Shapes/holo-45.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-45.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 63922
+  },
+  {
+    "id": "holo-46",
+    "name": "Holo 46",
+    "full": "https://assets.tokokino.com/Shapes/holo-46.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-46.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 73842
+  },
+  {
+    "id": "holo-47",
+    "name": "Holo 47",
+    "full": "https://assets.tokokino.com/Shapes/holo-47.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-47.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 54190
+  },
+  {
+    "id": "holo-48",
+    "name": "Holo 48",
+    "full": "https://assets.tokokino.com/Shapes/holo-48.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-48.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 70242
+  },
+  {
+    "id": "holo-49",
+    "name": "Holo 49",
+    "full": "https://assets.tokokino.com/Shapes/holo-49.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-49.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 55122
+  },
+  {
+    "id": "holo-50",
+    "name": "Holo 50",
+    "full": "https://assets.tokokino.com/Shapes/holo-50.webp",
+    "thumb": "https://assets.tokokino.com/Shapes/thumbs/holo-50.webp",
+    "width": 1080,
+    "height": 1080,
+    "bytes": 51388
+  }
+]

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -338,6 +338,15 @@ export type BackgroundCategory = {
   items: BackgroundEntry[]
 }
 
+export type ShapeEntry = {
+  id: string
+  name: string
+  full: string
+  thumb: string
+  width: number
+  height: number
+}
+
 export type GradientCategory = {
   key: string
   label: string

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "typecheck": "tsc --noEmit",
     "prepare": "husky",
     "build:thumbs": "node scripts/build-overlay-thumbs.mjs",
-    "build:backgrounds": "node scripts/build-background-thumbs.mjs"
+    "build:backgrounds": "node scripts/build-background-thumbs.mjs",
+    "build:shapes": "node --env-file-if-exists=.env.local scripts/build-shapes.mjs"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/scripts/build-shapes.mjs
+++ b/scripts/build-shapes.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+/**
+ * Upload 3D shape PNGs and WebP thumbnails to R2, then write a manifest the
+ * editor consumes.
+ *
+ *   - Reads source images from `shapes/*` (every pack folder, flattened).
+ *   - Uploads full-size shapes to `Shapes/{slug}.webp` (alpha preserved).
+ *   - Uploads 256px WebP thumbnails to `Shapes/thumbs/{slug}.webp`.
+ *   - Writes `lib/editor/shapes-data.json` with the manifest used by the UI.
+ *
+ * Usage:
+ *   pnpm build:shapes                  # process all packs
+ *   DRY=1 pnpm build:shapes            # no upload; writes shapes/.build for auditing
+ *   FORCE=1 pnpm build:shapes          # re-upload even if object exists
+ *   TRIM=1 pnpm build:shapes           # crop away transparent margins first
+ *   MAX_W=1920 MAX_H=1920 pnpm build:shapes
+ *   FORMAT=png pnpm build:shapes       # full-size as PNG instead of WebP
+ */
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { dirname, resolve, extname, join } from "node:path"
+
+import sharp from "sharp"
+import { S3Client, PutObjectCommand, HeadObjectCommand } from "@aws-sdk/client-s3"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const projectRoot = resolve(__dirname, "..")
+const manifestPath = resolve(projectRoot, "lib/editor/shapes-data.json")
+const backgroundsManifestPath = resolve(projectRoot, "lib/editor/backgrounds-data.json")
+
+const SHAPES_DIR = resolve(projectRoot, "shapes")
+const KEY_PREFIX = process.env.KEY_PREFIX ?? "Shapes"
+
+const MAX_W = Number(process.env.MAX_W ?? 1920)
+const MAX_H = Number(process.env.MAX_H ?? 1080)
+const FULL_FORMAT = (process.env.FORMAT ?? "webp").toLowerCase()
+const FULL_QUALITY = Number(process.env.QUALITY ?? 90)
+const THUMB_SIZE = Number(process.env.THUMB_SIZE ?? 256)
+const THUMB_QUALITY = Number(process.env.THUMB_QUALITY ?? 75)
+const CONCURRENCY = Number(process.env.CONCURRENCY ?? 4)
+const FORCE = process.env.FORCE === "1" || process.env.FORCE === "true"
+const DRY = process.env.DRY === "1" || process.env.DRY === "true"
+const TRIM = process.env.TRIM === "1" || process.env.TRIM === "true"
+
+if (FULL_FORMAT !== "webp" && FULL_FORMAT !== "png") {
+  console.error(`FORMAT must be webp or png, got: ${FULL_FORMAT}`)
+  process.exit(1)
+}
+
+// Each pack folder collapses into one flat namespace; the prefix keeps ids unique.
+const PACKS = [
+  { dir: "abstract-3d-holographic", prefix: "holo" },
+  { dir: "assetpro-free-3d", prefix: "" },
+]
+
+const SUPPORTED = new Set([".png", ".webp", ".jpg", ".jpeg", ".avif"])
+
+function resolvePublicBase() {
+  if (process.env.NEXT_PUBLIC_R2_PUBLIC_BASE) {
+    return process.env.NEXT_PUBLIC_R2_PUBLIC_BASE.replace(/\/$/, "")
+  }
+  for (const path of [manifestPath, backgroundsManifestPath]) {
+    if (!existsSync(path)) continue
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf8"))
+      const first = parsed?.[0]?.full ?? parsed?.[0]?.items?.[0]?.full
+      if (first) return new URL(first).origin
+    } catch {}
+  }
+  return "https://assets.tokokino.com"
+}
+
+function resolveEndpoint() {
+  if (process.env.R2_S3_ENDPOINT) return process.env.R2_S3_ENDPOINT
+  if (process.env.R2_ACCOUNT_ID) {
+    return `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`
+  }
+  return null
+}
+
+const PUBLIC_BASE = resolvePublicBase()
+const ENDPOINT = resolveEndpoint()
+
+let client = null
+if (!DRY) {
+  const missing = ["R2_BUCKET", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY"].filter(
+    (k) => !process.env[k]
+  )
+  if (!ENDPOINT) missing.push("R2_S3_ENDPOINT (or R2_ACCOUNT_ID)")
+  if (missing.length) {
+    console.error(`missing env: ${missing.join(", ")}`)
+    console.error("run with DRY=1 to build locally without uploading")
+    process.exit(1)
+  }
+  client = new S3Client({
+    region: "auto",
+    endpoint: ENDPOINT,
+    credentials: {
+      accessKeyId: process.env.R2_ACCESS_KEY_ID,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+    },
+  })
+}
+
+function slugify(name) {
+  return name
+    .toLowerCase()
+    .replace(/\.[^.]+$/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+// Source layer names are mostly junk ("r22", "g70 1", "4 35"), so the label is
+// just the pack plus its number — shapes get picked from the thumbnail anyway.
+function prettyName(slug) {
+  const numbered = slug.match(/^(holo|free)-(\d+)/)
+  if (numbered) {
+    const [, pack, n] = numbered
+    return `${pack === "holo" ? "Holo" : "Free"} ${n}`
+  }
+  return slug
+    .replace(/[-_]+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (m) => m.toUpperCase())
+}
+
+async function objectExists(key) {
+  try {
+    await client.send(new HeadObjectCommand({ Bucket: process.env.R2_BUCKET, Key: key }))
+    return true
+  } catch (err) {
+    if (err?.$metadata?.httpStatusCode === 404) return false
+    if (err?.name === "NotFound") return false
+    throw err
+  }
+}
+
+async function uploadIfMissing(key, body, contentType) {
+  if (!FORCE && (await objectExists(key))) return { skipped: true }
+  await client.send(
+    new PutObjectCommand({
+      Bucket: process.env.R2_BUCKET,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+      CacheControl: "public, max-age=31536000, immutable",
+    })
+  )
+  return { skipped: false }
+}
+
+function writeLocal(key, body) {
+  const out = resolve(SHAPES_DIR, ".build", key)
+  mkdirSync(dirname(out), { recursive: true })
+  writeFileSync(out, body)
+}
+
+async function processFile({ pack, file }) {
+  const srcPath = join(SHAPES_DIR, pack.dir, file)
+  const slug = slugify(pack.prefix ? `${pack.prefix}-${file}` : file)
+
+  const fullExt = FULL_FORMAT === "png" ? "png" : "webp"
+  const fullKey = `${KEY_PREFIX}/${slug}.${fullExt}`
+  const thumbKey = `${KEY_PREFIX}/thumbs/${slug}.webp`
+
+  let pipeline = sharp(readFileSync(srcPath), { failOn: "none" })
+  // Source packs frame each shape in a large transparent canvas; trimming makes
+  // the asset tight to the artwork so the editor can scale it predictably.
+  if (TRIM) pipeline = pipeline.trim()
+  const base = await pipeline
+    .resize(MAX_W, MAX_H, { fit: "inside", withoutEnlargement: true })
+    .toBuffer()
+
+  const fullBuffer =
+    FULL_FORMAT === "png"
+      ? await sharp(base).png({ compressionLevel: 9, palette: true }).toBuffer()
+      : await sharp(base).webp({ quality: FULL_QUALITY, effort: 5, alphaQuality: 100 }).toBuffer()
+
+  const thumbBuffer = await sharp(base)
+    .resize(THUMB_SIZE, THUMB_SIZE, { fit: "inside", withoutEnlargement: true })
+    .webp({ quality: THUMB_QUALITY, effort: 5, alphaQuality: 100 })
+    .toBuffer()
+
+  const meta = await sharp(fullBuffer).metadata()
+
+  let tag = "✓"
+  if (DRY) {
+    writeLocal(fullKey, fullBuffer)
+    writeLocal(thumbKey, thumbBuffer)
+    tag = "·"
+  } else {
+    const [fullRes, thumbRes] = await Promise.all([
+      uploadIfMissing(fullKey, fullBuffer, FULL_FORMAT === "png" ? "image/png" : "image/webp"),
+      uploadIfMissing(thumbKey, thumbBuffer, "image/webp"),
+    ])
+    if (fullRes.skipped && thumbRes.skipped) tag = "·"
+  }
+
+  console.log(
+    `${tag} ${slug}  ${meta.width}x${meta.height}  ` +
+      `full ${(fullBuffer.length / 1024).toFixed(0)}KB  ` +
+      `thumb ${(thumbBuffer.length / 1024).toFixed(0)}KB`
+  )
+
+  return {
+    id: slug,
+    name: prettyName(slug),
+    full: `${PUBLIC_BASE}/${fullKey}`,
+    thumb: `${PUBLIC_BASE}/${thumbKey}`,
+    width: meta.width,
+    height: meta.height,
+    bytes: fullBuffer.length,
+  }
+}
+
+async function runWithConcurrency(items, n, fn) {
+  const out = new Array(items.length)
+  let cursor = 0
+  let failures = 0
+  await Promise.all(
+    Array.from({ length: n }, async () => {
+      while (cursor < items.length) {
+        const i = cursor++
+        try {
+          out[i] = await fn(items[i])
+        } catch (err) {
+          failures++
+          console.error(`✗ ${items[i].file}: ${err.message}`)
+        }
+      }
+    })
+  )
+  return { results: out.filter(Boolean), failures }
+}
+
+const tasks = []
+for (const pack of PACKS) {
+  const dir = join(SHAPES_DIR, pack.dir)
+  let files
+  try {
+    files = readdirSync(dir)
+      .filter((f) => SUPPORTED.has(extname(f).toLowerCase()))
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+  } catch (err) {
+    console.error(`cannot read ${dir}: ${err.message}`)
+    continue
+  }
+  if (!files.length) {
+    console.warn(`no images in ${dir}`)
+    continue
+  }
+  for (const file of files) tasks.push({ pack, file })
+}
+
+if (!tasks.length) {
+  console.error(`no shapes found under ${SHAPES_DIR}`)
+  process.exit(1)
+}
+
+console.log(
+  `${tasks.length} shapes → ${DRY ? "shapes/.build" : `${PUBLIC_BASE}/${KEY_PREFIX}`}  ` +
+    `(max ${MAX_W}x${MAX_H}, ${FULL_FORMAT}${TRIM ? ", trimmed" : ""})\n`
+)
+
+const { results, failures } = await runWithConcurrency(tasks, CONCURRENCY, processFile)
+
+const duplicates = results.length - new Set(results.map((r) => r.id)).size
+if (duplicates) {
+  console.error(`\n${duplicates} duplicate ids — manifest would drop shapes, aborting`)
+  process.exit(1)
+}
+
+results.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }))
+mkdirSync(dirname(manifestPath), { recursive: true })
+writeFileSync(manifestPath, JSON.stringify(results, null, 2) + "\n")
+
+const totalMb = results.reduce((sum, r) => sum + r.bytes, 0) / 1e6
+console.log(`\nwrote manifest → ${manifestPath}`)
+console.log(`${results.length} shapes, ${totalMb.toFixed(1)}MB total`)
+
+if (failures) {
+  console.log(`done with ${failures} failures`)
+  process.exit(1)
+}
+console.log("done")


### PR DESCRIPTION
Adds a **Shapes** section to the inspector (after Backdrop) with 106 3D shapes, plus the asset pipeline that puts them on R2.

## What it does

Clicking a shape drops it on the canvas as a normal asset. It runs the exact same path as the toolbar's image-upload button — `addAsset(url)` → select → switch to pointer — so a placed shape is an ordinary `AssetElement` and inherits move, resize, rotate, filters, blend modes, opacity, flip, and layer ordering for free. No new element type, no new renderer, no export changes.

## The assets

106 shapes from two Figma community packs, uploaded to `Shapes/` and `Shapes/thumbs/` on R2:

| Pack | Count | Prefix |
|---|---|---|
| Abstract 3D (holographic) | 50 | `holo-*` |
| FREE 3D by assetpro.design | 56 | `free-*` |

Both packs frame every shape inside a **solid black parent frame**, so the originals are pulled by image fill rather than rendered — rendering composites that black backdrop into the result. The manifest committed here is `lib/editor/shapes-data.json`; the 620 MB of source PNGs stay out of git (`shapes/` is ignored).

## `pnpm build:shapes`

New script modelled on `build-background-thumbs.mjs` — same env vars, `uploadIfMissing`, concurrency, `FORCE`. It resizes, generates 256px WebP thumbs, uploads both, and rewrites the manifest.

```bash
pnpm build:shapes           # process + upload
DRY=1 pnpm build:shapes     # build into shapes/.build, no upload
TRIM=1 pnpm build:shapes    # crop transparent margins tight to the artwork
MAX_W=1920 MAX_H=1920 pnpm build:shapes
FORMAT=png pnpm build:shapes
```

Full-size output is capped at 1920x1080 with `fit: inside`, so the square shapes land at **1080x1080** — not stretched or padded to 16:9, which would distort them or pad dead transparent space. WebP with alpha takes the two packs from **620 MB to 11.5 MB**.

It also accepts `R2_ACCOUNT_ID` as a fallback for `R2_S3_ENDPOINT`, since `.env.local` carries the former.

## Notes for review

- **Thumbnails lazy-load** via an `IntersectionObserver` rooted on the section's own scroll container, so opening the section doesn't fire 106 requests at once.
- **Export is already handled** — `rewriteExportAssets` proxies every `<img>` through `/api/export/image`, so the remote R2 URLs capture fine. Verified the same mechanism backgrounds already rely on.
- **Display names are `Holo 1–50` / `Free 1–56`.** Source layer names were mostly junk (`r22`, `g70 1`, `4 35`); ids keep the descriptive source name where one existed.
- **Mobile is not wired up.** `mobile-controls/categories.ts` has its own category list and would need a separate entry — out of scope here.

## Unrelated bug spotted

`scripts/build-background-thumbs.mjs` does not parse — `manifestPath` is declared twice (lines 32 and 313), so `pnpm build:backgrounds` dies with a `SyntaxError` before doing anything. Left alone here since it is unrelated, but it needs a one-line fix.

## Testing

- `pnpm typecheck`, `pnpm lint`, `oxfmt` clean (pre-commit hooks ran on both commits).
- Verified live against the running dev server: thumbnails load from `assets.tokokino.com/Shapes/thumbs/*.webp` and clicking one adds the asset.
- Spot-checked uploaded objects return `HTTP 200 image/webp`, alpha intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Shapes section to the editor inspector.
  * Browse available shapes in a scrollable thumbnail grid.
  * Add shapes to the canvas by selecting a thumbnail.
  * Added a library of 106 shape assets, including free and holographic options.

* **Improvements**
  * Shape thumbnails load efficiently as they become visible.
  * Added tooling to generate and process shape assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an inspector shape library backed by a generated R2 manifest and an image-processing/upload pipeline.
- Adds 106 shape entries, lazy thumbnail loading, and normal asset insertion.
- Adds the `build:shapes` command for resizing, thumbnail generation, R2 uploads, and manifest generation.
- Extends editor preset and state types with shape metadata.

<h3>Confidence Score: 4/5</h3>

The manifest-write behavior should be fixed before merging because advertised dry runs and failed processing runs can leave the editor with unpublished or missing shapes.

The pipeline skips uploads in dry mode and drops per-file failures from its results, yet unconditionally replaces the application’s statically imported manifest before reporting failure.

**Files Needing Attention:** scripts/build-shapes.mjs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/editor/inspector/shapes-section.tsx | Adds lazy-loaded shape thumbnails and routes selection through the existing asset insertion workflow. |
| scripts/build-shapes.mjs | Adds the shape processing and R2 upload pipeline, but overwrites the runtime manifest during dry or partially failed runs. |
| lib/editor/shapes-data.json | Adds the generated manifest for 106 remotely hosted full-size images and thumbnails. |
| lib/editor/presets.ts | Statically imports and exposes the shape manifest to the inspector. |
| lib/editor/state-types.ts | Adds the ShapeEntry metadata type used by the manifest and UI. |
| components/editor/inspector.tsx | Mounts the new Shapes section after Backdrop. |
| package.json | Exposes the new shape pipeline through the build:shapes script. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Fbuild-shapes.mjs%3A275%0A**Manifest%20overwritten%20by%20incomplete%20runs**%0A%0AWhen%20%60DRY%3D1%60%20skips%20uploads%20or%20any%20file%20fails%20processing%2C%20the%20script%20still%20replaces%20%60shapes-data.json%60%20with%20CDN%20URLs%20for%20unpublished%20assets%20or%20with%20failed%20entries%20omitted%2C%20causing%20broken%20images%20or%20missing%20shapes%20in%20the%20editor.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=shivabhattacharjee%2Ftokokino&pr=46&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/build-shapes.mjs:275
**Manifest overwritten by incomplete runs**

When `DRY=1` skips uploads or any file fails processing, the script still replaces `shapes-data.json` with CDN URLs for unpublished assets or with failed entries omitted, causing broken images or missing shapes in the editor.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(inspector): add Shapes section that..."](https://github.com/shivabhattacharjee/tokokino/commit/7cbceaeaf75e61d77794660b6f9c3a9880659893) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49470801)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->