### PR TITLE
feat(animate): custom cubic-bezier transition curves

### DIFF
--- a/components/editor/animate/bezier-curve-editor.tsx
+++ b/components/editor/animate/bezier-curve-editor.tsx
@@ -143,6 +143,39 @@ export function BezierCurveEditor({
     [beginDrag]
   )
 
+  /** Arrow-key nudge for keyboard users — same normalize + onChange path as drag. */
+  const nudgeHandle = React.useCallback(
+    (target: DragTarget, dx: number, dy: number) => {
+      const base = bezierRef.current
+      const next =
+        target === "p1"
+          ? normalizeBezier({
+              ...base,
+              x1: base.x1 + dx,
+              y1: base.y1 + dy,
+            })
+          : normalizeBezier({
+              ...base,
+              x2: base.x2 + dx,
+              y2: base.y2 + dy,
+            })
+      bezierRef.current = next
+      onChangeRef.current(next)
+    },
+    []
+  )
+
+  const onP1KeyDown = React.useCallback(
+    (e: React.KeyboardEvent<SVGElement>) =>
+      handleNudgeKey(e, "p1", nudgeHandle),
+    [nudgeHandle]
+  )
+  const onP2KeyDown = React.useCallback(
+    (e: React.KeyboardEvent<SVGElement>) =>
+      handleNudgeKey(e, "p2", nudgeHandle),
+    [nudgeHandle]
+  )
+
   const gridLines = [0.25, 0.5, 0.75]
 
   const isDefault =
@@ -270,14 +303,18 @@ export function BezierCurveEditor({
             cy={p1.y}
             r={HANDLE_R}
             onPointerDown={onP1Down}
+            onKeyDown={onP1KeyDown}
             label="First control point"
+            valueText={`${bezier.x1.toFixed(2)}, ${bezier.y1.toFixed(2)}`}
           />
           <Handle
             cx={p2.x}
             cy={p2.y}
             r={HANDLE_R}
             onPointerDown={onP2Down}
+            onKeyDown={onP2KeyDown}
             label="Second control point"
+            valueText={`${bezier.x2.toFixed(2)}, ${bezier.y2.toFixed(2)}`}
           />
         </svg>
       </div>
@@ -293,18 +330,54 @@ export function BezierCurveEditor({
   )
 }
 
+/** Unit-space step for arrow-key nudges on control points. */
+const KEY_NUDGE = 0.02
+
+function handleNudgeKey(
+  e: React.KeyboardEvent<SVGElement>,
+  target: DragTarget,
+  nudge: (target: DragTarget, dx: number, dy: number) => void
+) {
+  let dx = 0
+  let dy = 0
+  switch (e.key) {
+    case "ArrowLeft":
+      dx = -KEY_NUDGE
+      break
+    case "ArrowRight":
+      dx = KEY_NUDGE
+      break
+    // Unit y is up; SVG y is down — arrows follow the value, not the screen.
+    case "ArrowUp":
+      dy = KEY_NUDGE
+      break
+    case "ArrowDown":
+      dy = -KEY_NUDGE
+      break
+    default:
+      return
+  }
+  e.preventDefault()
+  e.stopPropagation()
+  nudge(target, dx, dy)
+}
+
 function Handle({
   cx,
   cy,
   r,
   onPointerDown,
+  onKeyDown,
   label,
+  valueText,
 }: {
   cx: number
   cy: number
   r: number
   onPointerDown: (e: React.PointerEvent<SVGElement>) => void
+  onKeyDown: (e: React.KeyboardEvent<SVGElement>) => void
   label: string
+  valueText: string
 }) {
   // Invisible hit area slightly larger than the drawn square for easier grab.
   const hit = r + 2.5
@@ -316,8 +389,14 @@ function Handle({
         width={hit * 2}
         height={hit * 2}
         fill="transparent"
-        className="cursor-grab active:cursor-grabbing"
+        className="cursor-grab outline-none focus-visible:stroke-primary active:cursor-grabbing"
+        strokeWidth={1.2}
+        tabIndex={0}
+        role="slider"
+        aria-label={label}
+        aria-valuetext={valueText}
         onPointerDown={onPointerDown}
+        onKeyDown={onKeyDown}
       />
       <rect
         x={cx - r}

--- a/components/editor/animate/bezier-curve-editor.tsx
+++ b/components/editor/animate/bezier-curve-editor.tsx
@@ -1,0 +1,334 @@
+"use client"
+
+import * as React from "react"
+import { RiArrowGoBackLine } from "@remixicon/react"
+
+import {
+  BEZIER_Y_MAX,
+  BEZIER_Y_MIN,
+  cubicBezierEase,
+  DEFAULT_CUSTOM_BEZIER,
+  easingSvgPathFromFn,
+  normalizeBezier,
+  unitToSvg,
+  type ClipEasingBezier,
+} from "@/lib/editor/clip-easing"
+import { cn } from "@/lib/utils"
+
+const VIEW = 100
+const PAD = 10
+/** Compact handles — viewBox units, not CSS px. */
+const HANDLE_R = 2.8
+const ENDPOINT_R = 2.4
+
+type BezierCurveEditorProps = {
+  value: ClipEasingBezier
+  onChange: (next: ClipEasingBezier) => void
+  className?: string
+}
+
+type DragTarget = "p1" | "p2"
+
+function clientToUnit(
+  el: SVGSVGElement,
+  clientX: number,
+  clientY: number
+): { x: number; y: number } {
+  const rect = el.getBoundingClientRect()
+  // Map pointer into viewBox coords (preserveAspectRatio = meet, centered)
+  const scale = Math.min(rect.width / VIEW, rect.height / VIEW)
+  const ox = rect.left + (rect.width - VIEW * scale) / 2
+  const oy = rect.top + (rect.height - VIEW * scale) / 2
+  const sx = (clientX - ox) / scale
+  const sy = (clientY - oy) / scale
+  const span = VIEW - PAD * 2
+  return {
+    x: (sx - PAD) / span,
+    y: 1 - (sy - PAD) / span,
+  }
+}
+
+function applyHandle(
+  target: DragTarget,
+  base: ClipEasingBezier,
+  el: SVGSVGElement,
+  clientX: number,
+  clientY: number
+): ClipEasingBezier {
+  const u = clientToUnit(el, clientX, clientY)
+  const x = Math.min(1, Math.max(0, u.x))
+  const y = Math.min(BEZIER_Y_MAX, Math.max(BEZIER_Y_MIN, u.y))
+  return target === "p1"
+    ? normalizeBezier({ ...base, x1: x, y1: y })
+    : normalizeBezier({ ...base, x2: x, y2: y })
+}
+
+/**
+ * Interactive cubic-bezier graph for the Transition popover: fixed endpoints,
+ * two small control handles, grid + arms. Fixed height so the popover doesn't
+ * grow into a full-width square when Custom is selected.
+ */
+export function BezierCurveEditor({
+  value,
+  onChange,
+  className,
+}: BezierCurveEditorProps) {
+  const bezier = normalizeBezier(value)
+  const svgRef = React.useRef<SVGSVGElement>(null)
+  const dragRef = React.useRef<{
+    target: DragTarget
+    base: ClipEasingBezier
+  } | null>(null)
+  const onChangeRef = React.useRef(onChange)
+  const bezierRef = React.useRef(bezier)
+
+  React.useLayoutEffect(() => {
+    onChangeRef.current = onChange
+    bezierRef.current = bezier
+  })
+
+  const path = React.useMemo(
+    () => easingSvgPathFromFn(cubicBezierEase(bezier), VIEW, PAD, 40),
+    [bezier]
+  )
+
+  const p0 = unitToSvg(0, 0, VIEW, PAD)
+  const p3 = unitToSvg(1, 1, VIEW, PAD)
+  const p1 = unitToSvg(bezier.x1, bezier.y1, VIEW, PAD)
+  const p2 = unitToSvg(bezier.x2, bezier.y2, VIEW, PAD)
+
+  React.useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      const drag = dragRef.current
+      const el = svgRef.current
+      if (!drag || !el) return
+      e.preventDefault()
+      const next = applyHandle(drag.target, drag.base, el, e.clientX, e.clientY)
+      drag.base = next
+      onChangeRef.current(next)
+    }
+    const onUp = () => {
+      dragRef.current = null
+    }
+    window.addEventListener("pointermove", onMove)
+    window.addEventListener("pointerup", onUp)
+    window.addEventListener("pointercancel", onUp)
+    return () => {
+      window.removeEventListener("pointermove", onMove)
+      window.removeEventListener("pointerup", onUp)
+      window.removeEventListener("pointercancel", onUp)
+    }
+  }, [])
+
+  const beginDrag = React.useCallback(
+    (target: DragTarget, e: React.PointerEvent<SVGElement>) => {
+      e.preventDefault()
+      e.stopPropagation()
+      const el = svgRef.current
+      if (!el) return
+      const base = bezierRef.current
+      const next = applyHandle(target, base, el, e.clientX, e.clientY)
+      dragRef.current = { target, base: next }
+      onChangeRef.current(next)
+    },
+    []
+  )
+
+  const onP1Down = React.useCallback(
+    (e: React.PointerEvent<SVGElement>) => beginDrag("p1", e),
+    [beginDrag]
+  )
+  const onP2Down = React.useCallback(
+    (e: React.PointerEvent<SVGElement>) => beginDrag("p2", e),
+    [beginDrag]
+  )
+
+  const gridLines = [0.25, 0.5, 0.75]
+
+  const isDefault =
+    Math.abs(bezier.x1 - DEFAULT_CUSTOM_BEZIER.x1) < 1e-6 &&
+    Math.abs(bezier.y1 - DEFAULT_CUSTOM_BEZIER.y1) < 1e-6 &&
+    Math.abs(bezier.x2 - DEFAULT_CUSTOM_BEZIER.x2) < 1e-6 &&
+    Math.abs(bezier.y2 - DEFAULT_CUSTOM_BEZIER.y2) < 1e-6
+
+  const resetCurve = () => {
+    if (isDefault) return
+    onChange({ ...DEFAULT_CUSTOM_BEZIER })
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-1", className)}>
+      <div className="relative overflow-hidden rounded-md border border-border/60 bg-muted/25">
+        {/* Reset sits over the plot so it stays visible without growing the panel */}
+        <button
+          type="button"
+          title="Reset curve"
+          aria-label="Reset curve to default"
+          disabled={isDefault}
+          onClick={resetCurve}
+          className={cn(
+            "absolute top-1 right-1 z-10 flex size-6 items-center justify-center rounded-md bg-background/80 text-muted-foreground shadow-sm ring-1 ring-border/50 backdrop-blur-sm transition-colors",
+            isDefault
+              ? "pointer-events-none opacity-40"
+              : "hover:bg-background hover:text-foreground"
+          )}
+        >
+          <RiArrowGoBackLine className="size-3" />
+        </button>
+        <svg
+          ref={svgRef}
+          viewBox={`0 0 ${VIEW} ${VIEW}`}
+          className="h-[132px] w-full touch-none select-none"
+          role="img"
+          aria-label="Custom easing curve"
+        >
+          <rect
+            x={PAD}
+            y={PAD}
+            width={VIEW - PAD * 2}
+            height={VIEW - PAD * 2}
+            fill="none"
+            className="stroke-border/40"
+            strokeWidth={0.5}
+          />
+          {gridLines.map((g) => {
+            const a = unitToSvg(g, 0, VIEW, PAD)
+            const b = unitToSvg(g, 1, VIEW, PAD)
+            const c = unitToSvg(0, g, VIEW, PAD)
+            const d = unitToSvg(1, g, VIEW, PAD)
+            return (
+              <g key={g}>
+                <line
+                  x1={a.x}
+                  y1={a.y}
+                  x2={b.x}
+                  y2={b.y}
+                  className="stroke-border/25"
+                  strokeWidth={0.4}
+                />
+                <line
+                  x1={c.x}
+                  y1={c.y}
+                  x2={d.x}
+                  y2={d.y}
+                  className="stroke-border/25"
+                  strokeWidth={0.4}
+                />
+              </g>
+            )
+          })}
+
+          <line
+            x1={p0.x}
+            y1={p0.y}
+            x2={p1.x}
+            y2={p1.y}
+            className="stroke-foreground/30"
+            strokeWidth={1}
+            strokeLinecap="round"
+          />
+          <line
+            x1={p3.x}
+            y1={p3.y}
+            x2={p2.x}
+            y2={p2.y}
+            className="stroke-foreground/30"
+            strokeWidth={1}
+            strokeLinecap="round"
+          />
+
+          <path
+            d={path}
+            fill="none"
+            strokeWidth={1.6}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="stroke-foreground/80"
+          />
+
+          <rect
+            x={p0.x - ENDPOINT_R}
+            y={p0.y - ENDPOINT_R}
+            width={ENDPOINT_R * 2}
+            height={ENDPOINT_R * 2}
+            rx={0.6}
+            className="fill-background stroke-foreground"
+            strokeWidth={1}
+          />
+          <rect
+            x={p3.x - ENDPOINT_R}
+            y={p3.y - ENDPOINT_R}
+            width={ENDPOINT_R * 2}
+            height={ENDPOINT_R * 2}
+            rx={0.6}
+            className="fill-background stroke-foreground"
+            strokeWidth={1}
+          />
+
+          <Handle
+            cx={p1.x}
+            cy={p1.y}
+            r={HANDLE_R}
+            onPointerDown={onP1Down}
+            label="First control point"
+          />
+          <Handle
+            cx={p2.x}
+            cy={p2.y}
+            r={HANDLE_R}
+            onPointerDown={onP2Down}
+            label="Second control point"
+          />
+        </svg>
+      </div>
+      <div className="flex items-center justify-between gap-2 px-0.5 font-mono text-[9px] text-muted-foreground tabular-nums">
+        <span>
+          ({bezier.x1.toFixed(2)}, {bezier.y1.toFixed(2)})
+        </span>
+        <span>
+          ({bezier.x2.toFixed(2)}, {bezier.y2.toFixed(2)})
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function Handle({
+  cx,
+  cy,
+  r,
+  onPointerDown,
+  label,
+}: {
+  cx: number
+  cy: number
+  r: number
+  onPointerDown: (e: React.PointerEvent<SVGElement>) => void
+  label: string
+}) {
+  // Invisible hit area slightly larger than the drawn square for easier grab.
+  const hit = r + 2.5
+  return (
+    <g>
+      <rect
+        x={cx - hit}
+        y={cy - hit}
+        width={hit * 2}
+        height={hit * 2}
+        fill="transparent"
+        className="cursor-grab active:cursor-grabbing"
+        onPointerDown={onPointerDown}
+      />
+      <rect
+        x={cx - r}
+        y={cy - r}
+        width={r * 2}
+        height={r * 2}
+        rx={0.7}
+        className="pointer-events-none fill-background stroke-foreground"
+        strokeWidth={1.1}
+      />
+      <title>{label}</title>
+    </g>
+  )
+}

--- a/components/editor/animate/clip-transition-toolbar.tsx
+++ b/components/editor/animate/clip-transition-toolbar.tsx
@@ -17,9 +17,9 @@ import {
   clipEasingKind,
   clipReturnsToDefault,
   clipSpeed,
-  DEFAULT_CLIP_EASING,
   DEFAULT_CLIP_SPEED,
   DEFAULT_CUSTOM_BEZIER,
+  NEW_CLIP_EASING,
   effectiveActiveMs,
   MAX_CLIP_SPEED,
   MIN_CLIP_SPEED,
@@ -115,10 +115,12 @@ function TransitionPanel({
 
   const reset = () =>
     onUpdate({
-      easing: DEFAULT_CLIP_EASING,
+      easing: NEW_CLIP_EASING,
       speed: DEFAULT_CLIP_SPEED,
       returnToDefault: true,
-      ...(clip.easingBezier ? {} : { easingBezier: undefined }),
+      // Always clear stored handles so Custom after reset starts from default,
+      // not the pre-reset curve (shallow merge would otherwise leave it on).
+      easingBezier: undefined,
     })
 
   // The slider is driven by the effective transition duration in ms, not the raw

--- a/components/editor/animate/clip-transition-toolbar.tsx
+++ b/components/editor/animate/clip-transition-toolbar.tsx
@@ -13,19 +13,24 @@ import { Switch } from "@/components/ui/switch"
 import {
   CLIP_EASING_KINDS,
   CLIP_EASING_LABELS,
+  clipEasingBezier,
   clipEasingKind,
   clipReturnsToDefault,
   clipSpeed,
   DEFAULT_CLIP_EASING,
   DEFAULT_CLIP_SPEED,
+  DEFAULT_CUSTOM_BEZIER,
   effectiveActiveMs,
   MAX_CLIP_SPEED,
   MIN_CLIP_SPEED,
+  PRESET_BEZIER_SEEDS,
+  type ClipEasingBezier,
   type ClipEasingKind,
 } from "@/lib/editor/clip-easing"
 import type { AnimationClip } from "@/lib/editor/state-types"
 import { cn } from "@/lib/utils"
 
+import { BezierCurveEditor } from "./bezier-curve-editor"
 import { EasingCurve } from "./easing-curve"
 
 type ClipTransitionButtonProps = {
@@ -48,6 +53,7 @@ export function ClipTransitionButton({
   className,
 }: ClipTransitionButtonProps) {
   const kind = clipEasingKind(clip)
+  const bezier = kind === "custom" ? clipEasingBezier(clip) : undefined
   const [open, setOpen] = React.useState(false)
 
   return (
@@ -70,7 +76,11 @@ export function ClipTransitionButton({
           )}
         >
           <span className="flex size-4 items-center justify-center">
-            <EasingCurve kind={kind} strokeClassName="stroke-foreground/70" />
+            <EasingCurve
+              kind={kind}
+              bezier={bezier}
+              strokeClassName="stroke-foreground/70"
+            />
           </span>
           <span className="tabular-nums">{effectiveActiveMs(clip)}ms</span>
         </button>
@@ -79,6 +89,8 @@ export function ClipTransitionButton({
         side="top"
         align="center"
         sideOffset={10}
+        // Same width always — custom curve editor is compact so the popover
+        // doesn't jump wider when Custom is selected.
         className="w-60 rounded-md p-2.5 pb-3"
       >
         <TransitionPanel clip={clip} onUpdate={onUpdate} />
@@ -96,6 +108,7 @@ function TransitionPanel({
 }) {
   const kind = clipEasingKind(clip)
   const speed = clipSpeed(clip)
+  const bezier = clipEasingBezier(clip)
   const [hovered, setHovered] = React.useState<ClipEasingKind | null>(null)
 
   const returns = clipReturnsToDefault(clip)
@@ -105,6 +118,7 @@ function TransitionPanel({
       easing: DEFAULT_CLIP_EASING,
       speed: DEFAULT_CLIP_SPEED,
       returnToDefault: true,
+      ...(clip.easingBezier ? {} : { easingBezier: undefined }),
     })
 
   // The slider is driven by the effective transition duration in ms, not the raw
@@ -120,6 +134,40 @@ function TransitionPanel({
       speed: Math.min(MAX_CLIP_SPEED, Math.max(MIN_CLIP_SPEED, next)),
     })
   }
+
+  const selectPreset = (k: (typeof CLIP_EASING_KINDS)[number]) => {
+    onUpdate({ easing: k })
+  }
+
+  const selectCustom = () => {
+    // Seed from the last custom edit, else from the active preset so the graph
+    // starts near whatever tile they just had selected.
+    let seed: ClipEasingBezier = DEFAULT_CUSTOM_BEZIER
+    if (clip.easingBezier) {
+      seed = clip.easingBezier
+    } else if (kind !== "custom" && Object.hasOwn(PRESET_BEZIER_SEEDS, kind)) {
+      seed = PRESET_BEZIER_SEEDS[kind]
+    }
+    onUpdate({ easing: "custom", easingBezier: seed })
+  }
+
+  const onBezierChange = (next: ClipEasingBezier) => {
+    onUpdate({ easing: "custom", easingBezier: next })
+  }
+
+  const tileClass = (active: boolean) =>
+    cn(
+      "flex aspect-square w-full items-center justify-center rounded-md border p-2 transition-colors",
+      active
+        ? "border-primary bg-primary text-primary-foreground"
+        : "border-border/60 bg-muted/40 group-hover:border-border group-focus-visible:border-ring"
+    )
+
+  const labelClass = (active: boolean) =>
+    cn(
+      "text-[11px] transition-colors",
+      active ? "font-medium text-foreground" : "text-muted-foreground"
+    )
 
   return (
     <div className="flex flex-col gap-2.5">
@@ -137,6 +185,7 @@ function TransitionPanel({
         </button>
       </div>
 
+      {/* 5 presets + Custom in a 3×2 grid (Out Circ removed) */}
       <div className="grid grid-cols-3 gap-1.5">
         {CLIP_EASING_KINDS.map((k) => {
           const active = k === kind
@@ -144,21 +193,14 @@ function TransitionPanel({
             <button
               key={k}
               type="button"
-              onClick={() => onUpdate({ easing: k })}
+              onClick={() => selectPreset(k)}
               onPointerEnter={() => setHovered(k)}
               onPointerLeave={() => setHovered((h) => (h === k ? null : h))}
               onFocus={() => setHovered(k)}
               onBlur={() => setHovered((h) => (h === k ? null : h))}
               className="group flex flex-col items-center gap-1 outline-none"
             >
-              <span
-                className={cn(
-                  "flex aspect-square w-full items-center justify-center rounded-md border p-2 transition-colors",
-                  active
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-border/60 bg-muted/40 group-hover:border-border group-focus-visible:border-ring"
-                )}
-              >
+              <span className={tileClass(active)}>
                 <EasingCurve
                   kind={k}
                   animate={hovered === k}
@@ -173,20 +215,47 @@ function TransitionPanel({
                   }
                 />
               </span>
-              <span
-                className={cn(
-                  "text-[11px] transition-colors",
-                  active
-                    ? "font-medium text-foreground"
-                    : "text-muted-foreground"
-                )}
-              >
+              <span className={labelClass(active)}>
                 {CLIP_EASING_LABELS[k]}
               </span>
             </button>
           )
         })}
+
+        <button
+          type="button"
+          onClick={selectCustom}
+          onPointerEnter={() => setHovered("custom")}
+          onPointerLeave={() => setHovered((h) => (h === "custom" ? null : h))}
+          onFocus={() => setHovered("custom")}
+          onBlur={() => setHovered((h) => (h === "custom" ? null : h))}
+          className="group flex flex-col items-center gap-1 outline-none"
+        >
+          <span className={tileClass(kind === "custom")}>
+            <EasingCurve
+              kind="custom"
+              bezier={bezier}
+              animate={hovered === "custom"}
+              speed={speed}
+              strokeClassName={
+                kind === "custom"
+                  ? "stroke-primary-foreground"
+                  : "stroke-foreground/45"
+              }
+              dotClassName={
+                kind === "custom" ? "fill-primary-foreground" : "fill-primary"
+              }
+            />
+          </span>
+          <span className={labelClass(kind === "custom")}>
+            {CLIP_EASING_LABELS.custom}
+          </span>
+        </button>
       </div>
+
+      {kind === "custom" && (
+        <BezierCurveEditor value={bezier} onChange={onBezierChange} />
+      )}
 
       <ElasticSlider
         label="Speed"

--- a/components/editor/animate/easing-curve.tsx
+++ b/components/editor/animate/easing-curve.tsx
@@ -5,6 +5,7 @@ import * as React from "react"
 import {
   easingDotAt,
   easingSvgPath,
+  type ClipEasingBezier,
   type ClipEasingKind,
 } from "@/lib/editor/clip-easing"
 import { cn } from "@/lib/utils"
@@ -19,6 +20,8 @@ const LOOP_MS = 1650
 
 type EasingCurveProps = {
   kind: ClipEasingKind
+  /** Cubic-bezier handles when `kind` is `"custom"`. */
+  bezier?: ClipEasingBezier
   /** Run the moving-dot preview (true while the tile is hovered/focused). */
   animate?: boolean
   /** Clip speed (1..5): compresses the sweep so a faster clip zips to the end
@@ -37,13 +40,17 @@ type EasingCurveProps = {
  */
 export function EasingCurve({
   kind,
+  bezier,
   animate = false,
   speed = 1,
   className,
   strokeClassName,
   dotClassName,
 }: EasingCurveProps) {
-  const path = React.useMemo(() => easingSvgPath(kind, 100, PAD), [kind])
+  const path = React.useMemo(
+    () => easingSvgPath(kind, 100, PAD, 32, bezier),
+    [kind, bezier]
+  )
   const [t, setT] = React.useState(0)
 
   const sweep = FULL_SWEEP_MS / Math.max(1, speed)
@@ -62,7 +69,7 @@ export function EasingCurve({
 
   // The dot only shows while animating; `t` holds its last value between hovers
   // (harmless — a fresh hover restarts the sweep from its own timestamp).
-  const dot = animate ? easingDotAt(kind, t, 100, PAD) : null
+  const dot = animate ? easingDotAt(kind, t, 100, PAD, bezier) : null
 
   return (
     <svg

--- a/lib/editor/clip-easing.ts
+++ b/lib/editor/clip-easing.ts
@@ -18,11 +18,17 @@ import type {
 export type { ClipEasingBezier, ClipEasingKind }
 
 /**
- * The curve a clip uses when it hasn't picked one. Linear is the default for
- * new animation layers so motion maps 1:1 to the clip window; pick Out / Cubic /
- * etc. in the Transition popover when you want eased motion.
+ * Fallback when a clip has no `easing` field. Ease-out cubic is the historic
+ * default from before per-clip easing existed, so undefined keeps old drafts
+ * and templates animating identically.
  */
-export const DEFAULT_CLIP_EASING: ClipEasingKind = "linear"
+export const DEFAULT_CLIP_EASING: ClipEasingKind = "out"
+
+/**
+ * Easing written onto newly created clips (and used by Transition reset).
+ * Explicit so the shared fallback above can stay legacy-safe.
+ */
+export const NEW_CLIP_EASING: ClipEasingKind = "linear"
 
 /** Default custom cubic-bezier — soft ease-in-out (matches CSS `ease-in-out`). */
 export const DEFAULT_CUSTOM_BEZIER: ClipEasingBezier = {

--- a/lib/editor/clip-easing.ts
+++ b/lib/editor/clip-easing.ts
@@ -52,6 +52,10 @@ function clamp01(n: number): number {
   return n < 0 ? 0 : n > 1 ? 1 : n
 }
 
+function clamp(n: number, min: number, max: number): number {
+  return n < min ? min : n > max ? max : n
+}
+
 /** Named preset easing functions on t ∈ [0,1] → [0,1]. */
 const PRESET_EASING_FNS: Record<
   Exclude<ClipEasingKind, "custom">,
@@ -118,15 +122,19 @@ export function clipEasingKind(clip: {
   return clip.easing ?? DEFAULT_CLIP_EASING
 }
 
-/** Clamp / fill a bezier so both axes stay inside the unit plot [0,1]. */
+/** Clamp / fill a bezier; x stays in [0,1], y uses BEZIER_Y_MIN/MAX. */
 export function normalizeBezier(
   raw?: Partial<ClipEasingBezier> | null
 ): ClipEasingBezier {
   const base = DEFAULT_CUSTOM_BEZIER
   const x1 = Number.isFinite(raw?.x1) ? clamp01(raw!.x1!) : base.x1
   const x2 = Number.isFinite(raw?.x2) ? clamp01(raw!.x2!) : base.x2
-  const y1 = Number.isFinite(raw?.y1) ? clamp01(raw!.y1!) : base.y1
-  const y2 = Number.isFinite(raw?.y2) ? clamp01(raw!.y2!) : base.y2
+  const y1 = Number.isFinite(raw?.y1)
+    ? clamp(raw!.y1!, BEZIER_Y_MIN, BEZIER_Y_MAX)
+    : base.y1
+  const y2 = Number.isFinite(raw?.y2)
+    ? clamp(raw!.y2!, BEZIER_Y_MIN, BEZIER_Y_MAX)
+    : base.y2
   return { x1, y1, x2, y2 }
 }
 
@@ -301,8 +309,8 @@ export function easingSvgPathFromFn(
   for (let i = 0; i <= samples; i++) {
     const t = i / samples
     const x = pad + t * span
-    // Don't clamp y for display — custom curves can overshoot the pad box
-    // slightly; the editor shows that intentionally. Thumbnails still look fine.
+    // y is already clamped via normalizeBezier (BEZIER_Y_MIN/MAX); map into
+    // the padded box (SVG y-down).
     const y = pad + (1 - fn(t)) * span
     pts.push(`${i === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`)
   }
@@ -339,8 +347,8 @@ export function unitToSvg(
   const span = size - pad * 2
   return {
     x: pad + x * span,
-    // y can sit outside [0,1] for overshoot — map linearly so handles leave the
-    // pad when the user drags past the endpoints.
+    // Unit y is clamped to BEZIER_Y_MIN/MAX; map linearly into the padded box
+    // (SVG y-down, 0 at bottom → 1 at top).
     y: pad + (1 - y) * span,
   }
 }

--- a/lib/editor/clip-easing.ts
+++ b/lib/editor/clip-easing.ts
@@ -1,25 +1,40 @@
 // Per-clip transition easing + speed remap.
 //
-// Every animation clip eases its owned effects over its own window. Historically
-// that easing was a single hard-coded ease-out cubic shared by all clips; this
-// module makes the curve a per-clip choice (Linear / Cubic / In / Out / In Out /
-// Out Circ) and adds an independent SPEED remap that lets the transition finish
-// EARLY within the clip's window (then hold) WITHOUT moving the clip's keyframe
-// time. A 5 s clip can complete its motion in 1 s and hold for the remaining 4 s.
+// Every animation clip eases its owned effects over its own window. Named
+// presets (Linear / Cubic / In / Out / In Out / Out Circ) cover common motion;
+// Custom uses a CSS-style cubic-bezier the user can edit in the Transition
+// popover. An independent SPEED remap lets the transition finish EARLY within
+// the clip's window (then hold) WITHOUT moving the clip's keyframe time.
 //
 // The same helpers drive live playback, the exporter, and the little curve
 // thumbnails in the Transition popover — so the preview always matches output.
 
-import type { AnimationClip, ClipEasingKind } from "./state-types"
+import type {
+  AnimationClip,
+  ClipEasingBezier,
+  ClipEasingKind,
+} from "./state-types"
 
-export type { ClipEasingKind }
+export type { ClipEasingBezier, ClipEasingKind }
 
 /**
- * The curve a clip uses when it hasn't picked one. `out` (ease-out cubic) is the
- * motion every clip shipped with before per-clip easing existed, so undefined
- * `easing` reads as this and old drafts animate identically.
+ * The curve a clip uses when it hasn't picked one. Linear is the default for
+ * new animation layers so motion maps 1:1 to the clip window; pick Out / Cubic /
+ * etc. in the Transition popover when you want eased motion.
  */
-export const DEFAULT_CLIP_EASING: ClipEasingKind = "out"
+export const DEFAULT_CLIP_EASING: ClipEasingKind = "linear"
+
+/** Default custom cubic-bezier — soft ease-in-out (matches CSS `ease-in-out`). */
+export const DEFAULT_CUSTOM_BEZIER: ClipEasingBezier = {
+  x1: 0.42,
+  y1: 0,
+  x2: 0.58,
+  y2: 1,
+}
+
+/** Control-point y stays inside the plot box — same [0,1] clamp as x. */
+export const BEZIER_Y_MIN = 0
+export const BEZIER_Y_MAX = 1
 
 /** Speed remap bounds. 1 = the transition uses the clip's full window (original
  * behaviour); higher finishes proportionally sooner (5 = in one-fifth of it). */
@@ -31,8 +46,11 @@ function clamp01(n: number): number {
   return n < 0 ? 0 : n > 1 ? 1 : n
 }
 
-/** Raw easing functions on t ∈ [0,1] → [0,1]. */
-const EASING_FNS: Record<ClipEasingKind, (t: number) => number> = {
+/** Named preset easing functions on t ∈ [0,1] → [0,1]. */
+const PRESET_EASING_FNS: Record<
+  Exclude<ClipEasingKind, "custom">,
+  (t: number) => number
+> = {
   linear: (t) => t,
   // Strong symmetric S — accelerate then decelerate (ease-in-out cubic).
   cubic: (t) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2),
@@ -46,13 +64,17 @@ const EASING_FNS: Record<ClipEasingKind, (t: number) => number> = {
   outCirc: (t) => Math.sqrt(1 - Math.pow(t - 1, 2)),
 }
 
-export const CLIP_EASING_KINDS: readonly ClipEasingKind[] = [
+/**
+ * Preset tiles in the Transition grid (5 presets + Custom = 3×2).
+ * `outCirc` stays in the type system for drafts/templates that already use it,
+ * but is not offered as a grid tile.
+ */
+export const CLIP_EASING_KINDS: readonly Exclude<ClipEasingKind, "custom">[] = [
   "linear",
   "cubic",
   "in",
   "out",
   "inOut",
-  "outCirc",
 ]
 
 /** Human labels for the Transition popover tiles. */
@@ -63,6 +85,24 @@ export const CLIP_EASING_LABELS: Record<ClipEasingKind, string> = {
   out: "Out",
   inOut: "In Out",
   outCirc: "Out Circ",
+  custom: "Custom",
+}
+
+/**
+ * Seed bezier values when the user flips a named preset into Custom so the
+ * graph starts near the curve they were just looking at.
+ */
+export const PRESET_BEZIER_SEEDS: Record<
+  Exclude<ClipEasingKind, "custom">,
+  ClipEasingBezier
+> = {
+  // Approximate the named curves as cubic-beziers for a sensible hand-off.
+  linear: { x1: 0, y1: 0, x2: 1, y2: 1 },
+  cubic: { x1: 0.65, y1: 0, x2: 0.35, y2: 1 },
+  in: { x1: 0.55, y1: 0.055, x2: 0.675, y2: 0.19 },
+  out: { x1: 0.215, y1: 0.61, x2: 0.355, y2: 1 },
+  inOut: { x1: 0.42, y1: 0, x2: 0.58, y2: 1 },
+  outCirc: { x1: 0.08, y1: 0.82, x2: 0.17, y2: 1 },
 }
 
 /** The easing kind a clip resolves to (its own, or the default). */
@@ -72,6 +112,25 @@ export function clipEasingKind(clip: {
   return clip.easing ?? DEFAULT_CLIP_EASING
 }
 
+/** Clamp / fill a bezier so both axes stay inside the unit plot [0,1]. */
+export function normalizeBezier(
+  raw?: Partial<ClipEasingBezier> | null
+): ClipEasingBezier {
+  const base = DEFAULT_CUSTOM_BEZIER
+  const x1 = Number.isFinite(raw?.x1) ? clamp01(raw!.x1!) : base.x1
+  const x2 = Number.isFinite(raw?.x2) ? clamp01(raw!.x2!) : base.x2
+  const y1 = Number.isFinite(raw?.y1) ? clamp01(raw!.y1!) : base.y1
+  const y2 = Number.isFinite(raw?.y2) ? clamp01(raw!.y2!) : base.y2
+  return { x1, y1, x2, y2 }
+}
+
+/** Resolved bezier for a clip (custom handles, or default). */
+export function clipEasingBezier(clip: {
+  easingBezier?: ClipEasingBezier
+}): ClipEasingBezier {
+  return normalizeBezier(clip.easingBezier)
+}
+
 /** Clamp a raw speed into range, treating undefined as the default. */
 export function clipSpeed(clip: { speed?: number }): number {
   const s = clip.speed ?? DEFAULT_CLIP_SPEED
@@ -79,9 +138,74 @@ export function clipSpeed(clip: { speed?: number }): number {
   return Math.min(MAX_CLIP_SPEED, Math.max(MIN_CLIP_SPEED, s))
 }
 
-/** The bare easing function for a kind (used by the curve thumbnails). */
+/**
+ * CSS cubic-bezier evaluator: given x ∈ [0,1] (time), return y (eased progress).
+ * Newton-Raphson with binary-search fallback — same approach browsers use.
+ */
+export function cubicBezierEase(
+  bezier: ClipEasingBezier
+): (x: number) => number {
+  const { x1, y1, x2, y2 } = normalizeBezier(bezier)
+
+  // Bezier component: 3(1-t)²t·a + 3(1-t)t²·b + t³
+  const sampleCurve = (a: number, b: number, t: number) => {
+    const t2 = t * t
+    const t3 = t2 * t
+    const mt = 1 - t
+    const mt2 = mt * mt
+    return 3 * mt2 * t * a + 3 * mt * t2 * b + t3
+  }
+  const sampleDerivative = (a: number, b: number, t: number) => {
+    const mt = 1 - t
+    return 3 * mt * mt * a + 6 * mt * t * (b - a) + 3 * t * t * (1 - b)
+  }
+
+  return (x: number) => {
+    const xx = clamp01(x)
+    if (xx <= 0) return 0
+    if (xx >= 1) return 1
+
+    // Newton-Raphson for t such that Bx(t) ≈ x
+    let t = xx
+    for (let i = 0; i < 8; i++) {
+      const xEst = sampleCurve(x1, x2, t)
+      const dx = sampleDerivative(x1, x2, t)
+      if (Math.abs(dx) < 1e-6) break
+      t = clamp01(t - (xEst - xx) / dx)
+    }
+
+    // Binary refine if Newton left residual
+    let lo = 0
+    let hi = 1
+    for (let i = 0; i < 8; i++) {
+      const xEst = sampleCurve(x1, x2, t)
+      if (Math.abs(xEst - xx) < 1e-6) break
+      if (xEst < xx) lo = t
+      else hi = t
+      t = (lo + hi) / 2
+    }
+
+    return sampleCurve(y1, y2, t)
+  }
+}
+
+/**
+ * The bare easing function for a kind. `custom` uses `DEFAULT_CUSTOM_BEZIER`
+ * unless you pass a bezier via `resolveEasingFn`.
+ */
 export function easingFn(kind: ClipEasingKind): (t: number) => number {
-  return EASING_FNS[kind]
+  if (kind === "custom") return cubicBezierEase(DEFAULT_CUSTOM_BEZIER)
+  return PRESET_EASING_FNS[kind]
+}
+
+/** Resolve the full easing function for a clip (presets + custom bezier). */
+export function resolveEasingFn(clip: {
+  easing?: ClipEasingKind
+  easingBezier?: ClipEasingBezier
+}): (t: number) => number {
+  const kind = clipEasingKind(clip)
+  if (kind === "custom") return cubicBezierEase(clipEasingBezier(clip))
+  return PRESET_EASING_FNS[kind]
 }
 
 /**
@@ -93,9 +217,10 @@ export function easingFn(kind: ClipEasingKind): (t: number) => number {
  */
 export function clipProgressEase(clip: {
   easing?: ClipEasingKind
+  easingBezier?: ClipEasingBezier
   speed?: number
 }): (rawT: number) => number {
-  const fn = EASING_FNS[clipEasingKind(clip)]
+  const fn = resolveEasingFn(clip)
   const speed = clipSpeed(clip)
   return (rawT) => fn(clamp01(rawT * speed))
 }
@@ -127,7 +252,7 @@ export function clipReleaseMs(clip: AnimationClip): number {
  * again would compress the curve inside its own shortened window.
  */
 export function clipReleaseEase(clip: AnimationClip): (rawT: number) => number {
-  const fn = EASING_FNS[clipEasingKind(clip)]
+  const fn = resolveEasingFn(clip)
   return (rawT) => fn(clamp01(rawT))
 }
 
@@ -149,15 +274,30 @@ export function easingSvgPath(
   kind: ClipEasingKind,
   size = 100,
   pad = 14,
+  samples = 32,
+  bezier?: ClipEasingBezier
+): string {
+  const fn =
+    kind === "custom"
+      ? cubicBezierEase(normalizeBezier(bezier))
+      : PRESET_EASING_FNS[kind]
+  return easingSvgPathFromFn(fn, size, pad, samples)
+}
+
+export function easingSvgPathFromFn(
+  fn: (t: number) => number,
+  size = 100,
+  pad = 14,
   samples = 32
 ): string {
-  const fn = EASING_FNS[kind]
   const span = size - pad * 2
   const pts: string[] = []
   for (let i = 0; i <= samples; i++) {
     const t = i / samples
     const x = pad + t * span
-    const y = pad + (1 - clamp01(fn(t))) * span
+    // Don't clamp y for display — custom curves can overshoot the pad box
+    // slightly; the editor shows that intentionally. Thumbnails still look fine.
+    const y = pad + (1 - fn(t)) * span
     pts.push(`${i === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`)
   }
   return pts.join(" ")
@@ -168,13 +308,47 @@ export function easingDotAt(
   kind: ClipEasingKind,
   t: number,
   size = 100,
-  pad = 14
+  pad = 14,
+  bezier?: ClipEasingBezier
 ): { x: number; y: number } {
-  const fn = EASING_FNS[kind]
+  const fn =
+    kind === "custom"
+      ? cubicBezierEase(normalizeBezier(bezier))
+      : PRESET_EASING_FNS[kind]
   const span = size - pad * 2
   const p = clamp01(t)
   return {
     x: pad + p * span,
-    y: pad + (1 - clamp01(fn(p))) * span,
+    y: pad + (1 - fn(p)) * span,
+  }
+}
+
+/** Map unit (x,y) in [0,1]² (y-up) into the padded SVG box (y-down). */
+export function unitToSvg(
+  x: number,
+  y: number,
+  size = 100,
+  pad = 14
+): { x: number; y: number } {
+  const span = size - pad * 2
+  return {
+    x: pad + x * span,
+    // y can sit outside [0,1] for overshoot — map linearly so handles leave the
+    // pad when the user drags past the endpoints.
+    y: pad + (1 - y) * span,
+  }
+}
+
+/** Inverse of `unitToSvg`. */
+export function svgToUnit(
+  sx: number,
+  sy: number,
+  size = 100,
+  pad = 14
+): { x: number; y: number } {
+  const span = size - pad * 2
+  return {
+    x: (sx - pad) / span,
+    y: 1 - (sy - pad) / span,
   }
 }

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -419,6 +419,18 @@ export type ClipEasingKind =
   | "out"
   | "inOut"
   | "outCirc"
+  | "custom"
+
+/**
+ * CSS-style cubic-bezier control points for `easing: "custom"`.
+ * Anchors are always (0,0) → (1,1); all four values live in [0,1].
+ */
+export type ClipEasingBezier = {
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+}
 
 export type ClipSlotPose = {
   tilt: Tilt
@@ -469,6 +481,8 @@ export type AnimationClip = {
   effects?: AnimationEffect[]
   baseline?: ClipBaseline
   easing?: ClipEasingKind
+  /** Cubic-bezier handles used when `easing` is `"custom"`. */
+  easingBezier?: ClipEasingBezier
   speed?: number
   /**
    * Ease every owned effect back to the pre-clip state once the clip's window

--- a/lib/editor/store.tsx
+++ b/lib/editor/store.tsx
@@ -3,6 +3,7 @@
 import { create } from "zustand"
 
 import { DEFAULT_CLIP_DURATION_MS } from "./animation-motion"
+import { NEW_CLIP_EASING } from "./clip-easing"
 import {
   clipAffectsMain,
   clipAffectsSlot,
@@ -3148,6 +3149,9 @@ export const useEditorStore = create<EditorStore>((set, get) => {
             baseline: snapshot,
             // A fresh keyframe owns nothing until you edit an effect on it.
             effects: [],
+            // Explicit linear so undefined easing can keep meaning historic
+            // ease-out for drafts/templates saved before per-clip easing.
+            easing: NEW_CLIP_EASING,
           }
           return {
             animation: { ...animation, clips: [...animation.clips, clip] },

--- a/tests/lib/editor/animation-playback.test.ts
+++ b/tests/lib/editor/animation-playback.test.ts
@@ -121,7 +121,8 @@ describe("clipsProgressAt", () => {
   })
 
   it("eases inside the clip", () => {
-    expect(clipsProgressAt(clips, 1500)).toBeCloseTo(EASED_HALF, 5)
+    // Default clip easing is linear → midpoint of the window is 0.5.
+    expect(clipsProgressAt(clips, 1500)).toBeCloseTo(0.5, 5)
   })
 
   it("holds the pose (1) after the clip when it opts out of releasing", () => {
@@ -170,7 +171,7 @@ describe("activeClipAt", () => {
   it("inside a clip returns its eased progress and neighbours", () => {
     const r = activeClipAt([a, b], 1500)!
     expect(r.clip.id).toBe("a")
-    expect(r.progress).toBeCloseTo(EASED_HALF, 5)
+    expect(r.progress).toBeCloseTo(0.5, 5)
     expect(r.next?.id).toBe("b")
   })
 
@@ -236,9 +237,22 @@ describe("per-clip easing & speed", () => {
     expect(clipsProgressAt(linear, 500)).toBeCloseTo(0.5, 5)
   })
 
-  it("clipsProgressAt still defaults to ease-out with no easing set", () => {
+  it("clipsProgressAt defaults to linear with no easing set", () => {
     const dflt = [clip({ id: "a", startMs: 0, durationMs: 1000 })]
-    expect(clipsProgressAt(dflt, 500)).toBeCloseTo(EASED_HALF, 5)
+    expect(clipsProgressAt(dflt, 500)).toBeCloseTo(0.5, 5)
+  })
+
+  it("clipsProgressAt applies a custom cubic-bezier", () => {
+    const custom = [
+      clip({
+        id: "a",
+        startMs: 0,
+        durationMs: 1000,
+        easing: "custom",
+        easingBezier: { x1: 0, y1: 0, x2: 1, y2: 1 },
+      }),
+    ]
+    expect(clipsProgressAt(custom, 500)).toBeCloseTo(0.5, 4)
   })
 
   it("clipsProgressAt completes early then holds when speed > 1", () => {

--- a/tests/lib/editor/animation-playback.test.ts
+++ b/tests/lib/editor/animation-playback.test.ts
@@ -121,8 +121,8 @@ describe("clipsProgressAt", () => {
   })
 
   it("eases inside the clip", () => {
-    // Default clip easing is linear → midpoint of the window is 0.5.
-    expect(clipsProgressAt(clips, 1500)).toBeCloseTo(0.5, 5)
+    // Unset easing falls back to historic ease-out → midpoint is 0.875.
+    expect(clipsProgressAt(clips, 1500)).toBeCloseTo(EASED_HALF, 5)
   })
 
   it("holds the pose (1) after the clip when it opts out of releasing", () => {
@@ -171,7 +171,7 @@ describe("activeClipAt", () => {
   it("inside a clip returns its eased progress and neighbours", () => {
     const r = activeClipAt([a, b], 1500)!
     expect(r.clip.id).toBe("a")
-    expect(r.progress).toBeCloseTo(0.5, 5)
+    expect(r.progress).toBeCloseTo(EASED_HALF, 5)
     expect(r.next?.id).toBe("b")
   })
 
@@ -237,9 +237,9 @@ describe("per-clip easing & speed", () => {
     expect(clipsProgressAt(linear, 500)).toBeCloseTo(0.5, 5)
   })
 
-  it("clipsProgressAt defaults to linear with no easing set", () => {
+  it("clipsProgressAt defaults to ease-out with no easing set (legacy)", () => {
     const dflt = [clip({ id: "a", startMs: 0, durationMs: 1000 })]
-    expect(clipsProgressAt(dflt, 500)).toBeCloseTo(0.5, 5)
+    expect(clipsProgressAt(dflt, 500)).toBeCloseTo(EASED_HALF, 5)
   })
 
   it("clipsProgressAt applies a custom cubic-bezier", () => {

--- a/tests/lib/editor/clip-easing.test.ts
+++ b/tests/lib/editor/clip-easing.test.ts
@@ -1,22 +1,32 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  BEZIER_Y_MAX,
+  BEZIER_Y_MIN,
   CLIP_EASING_KINDS,
   CLIP_EASING_LABELS,
+  clipEasingBezier,
   clipEasingKind,
   clipProgressEase,
   clipReleaseEase,
   clipReleaseMs,
   clipReturnsToDefault,
   clipSpeed,
+  cubicBezierEase,
   DEFAULT_CLIP_EASING,
   DEFAULT_CLIP_SPEED,
+  DEFAULT_CUSTOM_BEZIER,
   easingDotAt,
   easingFn,
   easingSvgPath,
   effectiveActiveMs,
   MAX_CLIP_SPEED,
   MIN_CLIP_SPEED,
+  normalizeBezier,
+  PRESET_BEZIER_SEEDS,
+  resolveEasingFn,
+  svgToUnit,
+  unitToSvg,
 } from "@/lib/editor/clip-easing"
 import type { AnimationClip } from "@/lib/editor/state-types"
 
@@ -28,9 +38,9 @@ const clip = (over: Partial<AnimationClip> = {}): AnimationClip => ({
 })
 
 describe("clipEasingKind", () => {
-  it("defaults to the historic ease-out when unset", () => {
+  it("defaults to linear when unset", () => {
     expect(clipEasingKind(clip())).toBe(DEFAULT_CLIP_EASING)
-    expect(DEFAULT_CLIP_EASING).toBe("out")
+    expect(DEFAULT_CLIP_EASING).toBe("linear")
   })
 
   it("passes an explicit kind through", () => {
@@ -88,16 +98,16 @@ describe("easingFn", () => {
 })
 
 describe("clipProgressEase", () => {
-  it("an unset clip eases as ease-out over the full window", () => {
+  it("an unset clip eases linearly over the full window", () => {
     const p = clipProgressEase(clip())
     expect(p(0)).toBeCloseTo(0, 6)
-    expect(p(0.5)).toBeCloseTo(0.875, 6)
+    expect(p(0.5)).toBeCloseTo(0.5, 6)
     expect(p(1)).toBeCloseTo(1, 6)
   })
 
   it("applies the chosen curve", () => {
-    const p = clipProgressEase(clip({ easing: "linear" }))
-    expect(p(0.5)).toBeCloseTo(0.5, 6)
+    const p = clipProgressEase(clip({ easing: "out" }))
+    expect(p(0.5)).toBeCloseTo(0.875, 6)
   })
 
   it("speed compresses the ramp so it completes early then holds at 1", () => {
@@ -129,11 +139,166 @@ describe("effectiveActiveMs", () => {
 })
 
 describe("labels & kinds", () => {
-  it("exposes exactly six kinds each with a label", () => {
-    expect(CLIP_EASING_KINDS).toHaveLength(6)
+  it("exposes five grid presets each with a label, plus Custom", () => {
+    expect(CLIP_EASING_KINDS).toHaveLength(5)
     for (const kind of CLIP_EASING_KINDS) {
       expect(CLIP_EASING_LABELS[kind]).toBeTruthy()
     }
+    expect(CLIP_EASING_LABELS.custom).toBe("Custom")
+    // outCirc remains a valid kind (drafts/templates) but is not a grid tile.
+    expect(CLIP_EASING_LABELS.outCirc).toBe("Out Circ")
+  })
+})
+
+describe("custom cubic-bezier", () => {
+  it("normalizeBezier fills defaults and clamps both axes to [0,1]", () => {
+    expect(normalizeBezier(undefined)).toEqual(DEFAULT_CUSTOM_BEZIER)
+    expect(normalizeBezier({ x1: -1, y1: 0.5, x2: 2, y2: 0.5 })).toEqual({
+      x1: 0,
+      y1: 0.5,
+      x2: 1,
+      y2: 0.5,
+    })
+    expect(normalizeBezier({ x1: 0.2, y1: -0.5, x2: 0.8, y2: 1.5 })).toEqual({
+      x1: 0.2,
+      y1: 0,
+      x2: 0.8,
+      y2: 1,
+    })
+  })
+
+  it("linear bezier maps t → t", () => {
+    const fn = cubicBezierEase({ x1: 0, y1: 0, x2: 1, y2: 1 })
+    expect(fn(0)).toBeCloseTo(0, 5)
+    expect(fn(0.5)).toBeCloseTo(0.5, 5)
+    expect(fn(1)).toBeCloseTo(1, 5)
+  })
+
+  it("pins endpoints for any control points", () => {
+    const fn = cubicBezierEase({ x1: 0.2, y1: 0.9, x2: 0.8, y2: 0.1 })
+    expect(fn(0)).toBeCloseTo(0, 5)
+    expect(fn(1)).toBeCloseTo(1, 5)
+  })
+
+  it("clipProgressEase uses the clip's custom bezier", () => {
+    const p = clipProgressEase(
+      clip({
+        easing: "custom",
+        easingBezier: { x1: 0, y1: 0, x2: 1, y2: 1 },
+      })
+    )
+    expect(p(0.25)).toBeCloseTo(0.25, 4)
+    expect(p(0.75)).toBeCloseTo(0.75, 4)
+  })
+
+  it("resolveEasingFn falls back to default custom bezier when unset", () => {
+    const a = resolveEasingFn({ easing: "custom" })
+    const b = cubicBezierEase(DEFAULT_CUSTOM_BEZIER)
+    expect(a(0.4)).toBeCloseTo(b(0.4), 5)
+  })
+
+  it("clipEasingBezier returns the stored handles", () => {
+    const bezier = { x1: 0.1, y1: 0.2, x2: 0.8, y2: 0.9 }
+    expect(clipEasingBezier(clip({ easingBezier: bezier }))).toEqual(bezier)
+  })
+
+  it("easingSvgPath draws a custom curve", () => {
+    const path = easingSvgPath("custom", 100, 10, 4, {
+      x1: 0,
+      y1: 0,
+      x2: 1,
+      y2: 1,
+    })
+    expect(path.startsWith("M")).toBe(true)
+    expect((path.match(/L/g) ?? []).length).toBe(4)
+  })
+
+  it("clipProgressEase applies speed with a custom bezier", () => {
+    const p = clipProgressEase(
+      clip({
+        easing: "custom",
+        easingBezier: { x1: 0, y1: 0, x2: 1, y2: 1 },
+        speed: 2,
+      })
+    )
+    // Linear bezier + speed 2 → pose at half the window.
+    expect(p(0.25)).toBeCloseTo(0.5, 4)
+    expect(p(0.5)).toBeCloseTo(1, 4)
+  })
+
+  it("clipReleaseEase uses the custom bezier without speed remap", () => {
+    const c = clip({
+      easing: "custom",
+      easingBezier: { x1: 0, y1: 0, x2: 1, y2: 1 },
+      speed: 4,
+    })
+    expect(clipProgressEase(c)(0.5)).toBeCloseTo(1, 4)
+    expect(clipReleaseEase(c)(0.5)).toBeCloseTo(0.5, 4)
+  })
+
+  it("easingFn('custom') matches DEFAULT_CUSTOM_BEZIER", () => {
+    const a = easingFn("custom")
+    const b = cubicBezierEase(DEFAULT_CUSTOM_BEZIER)
+    expect(a(0.3)).toBeCloseTo(b(0.3), 5)
+    expect(a(0.7)).toBeCloseTo(b(0.7), 5)
+  })
+
+  it("easingDotAt tracks a custom curve", () => {
+    const pad = 10
+    const size = 100
+    const start = easingDotAt("custom", 0, size, pad, {
+      x1: 0,
+      y1: 0,
+      x2: 1,
+      y2: 1,
+    })
+    expect(start.x).toBeCloseTo(pad, 5)
+    expect(start.y).toBeCloseTo(size - pad, 5)
+  })
+
+  it("PRESET_BEZIER_SEEDS cover every named kind including outCirc", () => {
+    for (const kind of [...CLIP_EASING_KINDS, "outCirc" as const]) {
+      const seed = PRESET_BEZIER_SEEDS[kind]
+      expect(seed).toBeDefined()
+      const n = normalizeBezier(seed)
+      expect(n.x1).toBeGreaterThanOrEqual(0)
+      expect(n.x1).toBeLessThanOrEqual(1)
+      expect(n.y1).toBeGreaterThanOrEqual(BEZIER_Y_MIN)
+      expect(n.y1).toBeLessThanOrEqual(BEZIER_Y_MAX)
+    }
+  })
+
+  it("ease-in-out default custom is between linear midpoints at 0.25 and 0.75", () => {
+    // DEFAULT_CUSTOM_BEZIER ≈ CSS ease-in-out: slow start & finish, faster middle.
+    const fn = cubicBezierEase(DEFAULT_CUSTOM_BEZIER)
+    expect(fn(0.25)).toBeLessThan(0.25)
+    expect(fn(0.75)).toBeGreaterThan(0.75)
+  })
+})
+
+describe("unitToSvg / svgToUnit", () => {
+  it("round-trips corners of the unit square", () => {
+    const size = 100
+    const pad = 12
+    for (const [ux, uy] of [
+      [0, 0],
+      [1, 1],
+      [0.5, 0.5],
+    ] as const) {
+      const s = unitToSvg(ux, uy, size, pad)
+      const back = svgToUnit(s.x, s.y, size, pad)
+      expect(back.x).toBeCloseTo(ux, 6)
+      expect(back.y).toBeCloseTo(uy, 6)
+    }
+  })
+
+  it("maps (0,0) to bottom-left and (1,1) to top-right", () => {
+    const s0 = unitToSvg(0, 0, 100, 10)
+    expect(s0.x).toBeCloseTo(10, 6)
+    expect(s0.y).toBeCloseTo(90, 6)
+    const s1 = unitToSvg(1, 1, 100, 10)
+    expect(s1.x).toBeCloseTo(90, 6)
+    expect(s1.y).toBeCloseTo(10, 6)
   })
 })
 

--- a/tests/lib/editor/clip-easing.test.ts
+++ b/tests/lib/editor/clip-easing.test.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_CLIP_EASING,
   DEFAULT_CLIP_SPEED,
   DEFAULT_CUSTOM_BEZIER,
+  NEW_CLIP_EASING,
   easingDotAt,
   easingFn,
   easingSvgPath,
@@ -38,9 +39,14 @@ const clip = (over: Partial<AnimationClip> = {}): AnimationClip => ({
 })
 
 describe("clipEasingKind", () => {
-  it("defaults to linear when unset", () => {
+  it("defaults to historic ease-out when unset (legacy drafts/templates)", () => {
     expect(clipEasingKind(clip())).toBe(DEFAULT_CLIP_EASING)
-    expect(DEFAULT_CLIP_EASING).toBe("linear")
+    expect(DEFAULT_CLIP_EASING).toBe("out")
+  })
+
+  it("new clips use an explicit linear default separate from the fallback", () => {
+    expect(NEW_CLIP_EASING).toBe("linear")
+    expect(NEW_CLIP_EASING).not.toBe(DEFAULT_CLIP_EASING)
   })
 
   it("passes an explicit kind through", () => {
@@ -98,10 +104,10 @@ describe("easingFn", () => {
 })
 
 describe("clipProgressEase", () => {
-  it("an unset clip eases linearly over the full window", () => {
+  it("an unset clip eases as ease-out over the full window (legacy fallback)", () => {
     const p = clipProgressEase(clip())
     expect(p(0)).toBeCloseTo(0, 6)
-    expect(p(0.5)).toBeCloseTo(0.5, 6)
+    expect(p(0.5)).toBeCloseTo(0.875, 6)
     expect(p(1)).toBeCloseTo(1, 6)
   })
 

--- a/tests/lib/editor/custom-preset-snapshot.test.ts
+++ b/tests/lib/editor/custom-preset-snapshot.test.ts
@@ -153,6 +153,40 @@ describe("custom preset snapshot", () => {
     expect(remapped.clips[0]?.speed).toBe(2.5)
   })
 
+  it("preserves custom easingBezier through capture and apply", () => {
+    const bezier = { x1: 0.2, y1: 0.1, x2: 0.7, y2: 0.9 }
+    const source = canvasWithClips(["old-slot"])
+    source.animation = {
+      ...source.animation!,
+      clips: [
+        {
+          ...source.animation!.clips[0],
+          easing: "custom",
+          easingBezier: bezier,
+          speed: 1.5,
+        },
+      ],
+    }
+    const geometry = captureCustomPresetGeometry(
+      source,
+      { id: "16-10", w: 16, h: 10 },
+      { includeAnimation: true }
+    )
+    const saved = geometry.animation!.clips[0]
+    expect(saved?.easing).toBe("custom")
+    expect(saved?.easingBezier).toEqual(bezier)
+    expect(saved?.speed).toBe(1.5)
+
+    const remapped = remapAnimationForApply(
+      geometry.animation!,
+      ["new-slot"],
+      source.background
+    )
+    expect(remapped.clips[0]?.easing).toBe("custom")
+    expect(remapped.clips[0]?.easingBezier).toEqual(bezier)
+    expect(remapped.clips[0]?.speed).toBe(1.5)
+  })
+
   it("builds slot remap by index from sourceSlotIds", () => {
     const map = buildSlotIdRemap(["live-a", "live-b"], ["src-a", "src-b"], [])
     expect(map.get("src-a")).toBe("live-a")

--- a/tests/lib/editor/store/clip-return-to-default.test.ts
+++ b/tests/lib/editor/store/clip-return-to-default.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest"
 
-import { clipReturnsToDefault } from "@/lib/editor/clip-easing"
+import {
+  clipEasingKind,
+  clipReturnsToDefault,
+  NEW_CLIP_EASING,
+} from "@/lib/editor/clip-easing"
 import { useEditorStore } from "@/lib/editor/store"
 
 const store = useEditorStore
@@ -18,6 +22,36 @@ describe("addAnimationClip returnToDefault", () => {
   it("returns new clips to default without needing a stored flag", () => {
     const id = store.getState().addAnimationClip()
     expect(clipReturnsToDefault(clipById(id))).toBe(true)
+  })
+
+  it("stores an explicit linear easing so legacy unset still means ease-out", () => {
+    const id = store.getState().addAnimationClip()
+    const c = clipById(id)
+    expect(c.easing).toBe(NEW_CLIP_EASING)
+    expect(c.easing).toBe("linear")
+    // Unset easing (legacy shape) still resolves to historic ease-out.
+    expect(clipEasingKind({})).toBe("out")
+  })
+
+  it("clears easingBezier when the transition is patched with undefined", () => {
+    const id = store.getState().addAnimationClip()
+    store.getState().updateAnimationClip(id, {
+      easing: "custom",
+      easingBezier: { x1: 0.2, y1: 0.1, x2: 0.8, y2: 0.9 },
+    })
+    expect(clipById(id).easingBezier).toEqual({
+      x1: 0.2,
+      y1: 0.1,
+      x2: 0.8,
+      y2: 0.9,
+    })
+    // Same shape as Transition reset — shallow merge must drop the handles.
+    store.getState().updateAnimationClip(id, {
+      easing: NEW_CLIP_EASING,
+      easingBezier: undefined,
+    })
+    expect(clipById(id).easing).toBe("linear")
+    expect(clipById(id).easingBezier).toBeUndefined()
   })
 
   it("lets a clip be switched back to holding its pose", () => {

--- a/tests/lib/editor/store/draft-persistence.test.ts
+++ b/tests/lib/editor/store/draft-persistence.test.ts
@@ -234,6 +234,15 @@ describe("draft persistence", () => {
           easing: "linear",
           speed: 3,
         },
+        {
+          id: "clip-custom",
+          startMs: 1000,
+          durationMs: 1000,
+          effects: ["zoom"],
+          easing: "custom",
+          easingBezier: { x1: 0.2, y1: 0.1, x2: 0.7, y2: 0.95 },
+          speed: 1,
+        },
       ],
     }
 
@@ -272,8 +281,17 @@ describe("draft persistence", () => {
     }
 
     const applied = applyEditorDraft(draft)
-    const clip = applied.present?.canvases[0]?.animation?.clips[0]
+    const clips = applied.present?.canvases[0]?.animation?.clips ?? []
+    const clip = clips[0]
     expect(clip?.easing).toBe("linear")
     expect(clip?.speed).toBe(3)
+    const custom = clips.find((c) => c.id === "clip-custom")
+    expect(custom?.easing).toBe("custom")
+    expect(custom?.easingBezier).toEqual({
+      x1: 0.2,
+      y1: 0.1,
+      x2: 0.7,
+      y2: 0.95,
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Add a **Custom** easing option in the Transition popover with an interactive cubic-bezier graph (draggable control points, grid, handle arms, in-graph reset).
- Default new animation clips to **Linear** (was Out); keep named presets as templates (Out Circ removed from the grid but still valid for old drafts/templates).
- Control points clamp to the plot box on all edges; custom curves drive live playback, release, export, drafts, and custom preset snapshots.

## UI
- 3×2 grid: Linear · Cubic · In · Out · In Out · **Custom**
- Selecting Custom reveals a compact Bezier editor under the tiles (same popover width; ~132px graph).
- Curve reset button (top-right of the plot) restores the default ease-in-out handles without clearing Speed / Return to default.

## Tests
- Extended `clip-easing` coverage: normalize/clamp, cubic-bezier eval, speed + custom, release curve, SVG path/dot, unit↔svg mapping, preset seeds.
- Draft hydration preserves `easingBezier`.
- Custom preset capture/apply preserves custom bezier.
- Animation playback defaults updated for linear default + custom bezier sample.

## Test plan
- [ ] Open Animate → select a clip → Transition; confirm grid is 6 tiles with Custom in the last slot
- [ ] New clip defaults to Linear
- [ ] Select Custom: editor appears without widening the popover; drag handles stay inside the box
- [ ] Play/scrub: motion follows the custom curve; Speed and Return to default still work
- [ ] Curve reset restores default handles; Transition header reset still resets full transition
- [ ] Save/reload draft keeps custom curve
- [ ] `pnpm typecheck` and `pnpm exec vitest run tests/lib/editor/clip-easing.test.ts tests/lib/editor/animation-playback.test.ts tests/lib/editor/store/draft-persistence.test.ts tests/lib/editor/custom-preset-snapshot.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom cubic-bezier easing for animation clips.
  * Added an interactive curve editor with draggable control points, coordinate labels, and reset support.
  * Custom easing can be selected, edited, previewed, and preserved in saved animation settings.
  * Added preset-to-custom curve editing and improved transition controls.
* **Changes**
  * New clips now use linear easing by default.
  * Updated easing previews and playback to support custom curves, including overshoot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds editable custom cubic-bezier transitions while preserving historical easing behavior for legacy clips and using linear easing for newly created clips.
- Adds a compact draggable cubic-bezier editor and Custom transition tile.
- Routes custom curves through playback, release, previews, drafts, and preset snapshots.
- Explicitly distinguishes legacy ease-out fallback from the linear default for new and reset clips.
- Clears stored custom handles when resetting the full transition.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the legacy fallback now preserves historical ease-out behavior, new clips explicitly use linear easing, and full transition reset clears stored custom handles.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/editor/animate/bezier-curve-editor.tsx | Adds the interactive, bounded cubic-bezier control-point editor and curve-only reset control. |
| components/editor/animate/clip-transition-toolbar.tsx | Integrates Custom easing selection and correctly clears custom handles during full transition reset. |
| components/editor/animate/easing-curve.tsx | Extends transition thumbnails and animated dots to render supplied custom curves. |
| lib/editor/clip-easing.ts | Adds normalized cubic-bezier evaluation while retaining ease-out for unset legacy clips and defining linear explicitly for new clips. |
| lib/editor/state-types.ts | Extends the animation clip contract with custom easing and optional cubic-bezier handles. |
| lib/editor/store.tsx | Writes explicit linear easing when genuinely new clips are created, avoiding reinterpretation of legacy persisted clips. |
| tests/lib/editor/clip-easing.test.ts | Covers custom curve normalization, evaluation, SVG mapping, speed, release behavior, and preset seeds. |
| tests/lib/editor/store/clip-return-to-default.test.ts | Verifies that transition reset removes stored custom handles under the store’s shallow-merge semantics. |
| tests/lib/editor/store/draft-persistence.test.ts | Verifies custom cubic-bezier handles survive draft persistence and hydration. |
| tests/lib/editor/custom-preset-snapshot.test.ts | Verifies custom easing data is retained through custom preset capture and application. |
| tests/lib/editor/animation-playback.test.ts | Updates playback expectations for explicit linear defaults and custom curve sampling. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(animate): preserve legacy ease-out a..."](https://github.com/shivabhattacharjee/tokokino/commit/0d43226c4d851e148d93fc7cdb857f08c4112bcf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49627624)</sub>

<!-- /greptile_comment -->