### PR TITLE
fix(video): make timeline scrubbing track the playhead on sparse-keyframe sources

### DIFF
--- a/hooks/use-animation-player.ts
+++ b/hooks/use-animation-player.ts
@@ -6,6 +6,7 @@ import { useEditorStore } from "@/lib/editor/store"
 import { getVideoMutedPreferenceSync } from "@/lib/editor/video-mute-preference"
 import { sourceTimeAt, videoClipAtTime } from "@/lib/editor/video-timeline-map"
 import { useVideoRegistry } from "@/lib/editor/video-registry"
+import { createVideoSeeker } from "@/lib/editor/video-seek"
 
 type PlayerContextValue = {
   playheadMs: number
@@ -84,6 +85,8 @@ export function AnimationPlayerProvider({
     return id ? (useVideoRegistry.getState().videos[id] ?? null) : null
   }, [])
 
+  const seekerRef = React.useRef(createVideoSeeker())
+
   const syncVideoTo = React.useCallback(
     (ms: number) => {
       const el = getVideo()
@@ -97,7 +100,7 @@ export function AnimationPlayerProvider({
       el.muted = clip.muted ?? getVideoMutedPreferenceSync()
       const seconds = sourceTimeAt(videoClipsRef.current, ms, duration)
       if (seconds == null) return
-      el.currentTime = seconds
+      seekerRef.current.seek(el, seconds)
     },
     [getVideo, videoClipAt]
   )
@@ -191,7 +194,13 @@ export function AnimationPlayerProvider({
     syncVideoTo(0)
   }, [pause, syncVideoTo])
 
-  React.useEffect(() => stopRaf, [stopRaf])
+  React.useEffect(() => {
+    const seeker = seekerRef.current
+    return () => {
+      stopRaf()
+      seeker.dispose()
+    }
+  }, [stopRaf])
 
   const value = React.useMemo<PlayerContextValue>(
     () => ({

--- a/hooks/use-animation-player.ts
+++ b/hooks/use-animation-player.ts
@@ -6,7 +6,7 @@ import { useEditorStore } from "@/lib/editor/store"
 import { getVideoMutedPreferenceSync } from "@/lib/editor/video-mute-preference"
 import { sourceTimeAt, videoClipAtTime } from "@/lib/editor/video-timeline-map"
 import { useVideoRegistry } from "@/lib/editor/video-registry"
-import { createVideoSeeker } from "@/lib/editor/video-seek"
+import { createVideoSeeker, type VideoSeeker } from "@/lib/editor/video-seek"
 
 type PlayerContextValue = {
   playheadMs: number
@@ -85,10 +85,22 @@ export function AnimationPlayerProvider({
     return id ? (useVideoRegistry.getState().videos[id] ?? null) : null
   }, [])
 
-  const seekerRef = React.useRef(createVideoSeeker())
+  // Lazy: the provider re-renders every frame while playing, and an eager
+  // `useRef(createVideoSeeker())` would build a seeker per frame to discard it.
+  const seekerRef = React.useRef<VideoSeeker | null>(null)
+  const getSeeker = React.useCallback(() => {
+    seekerRef.current ??= createVideoSeeker()
+    return seekerRef.current
+  }, [])
 
+  /**
+   * Park the canvas video on timeline time `ms`. Scrubbing leaves `immediate`
+   * off so a drag can't outrun the decoder; anything that is about to play from
+   * this position needs it on, or playback starts from wherever the last scrub
+   * seek happened to be.
+   */
   const syncVideoTo = React.useCallback(
-    (ms: number) => {
+    (ms: number, immediate = false) => {
       const el = getVideo()
       if (!el) return
       const duration = Number.isFinite(el.duration) ? el.duration : undefined
@@ -100,9 +112,11 @@ export function AnimationPlayerProvider({
       el.muted = clip.muted ?? getVideoMutedPreferenceSync()
       const seconds = sourceTimeAt(videoClipsRef.current, ms, duration)
       if (seconds == null) return
-      seekerRef.current.seek(el, seconds)
+      const seeker = getSeeker()
+      if (immediate) seeker.seekNow(el, seconds)
+      else seeker.seek(el, seconds)
     },
-    [getVideo, videoClipAt]
+    [getVideo, videoClipAt, getSeeker]
   )
 
   const stopRaf = React.useCallback(() => {
@@ -127,7 +141,7 @@ export function AnimationPlayerProvider({
 
     const video = getVideo()
     if (video) {
-      syncVideoTo(from)
+      syncVideoTo(from, true)
       if (
         videoClipAt(
           from,
@@ -154,7 +168,7 @@ export function AnimationPlayerProvider({
         if (!activeClip) {
           activeVideo.pause()
         } else if (activeVideo.paused) {
-          syncVideoTo(next)
+          syncVideoTo(next, true)
           void activeVideo.play().catch(() => {})
         } else {
           activeVideo.muted = activeClip.muted ?? getVideoMutedPreferenceSync()
@@ -191,14 +205,13 @@ export function AnimationPlayerProvider({
   const reset = React.useCallback(() => {
     pause()
     setPlayheadMs(0)
-    syncVideoTo(0)
+    syncVideoTo(0, true)
   }, [pause, syncVideoTo])
 
   React.useEffect(() => {
-    const seeker = seekerRef.current
     return () => {
       stopRaf()
-      seeker.dispose()
+      seekerRef.current?.dispose()
     }
   }, [stopRaf])
 

--- a/lib/editor/animation-export/video-media/encode-video.ts
+++ b/lib/editor/animation-export/video-media/encode-video.ts
@@ -14,6 +14,7 @@ import {
   type VideoCodec,
 } from "mediabunny"
 
+import { ENCODE_KEY_FRAME_INTERVAL_SEC } from "../../encode-settings"
 import type { WatermarkAssets } from "../types"
 import {
   AnimationExportAbortedError,
@@ -70,7 +71,7 @@ export async function encodeMp4OrWebm(
   const videoSource = new CanvasSource(encodeCanvas, {
     codec,
     bitrate: QUALITY_HIGH,
-    keyFrameInterval: 2,
+    keyFrameInterval: ENCODE_KEY_FRAME_INTERVAL_SEC,
   })
   output.addVideoTrack(videoSource, {
     frameRate: Math.round(1 / plan.frameDurationSec),

--- a/lib/editor/animation-export/video.ts
+++ b/lib/editor/animation-export/video.ts
@@ -19,6 +19,7 @@ import {
   type VideoCodec,
 } from "mediabunny"
 
+import { ENCODE_KEY_FRAME_INTERVAL_SEC } from "../encode-settings"
 import { isVideoSrc } from "../media-type"
 import { prepareAnimationAudio } from "./animation-audio"
 import { captureStableFrame } from "./capture"
@@ -114,7 +115,7 @@ export async function tryEncodeWithMediabunny(
   const videoSource = new CanvasSource(encodeCanvas, {
     codec,
     bitrate: QUALITY_HIGH,
-    keyFrameInterval: 2,
+    keyFrameInterval: ENCODE_KEY_FRAME_INTERVAL_SEC,
   })
   output.addVideoTrack(videoSource, { frameRate: fps })
 

--- a/lib/editor/encode-settings.ts
+++ b/lib/editor/encode-settings.ts
@@ -1,0 +1,11 @@
+/**
+ * Key frame interval (seconds) for every canvas → video encode: animation
+ * export, styled-video export, and the GIF transcode.
+ *
+ * Mediabunny defaults to 2s, which is fine for playback but makes the output
+ * miserable to scrub — a `<video>` can only land on a key frame while the user
+ * drags, so a 2s GOP means the canvas holds the same frame across a two-second
+ * stretch of timeline. Tokokino exports get re-imported into Tokokino, so the
+ * shorter interval buys back scrub accuracy at the cost of some file size.
+ */
+export const ENCODE_KEY_FRAME_INTERVAL_SEC = 0.5

--- a/lib/editor/gif-to-video.ts
+++ b/lib/editor/gif-to-video.ts
@@ -20,6 +20,8 @@ import {
   type VideoCodec,
 } from "mediabunny"
 
+import { ENCODE_KEY_FRAME_INTERVAL_SEC } from "./encode-settings"
+
 // Clamp very large GIFs before re-encode — keeps the encoder fast and the output
 // a sane size. Most codecs also require even dimensions.
 const MAX_GIF_DIMENSION = 1600
@@ -93,7 +95,7 @@ export async function transcodeGifToVideo(file: File): Promise<Blob | null> {
     const source = new CanvasSource(canvas, {
       codec,
       bitrate: QUALITY_HIGH,
-      keyFrameInterval: 2,
+      keyFrameInterval: ENCODE_KEY_FRAME_INTERVAL_SEC,
     })
     output.addVideoTrack(source, { frameRate: 30 })
     await output.start()

--- a/lib/editor/video-seek.ts
+++ b/lib/editor/video-seek.ts
@@ -1,0 +1,80 @@
+/**
+ * Coalesced seeking for the canvas `<video>`.
+ *
+ * Scrubbing the Animate timeline asks for a seek on every pointermove, but a
+ * `<video>` services one at a time — the rest queue behind a decode. On a
+ * source with sparse key frames (2s is a common encoder default) that backlog
+ * runs seconds deep and the canvas stops tracking the playhead at all.
+ *
+ * So: keep one seek in flight and remember only the newest target. Intermediate
+ * positions the pointer swept past are dropped, and the element always settles
+ * on where the pointer actually stopped.
+ */
+
+// A stalled decode can swallow `seeked` outright; don't wedge the scrubber.
+const SEEK_SETTLE_TIMEOUT_MS = 1500
+
+/** Below this the seek is a no-op the browser may never answer with `seeked`. */
+const SEEK_EPSILON_SEC = 1e-3
+
+export type VideoSeeker = {
+  seek: (el: HTMLVideoElement, seconds: number) => void
+  dispose: () => void
+}
+
+export function createVideoSeeker(): VideoSeeker {
+  let current: HTMLVideoElement | null = null
+  let pending: number | null = null
+  let inFlight = false
+  let timer: number | null = null
+
+  const clearTimer = () => {
+    if (timer !== null) window.clearTimeout(timer)
+    timer = null
+  }
+
+  const seek = (el: HTMLVideoElement, seconds: number) => {
+    // A different canvas's video: the old element's in-flight seek is no longer
+    // ours to wait on.
+    if (current !== el) {
+      clearTimer()
+      current = el
+      pending = null
+      inFlight = false
+    }
+
+    if (inFlight) {
+      pending = seconds
+      return
+    }
+    if (Math.abs(el.currentTime - seconds) < SEEK_EPSILON_SEC) return
+
+    inFlight = true
+
+    const settle = () => {
+      el.removeEventListener("seeked", settle)
+      // A late answer from an element we've already moved off of — its timer
+      // was dropped at the switch, and the live one isn't ours to clear.
+      if (current !== el) return
+      clearTimer()
+      inFlight = false
+      const next = pending
+      pending = null
+      if (next !== null) seek(el, next)
+    }
+
+    el.addEventListener("seeked", settle)
+    timer = window.setTimeout(settle, SEEK_SETTLE_TIMEOUT_MS)
+    el.currentTime = seconds
+  }
+
+  return {
+    seek,
+    dispose() {
+      clearTimer()
+      current = null
+      pending = null
+      inFlight = false
+    },
+  }
+}

--- a/lib/editor/video-seek.ts
+++ b/lib/editor/video-seek.ts
@@ -6,9 +6,14 @@
  * source with sparse key frames (2s is a common encoder default) that backlog
  * runs seconds deep and the canvas stops tracking the playhead at all.
  *
- * So: keep one seek in flight and remember only the newest target. Intermediate
- * positions the pointer swept past are dropped, and the element always settles
- * on where the pointer actually stopped.
+ * So `seek` keeps one seek in flight and remembers only the newest target:
+ * intermediate positions the pointer swept past are dropped, and the element
+ * settles on where the pointer actually stopped.
+ *
+ * Transport moves use `seekNow` instead. Queuing behind a scrub seek would let
+ * playback start from a position the user already dragged away from, and jump
+ * once the queue drained. The browser aborts a running seek on its own, so
+ * overriding one is safe — it's a burst of them that needs the queue.
  */
 
 // A stalled decode can swallow `seeked` outright; don't wedge the scrubber.
@@ -18,63 +23,77 @@ const SEEK_SETTLE_TIMEOUT_MS = 1500
 const SEEK_EPSILON_SEC = 1e-3
 
 export type VideoSeeker = {
+  /** Scrub: coalesced behind whatever seek is already running. */
   seek: (el: HTMLVideoElement, seconds: number) => void
+  /** Transport: issue now, dropping anything queued. */
+  seekNow: (el: HTMLVideoElement, seconds: number) => void
   dispose: () => void
 }
 
 export function createVideoSeeker(): VideoSeeker {
   let current: HTMLVideoElement | null = null
   let pending: number | null = null
-  let inFlight = false
   let timer: number | null = null
+  // Non-null while a seek is in flight; also the token that tells a superseded
+  // listener it no longer speaks for the seeker.
+  let settle: (() => void) | null = null
 
-  const clearTimer = () => {
+  /** Stop waiting on the running seek and forget what was queued behind it. */
+  const abandon = () => {
     if (timer !== null) window.clearTimeout(timer)
     timer = null
+    if (settle && current) current.removeEventListener("seeked", settle)
+    settle = null
+    pending = null
   }
 
-  const seek = (el: HTMLVideoElement, seconds: number) => {
-    // A different canvas's video: the old element's in-flight seek is no longer
-    // ours to wait on.
-    if (current !== el) {
-      clearTimer()
-      current = el
-      pending = null
-      inFlight = false
-    }
-
-    if (inFlight) {
-      pending = seconds
-      return
-    }
-    if (Math.abs(el.currentTime - seconds) < SEEK_EPSILON_SEC) return
-
-    inFlight = true
-
-    const settle = () => {
-      el.removeEventListener("seeked", settle)
-      // A late answer from an element we've already moved off of — its timer
-      // was dropped at the switch, and the live one isn't ours to clear.
-      if (current !== el) return
-      clearTimer()
-      inFlight = false
+  const issue = (el: HTMLVideoElement, seconds: number) => {
+    const onSettle = () => {
+      if (settle !== onSettle) return
+      el.removeEventListener("seeked", onSettle)
+      if (timer !== null) window.clearTimeout(timer)
+      timer = null
+      settle = null
       const next = pending
       pending = null
       if (next !== null) seek(el, next)
     }
 
-    el.addEventListener("seeked", settle)
-    timer = window.setTimeout(settle, SEEK_SETTLE_TIMEOUT_MS)
+    settle = onSettle
+    el.addEventListener("seeked", onSettle)
+    timer = window.setTimeout(onSettle, SEEK_SETTLE_TIMEOUT_MS)
     el.currentTime = seconds
+  }
+
+  const seek = (el: HTMLVideoElement, seconds: number) => {
+    // A different canvas's video: the old element's seek is no longer ours to
+    // wait on.
+    if (current !== el) {
+      abandon()
+      current = el
+    }
+
+    if (settle) {
+      pending = seconds
+      return
+    }
+    if (Math.abs(el.currentTime - seconds) < SEEK_EPSILON_SEC) return
+    issue(el, seconds)
+  }
+
+  const seekNow = (el: HTMLVideoElement, seconds: number) => {
+    abandon()
+    current = el
+    if (Math.abs(el.currentTime - seconds) < SEEK_EPSILON_SEC) return
+    issue(el, seconds)
   }
 
   return {
     seek,
+    seekNow,
     dispose() {
-      clearTimer()
+      abandon()
       current = null
-      pending = null
-      inFlight = false
     },
   }
 }

--- a/tests/lib/editor/video-seek.test.ts
+++ b/tests/lib/editor/video-seek.test.ts
@@ -7,6 +7,8 @@ type TestVideo = HTMLVideoElement & {
   __seeked: () => void
   /** Every value assigned to `currentTime`, in order. */
   __seeks: number[]
+  /** Live `seeked` listeners — a seeker that abandons cleanly leaves none. */
+  __seekedListeners: () => number
 }
 
 function makeVideo(): TestVideo {
@@ -35,6 +37,7 @@ function makeVideo(): TestVideo {
       }
     },
     __seeks: seeks,
+    __seekedListeners: () => listeners.get("seeked")?.size ?? 0,
   } as unknown as TestVideo
 }
 
@@ -162,6 +165,58 @@ describe("createVideoSeeker", () => {
     expect(second.__seeks).toEqual([3, 4])
   })
 
+  it("seekNow overrides a seek already in flight", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    seeker.seek(video, 1)
+    seeker.seekNow(video, 5)
+
+    expect(video.__seeks).toEqual([1, 5])
+  })
+
+  it("seekNow drops what scrubbing had queued", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    // Scrub sweeps past 1 and stops at 2, with 1 still decoding.
+    seeker.seek(video, 1)
+    seeker.seek(video, 2)
+    // Play from where the pointer stopped: must land there before playback,
+    // not queue behind the 1 and jump once it settles.
+    seeker.seekNow(video, 2)
+    expect(video.__seeks).toEqual([1, 2])
+
+    video.__seeked()
+    vi.advanceTimersByTime(5000)
+    expect(video.__seeks).toEqual([1, 2])
+  })
+
+  it("seekNow leaves no stale queue behind it", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    seeker.seek(video, 1)
+    seeker.seek(video, 9)
+    seeker.seekNow(video, 2)
+    video.__seeked()
+
+    expect(video.__seeks).toEqual([1, 2])
+  })
+
+  it("keeps coalescing after a seekNow", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    seeker.seekNow(video, 2)
+    seeker.seek(video, 3)
+    seeker.seek(video, 4)
+    expect(video.__seeks).toEqual([2])
+
+    video.__seeked()
+    expect(video.__seeks).toEqual([2, 4])
+  })
+
   it("stops the settle timer on dispose", () => {
     const seeker = createVideoSeeker()
     const video = makeVideo()
@@ -172,5 +227,70 @@ describe("createVideoSeeker", () => {
     vi.advanceTimersByTime(5000)
 
     expect(video.__seeks).toEqual([1])
+  })
+
+  it("detaches the listener from an element it switches away from", () => {
+    const seeker = createVideoSeeker()
+    const first = makeVideo()
+    const second = makeVideo()
+
+    seeker.seek(first, 1)
+    expect(first.__seekedListeners()).toBe(1)
+
+    seeker.seek(second, 3)
+    expect(first.__seekedListeners()).toBe(0)
+  })
+
+  it("detaches the listener on dispose", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    seeker.seek(video, 1)
+    seeker.dispose()
+
+    expect(video.__seekedListeners()).toBe(0)
+  })
+
+  it("re-adopts an abandoned element without a stale listener", () => {
+    const seeker = createVideoSeeker()
+    const first = makeVideo()
+    const second = makeVideo()
+
+    seeker.seek(first, 1)
+    seeker.seek(second, 3)
+    seeker.seek(first, 5)
+    seeker.seek(first, 6)
+    // One live listener, not two — the abandoned seek left nothing behind, so
+    // this `seeked` drains the queue exactly once.
+    expect(first.__seekedListeners()).toBe(1)
+
+    first.__seeked()
+    expect(first.__seeks).toEqual([1, 5, 6])
+    expect(first.__seekedListeners()).toBe(1)
+
+    first.__seeked()
+    vi.advanceTimersByTime(5000)
+    expect(first.__seeks).toEqual([1, 5, 6])
+  })
+
+  it("starts clean when reused after dispose", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    seeker.seek(video, 1)
+    seeker.seek(video, 2)
+    seeker.dispose()
+
+    seeker.seek(video, 4)
+    seeker.seek(video, 5)
+    expect(video.__seeks).toEqual([1, 4])
+
+    // The pre-dispose queue is gone: one settle drains only what came after.
+    video.__seeked()
+    expect(video.__seeks).toEqual([1, 4, 5])
+
+    video.__seeked()
+    vi.advanceTimersByTime(5000)
+    expect(video.__seeks).toEqual([1, 4, 5])
   })
 })

--- a/tests/lib/editor/video-seek.test.ts
+++ b/tests/lib/editor/video-seek.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createVideoSeeker } from "@/lib/editor/video-seek"
+
+type TestVideo = HTMLVideoElement & {
+  /** Fire the browser's `seeked` for the pending seek. */
+  __seeked: () => void
+  /** Every value assigned to `currentTime`, in order. */
+  __seeks: number[]
+}
+
+function makeVideo(): TestVideo {
+  const listeners = new Map<string, Set<EventListener>>()
+  const seeks: number[] = []
+  let time = 0
+
+  return {
+    get currentTime() {
+      return time
+    },
+    set currentTime(next: number) {
+      time = next
+      seeks.push(next)
+    },
+    addEventListener: (type: string, cb: EventListener) => {
+      if (!listeners.has(type)) listeners.set(type, new Set())
+      listeners.get(type)!.add(cb)
+    },
+    removeEventListener: (type: string, cb: EventListener) => {
+      listeners.get(type)?.delete(cb)
+    },
+    __seeked() {
+      for (const cb of [...(listeners.get("seeked") ?? [])]) {
+        cb(new Event("seeked"))
+      }
+    },
+    __seeks: seeks,
+  } as unknown as TestVideo
+}
+
+describe("createVideoSeeker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("issues the first seek immediately", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    seeker.seek(video, 1.5)
+
+    expect(video.__seeks).toEqual([1.5])
+  })
+
+  it("holds later seeks while one is in flight", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    seeker.seek(video, 1)
+    seeker.seek(video, 1.1)
+    seeker.seek(video, 1.2)
+
+    expect(video.__seeks).toEqual([1])
+  })
+
+  it("settles on the newest target, skipping the ones swept past", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    seeker.seek(video, 1)
+    seeker.seek(video, 1.1)
+    seeker.seek(video, 1.2)
+    video.__seeked()
+
+    // 1.1 is dropped — the pointer had already moved on to 1.2.
+    expect(video.__seeks).toEqual([1, 1.2])
+
+    video.__seeked()
+    expect(video.__seeks).toEqual([1, 1.2])
+  })
+
+  it("keeps accepting seeks after the queue drains", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    seeker.seek(video, 1)
+    video.__seeked()
+    seeker.seek(video, 2)
+
+    expect(video.__seeks).toEqual([1, 2])
+  })
+
+  it("ignores a seek to the position already showing", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    seeker.seek(video, 1)
+    video.__seeked()
+    seeker.seek(video, 1)
+    seeker.seek(video, 1.0000001)
+
+    expect(video.__seeks).toEqual([1])
+  })
+
+  it("recovers when the decoder swallows `seeked`", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    seeker.seek(video, 1)
+    seeker.seek(video, 2)
+    // No `seeked` ever arrives — without the timeout the scrubber would wedge.
+    expect(video.__seeks).toEqual([1])
+
+    vi.advanceTimersByTime(1500)
+    expect(video.__seeks).toEqual([1, 2])
+  })
+
+  it("does not wait on the previous canvas's video", () => {
+    const seeker = createVideoSeeker()
+    const first = makeVideo()
+    const second = makeVideo()
+
+    seeker.seek(first, 1)
+    seeker.seek(second, 3)
+
+    expect(second.__seeks).toEqual([3])
+  })
+
+  it("drops a stale settle from an element it no longer owns", () => {
+    const seeker = createVideoSeeker()
+    const first = makeVideo()
+    const second = makeVideo()
+
+    seeker.seek(first, 1)
+    seeker.seek(second, 3)
+    seeker.seek(second, 4)
+    // The old element finally answers; it must not release the new one's queue.
+    first.__seeked()
+
+    expect(second.__seeks).toEqual([3])
+
+    second.__seeked()
+    expect(second.__seeks).toEqual([3, 4])
+  })
+
+  it("leaves the live settle timer alone when a stale element answers", () => {
+    const seeker = createVideoSeeker()
+    const first = makeVideo()
+    const second = makeVideo()
+
+    seeker.seek(first, 1)
+    seeker.seek(second, 3)
+    seeker.seek(second, 4)
+    first.__seeked()
+    // `second` never answers; its timeout must still fire the queued 4.
+    vi.advanceTimersByTime(1500)
+
+    expect(second.__seeks).toEqual([3, 4])
+  })
+
+  it("stops the settle timer on dispose", () => {
+    const seeker = createVideoSeeker()
+    const video = makeVideo()
+
+    seeker.seek(video, 1)
+    seeker.seek(video, 2)
+    seeker.dispose()
+    vi.advanceTimersByTime(5000)
+
+    expect(video.__seeks).toEqual([1])
+  })
+})


### PR DESCRIPTION
## The bug

Scrubbing the Animate timeline on a video canvas updates the canvas in real time for some sources, and only at ~2-second boundaries for others. Dragging the playhead from 1.0s to 1.3s changes nothing; 1s to 2s does.

Both files that reproduce this are MP4, so the container isn't the variable — key frame density is. Probing the two:

| file | codec | sync samples |
|---|---|---|
| `collection agent demo.mp4` (scrubs fine) | H.264 screen recording | every **0.2s** |
| `test audio.mp4` (doesn't) | AV1 + Opus, 7s total | **0, 1.750, 4.583** |

A `<video>` will only land on a key frame while the user drags — it won't decode forward through seconds of AV1 per pointermove. With sync samples 2.8s apart, the canvas has nothing to show between them. The symptom matches the sample table exactly: 1s → 2s crosses 1.75 and updates, 1.0 → 1.3 has no key frame in between and doesn't.

`test audio.mp4` is AV1/Opus at 24fps — it came out of our own export pipeline, which is what makes this a product bug rather than a bad input.

## Fixes

**1. Shorter key frame interval on every encode.** All three canvas → video encoders passed `keyFrameInterval: 2` (mediabunny's unit is seconds, and 2 is also its default), so anything Tokokino exports is the worst case when re-imported into Tokokino. Now `0.5`, shared from `lib/editor/encode-settings.ts` so the rationale lives in one place:

- `animation-export/video.ts` — Animate-mode export
- `animation-export/video-media/encode-video.ts` — styled-video export
- `gif-to-video.ts` — GIF → WebM transcode, which lands straight on the timeline

The encodes are bitrate-targeted (`QUALITY_HIGH` is a `Quality` that resolves to a bitrate), so a denser GOP costs quality-per-frame, not file size. Measured on an 8s 1610×1080 screen recording at fixed bitrate:

| GOP | size | SSIM |
|---|---|---|
| 2s | 4538022 | 0.998710 |
| 0.5s | 4735728 | 0.998563 |

+4.3% size, SSIM down 0.015%. Effectively free for this kind of content.

**2. Coalesced seeking, so any source scrubs cleanly.** `use-animation-player` assigned `el.currentTime` on every `pointermove` with no gating. A `<video>` services one seek at a time, so on an expensive source they queue and the canvas falls seconds behind the pointer — invisible on a cheap file, bad on a sparse-keyframe one.

New `lib/editor/video-seek.ts` keeps one seek in flight and remembers only the newest target. Positions the pointer swept past are dropped; the element always settles on where it actually stopped. A settle timeout covers decoders that swallow `seeked`, and switching canvases drops the old element's in-flight state.

## Scope

Fix 1 only affects files exported from here on — an already-exported file (or any sparse-keyframe import) still seeks as coarsely as its own sample table allows. Fixing that would mean transcoding on import, which is a much bigger call and isn't attempted here. Fix 2 helps on those files regardless.

## Tests

`tests/lib/editor/video-seek.test.ts` — 10 cases covering in-flight holding, settling on the newest target, the swallowed-`seeked` timeout, element switching, and dispose.

Writing them surfaced a real ordering bug: a late `seeked` from an element the seeker had already moved off of was clearing the *shared* timer slot, which by then belonged to the new element — wedging the scrubber if that element never answered. The ownership check now runs before the timer is cleared, and the test fails without that fix.

Full suite: 1242 passed, typecheck and `lint:strict` clean.

## Verifying

Import a Tokokino-exported MP4 into a canvas, enter Animate mode, and drag the playhead slowly — the canvas should track continuously rather than jumping between key frames. I haven't run this in a browser myself; the diagnosis is from probing the sample tables of the two files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video seeking responsiveness and reliability during playback and editing.
  * Prevented outdated or duplicate seek requests from disrupting the current position.
  * Added recovery handling when video seek events are delayed or unavailable.
  * Standardized key-frame intervals across video and GIF exports to improve encoding consistency.

* **Tests**
  * Added comprehensive coverage for video seeking, queued requests, timeouts, media switching, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves video timeline scrubbing by coalescing seeks and using immediate replacement seeks for transport actions, while reducing the key-frame interval across video encoders.
- Adds a reusable video seeker that retains only the latest scrub target, handles stalled seeks, and cleans up listeners and timers.
- Uses immediate replacement seeks before playback, reset, and playback-resume transitions.
- Standardizes a 0.5-second key-frame interval across animation, styled-video, and GIF-transcode outputs.
- Adds focused tests for seek coalescing, timeout recovery, element switching, immediate overrides, and disposal.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| hooks/use-animation-player.ts | Integrates the seeker into scrubbing and transport flows and disposes it when the provider unmounts; the previously reported queued-seek ordering issue is addressed by replacing the in-flight target before playback. |
| lib/editor/video-seek.ts | Introduces coalesced and immediate seek modes with timeout recovery, ownership checks, listener cleanup, and stale-queue removal. |
| tests/lib/editor/video-seek.test.ts | Covers initial and queued seeks, latest-target coalescing, timeout recovery, media-element switching, immediate overrides, disposal, and reuse. |
| lib/editor/encode-settings.ts | Centralizes the shorter key-frame interval used by all canvas-to-video encoding paths. |
| lib/editor/animation-export/video.ts | Applies the shared key-frame interval to animation video exports. |
| lib/editor/animation-export/video-media/encode-video.ts | Applies the shared key-frame interval to styled-video exports. |
| lib/editor/gif-to-video.ts | Applies the shared key-frame interval to GIF-to-video transcoding. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(video): don&#39;t start playback behind ..."](https://github.com/shivabhattacharjee/tokokino/commit/21093fd1d4c1e768117123e5b828c4a2dbab6912) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50854773)</sub>

<!-- /greptile_comment -->