### PR TITLE
feat(animate): keyframe the screenshot and video colour grade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -543,7 +543,8 @@ AnimationClip = {
   target?: { scope: "all" } | { scope: "main" } | { scope: "slot"; slotId }
   effects?: AnimationEffect[]      // "position"|"zoom"|"tilt"|"padding"|"shadow"|
                                    // "background"|"backdrop"|"canvasRadius"|"lighting"|
-                                   // "filter"|"portrait"|"pattern"|"overlay"|"border"|
+                                   // "filter"|"mediaEffects"|"mediaFilter"|
+                                   // "portrait"|"pattern"|"overlay"|"border"|
                                    // "borderRadius"|"crop"
   pose?: ClipBaseline              // target values
   baseline?: ClipBaseline          // committed values the clip eases FROM
@@ -555,7 +556,8 @@ AnimationClip = {
 ```
 
 - Easing helpers and the custom cubic-bezier maths live in `lib/editor/clip-easing.ts`; the draggable graph is `animate/bezier-curve-editor.tsx`, wired up from `animate/clip-transition-toolbar.tsx`.
-- Only `tilt`, `zoom`, `shadow`, `position`, `border`, `borderRadius`, `padding`, and `lighting` can animate on an extra screenshot slot (`SLOT_ANIMATABLE_EFFECTS` in `store.tsx`); everything else is main-canvas only.
+- `backdrop`/`filter` animate the canvas backdrop's grade; `mediaEffects`/`mediaFilter` animate the screenshot or video's own pixels.
+- Only `tilt`, `zoom`, `shadow`, `position`, `border`, `borderRadius`, `padding`, `lighting`, `mediaEffects`, and `mediaFilter` can animate on an extra screenshot slot (`SLOT_ANIMATABLE_EFFECTS` in `store.tsx`); everything else is main-canvas only.
 - Adding a *new* animatable effect is a multi-file checklist — follow the Animate mode section in `agents.md`.
 
 ---

--- a/agents.md
+++ b/agents.md
@@ -247,7 +247,7 @@ Core files:
 ### Two interpolation shapes — pick the right one
 
 - **Numeric / interpolatable track** (tilt, zoom, padding, canvasRadius, shadow, border,
-  backdrop effects, lighting): sample with `sampleKeyframes<V>(framesFor(...), playhead,
+  backdrop effects, media colour grade, lighting): sample with `sampleKeyframes<V>(framesFor(...), playhead,
   restFor(...), lerpValue)`. Provide a `lerpValue(from, to, p)` (e.g. `borderBetween`,
   `shadowBetween`, `lightingBetween`). Drive the result onto a CSS var each frame; the
   renderer reads `var(--…, <committed>)`.
@@ -291,10 +291,16 @@ Core files:
   clip as owning the effect, so it silently won't animate.
 - **Stale IDE diagnostics** — after extending the `AnimationEffect` union the TS language
   server may still flag `"myEffect" does not exist`; `pnpm typecheck` is authoritative.
-- **Main vs slots** — only effects in `SLOT_ANIMATABLE_EFFECTS` (tilt/zoom/shadow) animate
+- **Main vs slots** — only effects in `SLOT_ANIMATABLE_EFFECTS` (transform/shadow/position/
+  border/radius/padding/lighting/media grade) animate
   on extra screenshot slots; canvas-wide effects are main-only (driven on `mainScopeEl`).
 - **"Remove effects"** on a clip must revert its pose to baseline AND clear
   `clip.effects` — see `clearAnimationClipEffects` in `store.tsx`.
+- **The committed canvas rests at the animation's START**, never at a keyframe's
+  look — `buildRestingPose`. A new effect gets this for free through
+  `EFFECT_MAIN_POSE_FIELDS` / `EFFECT_SLOT_POSE_FIELDS`, which is the whole
+  reason those maps are exhaustive; forget to add your effect there and it will
+  silently bind itself to the document on exit.
 
 ---
 

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -63,6 +63,18 @@ const releases: Release[] = [
         text: "With nothing selected a grade covers every screenshot on the canvas; select a single one first and it only changes that one.",
       },
       {
+        title: "Animate the grade",
+        text: "Screenshot and video grades are now keyframeable in Animate mode — fade a video from black and white into full colour, or ease brightness and saturation across a clip. Works on extra screenshots too, and carries through to video export.",
+      },
+      {
+        title: "Keyframes stop restyling your canvas",
+        text: "Leaving Animate mode used to leave the last keyframe's look painted onto the canvas, so a still export showed the end of the animation instead of your composition. The canvas now returns to where the animation starts.",
+      },
+      {
+        title: "Grades and filters export correctly in Safari",
+        text: "Video exports in Safari dropped every colour grade and filter preset from the finished file, even though the canvas showed them. They are now applied to the exported frames.",
+      },
+      {
         title: "Custom transition curves",
         text: "Pick Custom in the Animate transition menu and drag the two handles on the curve to shape exactly how a clip eases in and out, then set its speed in milliseconds.",
       },

--- a/components/editor/animate/timeline-clip.tsx
+++ b/components/editor/animate/timeline-clip.tsx
@@ -8,9 +8,11 @@ import {
   RiCropLine,
   RiDeleteBinLine,
   RiDragMove2Line,
+  RiEqualizerLine,
   RiEraserLine,
   RiFileCopyLine,
   RiLayoutGrid2Line,
+  RiMagicLine,
   RiMoonClearLine,
   RiPaletteLine,
   RiRotateLockLine,
@@ -110,6 +112,9 @@ const ICON_FOR: Record<ClipIconKey, typeof RiDragMove2Line> = {
   portrait: RiSunLine,
   pattern: RiSunLine,
   overlay: RiSunLine,
+  // The media grade has its own Effects / Filters controls — share their icons.
+  mediaEffects: RiEqualizerLine,
+  mediaFilter: RiMagicLine,
   // Border lives in its own inspector section — share its brush icon.
   border: RiBrushLine,
   borderRadius: RiBrushLine,

--- a/components/editor/inspector/background-section-parts/expand-toggle-tile.tsx
+++ b/components/editor/inspector/background-section-parts/expand-toggle-tile.tsx
@@ -4,6 +4,8 @@ import * as React from "react"
 import { RiArrowDownSLine, RiArrowUpSLine } from "@remixicon/react"
 import { motion } from "motion/react"
 
+import { cn } from "@/lib/utils"
+
 import { TILE_FADE_VARIANTS } from "./constants"
 
 export function ExpandToggleTile({
@@ -13,6 +15,8 @@ export function ExpandToggleTile({
   peekStyle,
   title,
   animate = true,
+  aspect = "video",
+  peekFit = "cover",
 }: {
   expanded: boolean
   onToggle: () => void
@@ -20,6 +24,9 @@ export function ExpandToggleTile({
   peekStyle?: React.CSSProperties
   title: string
   animate?: boolean
+  /** Matches the shape of the tiles this toggle sits among. */
+  aspect?: "video" | "square"
+  peekFit?: "cover" | "contain"
 }) {
   const Icon = expanded ? RiArrowUpSLine : RiArrowDownSLine
 
@@ -29,12 +36,18 @@ export function ExpandToggleTile({
       onClick={onToggle}
       title={title}
       aria-expanded={expanded}
-      className="group relative aspect-video w-full cursor-pointer overflow-hidden rounded-lg border border-border/60 bg-secondary/40 transition-colors hover:border-foreground/30"
+      className={cn(
+        "group relative w-full cursor-pointer overflow-hidden rounded-lg border border-border/60 bg-secondary/40 transition-colors hover:border-foreground/30",
+        aspect === "square" ? "aspect-square" : "aspect-video"
+      )}
     >
       {peekStyle ? (
         <span
           aria-hidden
-          className="absolute inset-0 scale-110 bg-cover bg-center blur-sm"
+          className={cn(
+            "absolute inset-0 scale-110 bg-center bg-no-repeat blur-sm",
+            peekFit === "contain" ? "bg-contain" : "bg-cover"
+          )}
           style={peekStyle}
         />
       ) : null}

--- a/components/editor/inspector/shapes-section.tsx
+++ b/components/editor/inspector/shapes-section.tsx
@@ -7,6 +7,10 @@ import type { ShapeEntry } from "@/lib/editor/state-types"
 import { useEditor } from "@/lib/editor/store"
 import { cn } from "@/lib/utils"
 
+import { ExpandToggleTile } from "./background-section-parts/expand-toggle-tile"
+
+/** Shapes shown before the library is expanded (+1 grid slot for the toggle). */
+const SHAPE_PREVIEW_COUNT = 8
 const SHAPE_BATCH = 24
 /** Distance from the bottom of the scroller that pulls in the next batch. */
 const LOAD_MORE_MARGIN = 240
@@ -54,20 +58,63 @@ export function ShapesSection({ flat = false }: { flat?: boolean } = {}) {
   } = useEditor()
 
   const wrapRef = React.useRef<HTMLDivElement>(null)
+  const gridRef = React.useRef<HTMLDivElement>(null)
   const scrollRootRef = React.useRef<HTMLElement | null>(null)
-  const [count, setCount] = React.useState(SHAPE_BATCH)
+  // How many shapes are rendered — and, at its floor, whether the section is
+  // still collapsed. One value rather than two, so expanding and paging can't
+  // disagree about what is on screen.
+  const [count, setCount] = React.useState(SHAPE_PREVIEW_COUNT)
+  const expanded = count > SHAPE_PREVIEW_COUNT
+  // Height of the collapsed preview grid. Expanding scrolls the full library
+  // inside exactly that box instead of pushing the rest of the inspector down.
+  const [collapsedHeight, setCollapsedHeight] = React.useState<number | null>(
+    null
+  )
+
+  React.useLayoutEffect(() => {
+    if (expanded) return
+    const grid = gridRef.current
+    if (!grid) return
+    const measure = () => {
+      const h = grid.offsetHeight
+      if (h > 0) setCollapsedHeight(h)
+    }
+    measure()
+    if (typeof ResizeObserver === "undefined") return
+    // The tiles are square, so the grid's height follows the panel's width —
+    // re-measure rather than freezing the height the section first opened at.
+    const observer = new ResizeObserver(measure)
+    observer.observe(grid)
+    return () => observer.disconnect()
+  }, [expanded])
 
   const loadMore = React.useCallback(() => {
     setCount((c) => Math.min(c + SHAPE_BATCH, SHAPE_LIBRARY.length))
   }, [])
+  const showAll = React.useCallback(() => {
+    setCount(SHAPE_LIBRARY.length)
+  }, [])
+  const toggleExpanded = React.useCallback(() => {
+    setCount((c) =>
+      c > SHAPE_PREVIEW_COUNT ? SHAPE_PREVIEW_COUNT : SHAPE_BATCH
+    )
+  }, [])
 
-  // Flat mode scrolls in an ancestor panel rather than in our own box, so the
-  // listener has to go on whichever element actually scrolls.
+  // Collapsed, the section is a fixed preview grid — there is nothing to page
+  // through, so the scroll listener and the top-up below only run once the user
+  // has asked for the whole library.
   React.useEffect(() => {
+    if (!expanded) {
+      scrollRootRef.current = null
+      return
+    }
+    // Flat mode scrolls in an ancestor panel rather than in our own box, so the
+    // listener has to go on whichever element actually scrolls.
     const root = flat ? findScrollParent(wrapRef.current) : wrapRef.current
     scrollRootRef.current = root
+    // Nothing scrolls, so no batch after this one could ever be reached.
     if (!root) {
-      setCount(SHAPE_LIBRARY.length)
+      showAll()
       return
     }
     const onScroll = () => {
@@ -80,15 +127,15 @@ export function ShapesSection({ flat = false }: { flat?: boolean } = {}) {
     }
     root.addEventListener("scroll", onScroll, { passive: true })
     return () => root.removeEventListener("scroll", onScroll)
-  }, [flat, loadMore])
+  }, [expanded, flat, loadMore, showAll])
 
   // A batch that doesn't overflow the scroller leaves nothing to scroll, so
   // the rest would be unreachable — keep topping up until it does.
   React.useEffect(() => {
     const root = scrollRootRef.current
-    if (!root || count >= SHAPE_LIBRARY.length) return
+    if (!expanded || !root || count >= SHAPE_LIBRARY.length) return
     if (root.scrollHeight <= root.clientHeight) loadMore()
-  }, [count, loadMore])
+  }, [count, expanded, loadMore])
 
   // Mirrors the toolbar's image-upload path so a shape behaves exactly like any
   // other asset once it lands on the canvas.
@@ -113,6 +160,11 @@ export function ShapesSection({ flat = false }: { flat?: boolean } = {}) {
 
   if (!SHAPE_LIBRARY.length) return null
 
+  const head = SHAPE_LIBRARY.slice(0, SHAPE_PREVIEW_COUNT)
+  const hiddenCount = SHAPE_LIBRARY.length - head.length
+  const peek = SHAPE_LIBRARY[SHAPE_PREVIEW_COUNT] ?? null
+  const shown = expanded ? SHAPE_LIBRARY.slice(0, count) : head
+
   return (
     <div className="space-y-2">
       <p className="px-1 text-[11px] text-muted-foreground">
@@ -122,16 +174,49 @@ export function ShapesSection({ flat = false }: { flat?: boolean } = {}) {
         ref={wrapRef}
         className={cn(
           "[contain:layout_paint]",
-          !flat && "max-h-[268px] overflow-y-auto overscroll-contain"
+          !flat && expanded && "overflow-y-auto overscroll-contain"
         )}
+        style={
+          !flat && expanded && collapsedHeight
+            ? { maxHeight: collapsedHeight }
+            : undefined
+        }
       >
         <div
+          ref={gridRef}
           className={cn(
             "grid gap-2 px-1 py-1",
             flat ? "grid-cols-4" : "grid-cols-3"
           )}
         >
-          {SHAPE_LIBRARY.slice(0, count).map((shape) => (
+          {head.map((shape) => (
+            <ShapeTile
+              key={shape.id}
+              shape={shape}
+              onClick={() => handleAdd(shape)}
+            />
+          ))}
+          {/* The toggle keeps its slot in the grid in both states, so expanding
+              reveals the rest after it instead of moving the control. */}
+          {hiddenCount > 0 ? (
+            <ExpandToggleTile
+              expanded={expanded}
+              onToggle={toggleExpanded}
+              hiddenCount={hiddenCount}
+              aspect="square"
+              peekFit="contain"
+              peekStyle={
+                peek ? { backgroundImage: `url("${peek.thumb}")` } : undefined
+              }
+              title={
+                expanded
+                  ? "Show fewer shapes"
+                  : `Show all ${SHAPE_LIBRARY.length} shapes`
+              }
+              animate={!flat}
+            />
+          ) : null}
+          {shown.slice(head.length).map((shape) => (
             <ShapeTile
               key={shape.id}
               shape={shape}

--- a/lib/editor/animation-export/capture.ts
+++ b/lib/editor/animation-export/capture.ts
@@ -7,7 +7,9 @@
 import {
   applyAnimationFrameAtTime,
   measureBareStageDims,
+  sampleMainMediaGrade,
 } from "../apply-animation-frame"
+import { clipAffectsMain, clipPose } from "../animation-playback"
 import {
   prepareAnimationCapture,
   prepareFastAnimationCapture,
@@ -410,6 +412,15 @@ export async function captureStableFrame(
       enhance: canvas.enhance,
       filter: canvas.mediaFilter,
       adjustments: canvas.mediaAdjustments,
+      // The layered path draws the decoded frame itself, so it never sees the
+      // grade var `applyExportFrame` just wrote. Hand it this frame's chain
+      // whenever a keyframe animates the grade; null keeps the committed one.
+      gradeCss: sampleMainMediaGrade(
+        canvas,
+        clips.filter(clipAffectsMain),
+        clipPose,
+        timeMs
+      ),
     },
   }).catch(() => null)
   if (layered) {

--- a/lib/editor/animation-export/video-layer.ts
+++ b/lib/editor/animation-export/video-layer.ts
@@ -206,6 +206,11 @@ export async function prepareCloneVideoLayer({
     return null
   }
 
+  // Must happen here: the <video> is loaded and still in the clone, and it sits
+  // at 0 so the decoded frame at 0 is the same picture. The swap below replaces
+  // it with an <img>, and the first frame requested is a clip's start, not 0.
+  await decoded.calibrateRange(video, 0)
+
   const frameImage = replaceVideoWithFrameImage(video)
   if (!frameImage) {
     decoded.cleanup()

--- a/lib/editor/animation-export/video-media/decoded-frames.ts
+++ b/lib/editor/animation-export/video-media/decoded-frames.ts
@@ -16,10 +16,31 @@ import {
   registerDav1dAv1Decoder,
 } from "./dav1d-av1-decoder"
 import { AnimationExportAbortedError, throwIfAborted } from "../utils"
+import {
+  decodedNeedsRangeExpansion,
+  drawVideoReference,
+  expandLimitedRange,
+  isFrameCanvas,
+  type FrameCanvas,
+} from "./frame-range"
 
 export type DecodedFrameSource = {
   /** Decoded frame whose start timestamp is ≤ `t` seconds, or null if none. */
   getFrameAt: (t: number) => Promise<CanvasImageSource | null>
+  /**
+   * Check whether this engine's decode leaves frames in studio swing, and start
+   * repairing them if so — see `frame-range.ts`.
+   *
+   * `reference` must be a `<video>` on this same clip, loaded and sitting at
+   * `atSeconds`: the test compares the two conversions of ONE picture, so a
+   * mismatched time would compare content instead of conversions. Call it before
+   * the first `getFrameAt` and before anything detaches that element. Skipping it
+   * entirely just passes frames through as decoded.
+   */
+  calibrateRange: (
+    reference: HTMLVideoElement,
+    atSeconds?: number
+  ) => Promise<void>
   cleanup: () => void
 }
 
@@ -101,7 +122,19 @@ export async function createDecodedFrameSource(
     let chosen: WrappedCanvas | null = null
     let lastT = -Infinity
 
-    return {
+    // Set by calibrateRange; until then frames pass through untouched.
+    let expandRange = false
+    // poolSize 0 gives every frame its own canvas, but one canvas is handed out
+    // for every output frame that lands on it — expand each exactly once.
+    const expanded = new WeakSet<object>()
+    const repair = (canvas: FrameCanvas) => {
+      if (!expandRange || expanded.has(canvas)) return canvas
+      expandLimitedRange(canvas)
+      expanded.add(canvas)
+      return canvas
+    }
+
+    const source: DecodedFrameSource = {
       getFrameAt: async (t) => {
         // A backward jump (e.g. GIF's palette pass restarting at 0) cannot be
         // served by the forward-only iterator, so restart it from that time.
@@ -123,13 +156,25 @@ export async function createDecodedFrameSource(
             buffered = null
           } else break
         }
-        return chosen?.canvas ?? null
+        return chosen ? repair(chosen.canvas) : null
+      },
+      calibrateRange: async (reference, atSeconds = 0) => {
+        const native = drawVideoReference(reference)
+        if (!native) return
+        // Measured BEFORE any repair — this frame is the evidence.
+        const decodedFrame = await source.getFrameAt(atSeconds)
+        if (!decodedFrame || !isFrameCanvas(decodedFrame)) return
+        expandRange = decodedNeedsRangeExpansion(decodedFrame, native)
+        // The frame just measured is handed out again for the first output
+        // frame, so repair it now rather than letting one frame through raw.
+        if (expandRange) repair(decodedFrame)
       },
       cleanup: () => {
         void frames.return(undefined)
         boundInput.dispose()
       },
     }
+    return source
   } catch (error) {
     input?.dispose()
     // Cancellation must propagate — swallowing it to null would make the caller

--- a/lib/editor/animation-export/video-media/frame-grade.ts
+++ b/lib/editor/animation-export/video-media/frame-grade.ts
@@ -1,0 +1,350 @@
+/**
+ * Canvas-2D fallback for the media grade.
+ *
+ * WebKit accepts an assignment to `ctx.filter` and then ignores it, so on Safari
+ * the screenshot/video grade silently vanished from every exported frame that
+ * paints decoded pixels by hand — which, on that engine, is every frame of a
+ * video export (the layered and composite renderers both draw the frame
+ * themselves and re-apply what CSS would have done).
+ *
+ * Every leg of the chain except `blur()` is a per-pixel function from the Filter
+ * Effects spec, and they all compose into one affine colour matrix, so a graded
+ * frame costs a single pass. Blur is the only leg that has to run on its own.
+ */
+
+type ColorMatrix = {
+  /** Row-major 3×3 linear part (RGB in, RGB out). */
+  m: [number, number, number, number, number, number, number, number, number]
+  /** Per-channel offset, in 0..1 units. */
+  o: [number, number, number]
+  /** Alpha multiplier (only `opacity()` moves it). */
+  a: number
+}
+
+type GradeOp =
+  | { kind: "matrix"; matrix: ColorMatrix }
+  | { kind: "blur"; px: number }
+
+const IDENTITY: ColorMatrix = {
+  m: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+  o: [0, 0, 0],
+  a: 1,
+}
+
+const LUMA = [0.2126, 0.7152, 0.0722] as const
+
+const isIdentity = (c: ColorMatrix) =>
+  c.a === 1 &&
+  c.o[0] === 0 &&
+  c.o[1] === 0 &&
+  c.o[2] === 0 &&
+  c.m[0] === 1 &&
+  c.m[1] === 0 &&
+  c.m[2] === 0 &&
+  c.m[3] === 0 &&
+  c.m[4] === 1 &&
+  c.m[5] === 0 &&
+  c.m[6] === 0 &&
+  c.m[7] === 0 &&
+  c.m[8] === 1
+
+/** `b` applied after `a`. */
+function compose(a: ColorMatrix, b: ColorMatrix): ColorMatrix {
+  const m = Array.from({ length: 9 }, (_, i) => {
+    const row = Math.floor(i / 3) * 3
+    const col = i % 3
+    return (
+      b.m[row] * a.m[col] +
+      b.m[row + 1] * a.m[3 + col] +
+      b.m[row + 2] * a.m[6 + col]
+    )
+  }) as ColorMatrix["m"]
+  const o = Array.from({ length: 3 }, (_, row) => {
+    const r = row * 3
+    return (
+      b.m[r] * a.o[0] + b.m[r + 1] * a.o[1] + b.m[r + 2] * a.o[2] + b.o[row]
+    )
+  }) as ColorMatrix["o"]
+  return { m, o, a: a.a * b.a }
+}
+
+/** Per-channel `c → c·scale + offset`. */
+const linear = (scale: number, offset: number): ColorMatrix => ({
+  m: [scale, 0, 0, 0, scale, 0, 0, 0, scale],
+  o: [offset, offset, offset],
+  a: 1,
+})
+
+/** Blend `matrix` toward identity, the shape every "amount" filter takes. */
+const lerpToIdentity = (
+  full: ColorMatrix["m"],
+  amount: number
+): ColorMatrix => {
+  const k = 1 - amount
+  return {
+    m: [
+      full[0] * amount + k,
+      full[1] * amount,
+      full[2] * amount,
+      full[3] * amount,
+      full[4] * amount + k,
+      full[5] * amount,
+      full[6] * amount,
+      full[7] * amount,
+      full[8] * amount + k,
+    ],
+    o: [0, 0, 0],
+    a: 1,
+  }
+}
+
+function saturateMatrix(s: number): ColorMatrix {
+  const [lr, lg, lb] = LUMA
+  return {
+    m: [
+      lr + (1 - lr) * s,
+      lg - lg * s,
+      lb - lb * s,
+      lr - lr * s,
+      lg + (1 - lg) * s,
+      lb - lb * s,
+      lr - lr * s,
+      lg - lg * s,
+      lb + (1 - lb) * s,
+    ],
+    o: [0, 0, 0],
+    a: 1,
+  }
+}
+
+function hueRotateMatrix(deg: number): ColorMatrix {
+  const rad = (deg * Math.PI) / 180
+  const c = Math.cos(rad)
+  const s = Math.sin(rad)
+  return {
+    m: [
+      0.213 + c * 0.787 - s * 0.213,
+      0.715 - c * 0.715 - s * 0.715,
+      0.072 - c * 0.072 + s * 0.928,
+      0.213 - c * 0.213 + s * 0.143,
+      0.715 + c * 0.285 + s * 0.14,
+      0.072 - c * 0.072 - s * 0.283,
+      0.213 - c * 0.213 - s * 0.787,
+      0.715 - c * 0.715 + s * 0.715,
+      0.072 + c * 0.928 + s * 0.072,
+    ],
+    o: [0, 0, 0],
+    a: 1,
+  }
+}
+
+const GRAYSCALE_FULL: ColorMatrix["m"] = [
+  LUMA[0],
+  LUMA[1],
+  LUMA[2],
+  LUMA[0],
+  LUMA[1],
+  LUMA[2],
+  LUMA[0],
+  LUMA[1],
+  LUMA[2],
+]
+
+const SEPIA_FULL: ColorMatrix["m"] = [
+  0.393, 0.769, 0.189, 0.349, 0.686, 0.168, 0.272, 0.534, 0.131,
+]
+
+/** `120%` → 1.2, `1.2` → 1.2, `30deg` → 30, `0.5px` → 0.5. */
+function filterAmount(raw: string): number {
+  const value = parseFloat(raw)
+  if (!Number.isFinite(value)) return 0
+  return raw.trim().endsWith("%") ? value / 100 : value
+}
+
+/**
+ * Split a filter chain into an ordered op list, collapsing every run of colour
+ * functions into one matrix. Returns null when a leg isn't recognised, so the
+ * caller can leave the frame alone rather than paint a half-applied grade.
+ */
+export function parseGradeChain(chain: string): GradeOp[] | null {
+  const ops: GradeOp[] = []
+  let pending = IDENTITY
+  const flush = () => {
+    if (isIdentity(pending)) return
+    ops.push({ kind: "matrix", matrix: pending })
+    pending = IDENTITY
+  }
+
+  const legs = chain.match(/[a-z-]+\([^)]*\)/gi)
+  if (!legs) return chain.trim() === "" || chain.trim() === "none" ? [] : null
+
+  for (const leg of legs) {
+    const open = leg.indexOf("(")
+    const name = leg.slice(0, open).trim().toLowerCase()
+    const arg = leg.slice(open + 1, -1).trim()
+    const amount = filterAmount(arg)
+    switch (name) {
+      case "blur":
+        flush()
+        if (amount > 0) ops.push({ kind: "blur", px: amount })
+        break
+      case "brightness":
+        pending = compose(pending, linear(amount, 0))
+        break
+      case "contrast":
+        pending = compose(pending, linear(amount, 0.5 - 0.5 * amount))
+        break
+      case "invert":
+        pending = compose(pending, linear(1 - 2 * amount, amount))
+        break
+      case "opacity":
+        pending = compose(pending, { ...IDENTITY, a: amount })
+        break
+      case "grayscale":
+        pending = compose(pending, lerpToIdentity(GRAYSCALE_FULL, amount))
+        break
+      case "sepia":
+        pending = compose(pending, lerpToIdentity(SEPIA_FULL, amount))
+        break
+      case "saturate":
+        pending = compose(pending, saturateMatrix(amount))
+        break
+      case "hue-rotate":
+        pending = compose(pending, hueRotateMatrix(amount))
+        break
+      default:
+        return null
+    }
+  }
+  flush()
+  return ops
+}
+
+function applyMatrix(data: Uint8ClampedArray, c: ColorMatrix) {
+  const [m0, m1, m2, m3, m4, m5, m6, m7, m8] = c.m
+  const or = c.o[0] * 255
+  const og = c.o[1] * 255
+  const ob = c.o[2] * 255
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i]
+    const g = data[i + 1]
+    const b = data[i + 2]
+    data[i] = m0 * r + m1 * g + m2 * b + or
+    data[i + 1] = m3 * r + m4 * g + m5 * b + og
+    data[i + 2] = m6 * r + m7 * g + m8 * b + ob
+    if (c.a !== 1) data[i + 3] = data[i + 3] * c.a
+  }
+}
+
+/**
+ * One separable box-blur pass, edge-clamped, reading `src` into `dst` (they must
+ * differ — a sliding window can't blur in place). Three passes approximate a
+ * gaussian closely enough for a grade's blur leg.
+ */
+function boxBlurPass(
+  src: Uint8ClampedArray,
+  dst: Uint8ClampedArray,
+  lines: number,
+  lineStride: number,
+  count: number,
+  stride: number,
+  radius: number
+) {
+  const norm = 1 / (radius * 2 + 1)
+  for (let line = 0; line < lines; line++) {
+    const base = line * lineStride
+    for (let ch = 0; ch < 4; ch++) {
+      let sum = 0
+      for (let k = -radius; k <= radius; k++) {
+        const i = k < 0 ? 0 : k >= count ? count - 1 : k
+        sum += src[base + i * stride + ch]
+      }
+      for (let x = 0; x < count; x++) {
+        dst[base + x * stride + ch] = sum * norm
+        const addI = x + radius + 1
+        const subI = x - radius
+        const a = addI >= count ? count - 1 : addI
+        const s = subI < 0 ? 0 : subI
+        sum += src[base + a * stride + ch] - src[base + s * stride + ch]
+      }
+    }
+  }
+}
+
+function applyBlur(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+  px: number
+) {
+  const radius = Math.round(px)
+  if (radius < 1) return
+  // Six passes total (3 gaussian approximations × horizontal + vertical), each
+  // reading one buffer into the other, so the result lands back in `data`.
+  const scratch = new Uint8ClampedArray(data.length)
+  for (let pass = 0; pass < 3; pass++) {
+    boxBlurPass(data, scratch, height, width * 4, width, 4, radius)
+    boxBlurPass(scratch, data, width, 4, height, width * 4, radius)
+  }
+}
+
+let canvasFilterWorks: boolean | null = null
+
+/**
+ * Whether `ctx.filter` actually paints. WebKit accepts the assignment and
+ * ignores it, so a chain set there silently no-ops. Probed once by drawing a
+ * white pixel through `brightness(0)` and checking it came out black.
+ */
+export function supportsCanvas2dFilter(): boolean {
+  if (canvasFilterWorks !== null) return canvasFilterWorks
+  try {
+    const c = document.createElement("canvas")
+    c.width = 1
+    c.height = 1
+    const cx = c.getContext("2d", { willReadFrequently: true })
+    if (!cx) return (canvasFilterWorks = false)
+    cx.fillStyle = "#ffffff"
+    cx.fillRect(0, 0, 1, 1)
+    cx.filter = "brightness(0)"
+    cx.fillStyle = "#ffffff"
+    cx.fillRect(0, 0, 1, 1)
+    cx.filter = "none"
+    canvasFilterWorks = cx.getImageData(0, 0, 1, 1).data[0] < 20
+  } catch {
+    canvasFilterWorks = false
+  }
+  return canvasFilterWorks
+}
+
+/**
+ * Apply `chain` to `canvas`'s pixels in place. No-op when the chain is empty or
+ * has a leg this doesn't model — better an ungraded frame than a wrong one.
+ *
+ * Reads the buffer back, which the draw-only surfaces this runs on otherwise
+ * avoid; that cost only lands on engines whose `ctx.filter` doesn't work, and
+ * only when the user actually graded the media.
+ */
+export function applyGradeToCanvas(
+  canvas: HTMLCanvasElement,
+  chain: string
+): void {
+  const ops = parseGradeChain(chain)
+  if (!ops || ops.length === 0) return
+  // Plain `getContext("2d")` on purpose: the buffer already has a context, and
+  // attributes passed after the first call are ignored, so asking for
+  // `willReadFrequently` here would only misdescribe what we get back.
+  const ctx = canvas.getContext("2d")
+  if (!ctx || canvas.width === 0 || canvas.height === 0) return
+
+  let image: ImageData
+  try {
+    image = ctx.getImageData(0, 0, canvas.width, canvas.height)
+  } catch {
+    return
+  }
+  for (const op of ops) {
+    if (op.kind === "matrix") applyMatrix(image.data, op.matrix)
+    else applyBlur(image.data, canvas.width, canvas.height, op.px)
+  }
+  ctx.putImageData(image, 0, 0)
+}

--- a/lib/editor/animation-export/video-media/frame-grade.ts
+++ b/lib/editor/animation-export/video-media/frame-grade.ts
@@ -320,6 +320,16 @@ export function supportsCanvas2dFilter(): boolean {
  * Apply `chain` to `canvas`'s pixels in place. No-op when the chain is empty or
  * has a leg this doesn't model — better an ungraded frame than a wrong one.
  *
+ * The alpha channel is put back exactly as it was found. The native path sets
+ * `ctx.filter` on a clipped draw, so its filter lands *inside* the rounded media
+ * box; this one runs on the whole buffer after that clip has been popped, and
+ * `blur()` spreads alpha — which would soften the rounded corners and bleed the
+ * media into the transparent padding. Restoring alpha is the same mask the clip
+ * already left behind, so it reproduces "filter, then clip" without a second
+ * composite. Nothing is lost: `opacity()` is the only leg that means to move
+ * alpha, and it cannot appear here (only `BackdropEffects` carries an opacity,
+ * and the backdrop does not come through this path).
+ *
  * Reads the buffer back, which the draw-only surfaces this runs on otherwise
  * avoid; that cost only lands on engines whose `ctx.filter` doesn't work, and
  * only when the user actually graded the media.
@@ -342,9 +352,15 @@ export function applyGradeToCanvas(
   } catch {
     return
   }
+  const { data } = image
+  const alpha = new Uint8ClampedArray(data.length / 4)
+  for (let i = 0, a = 0; i < data.length; i += 4, a++) alpha[a] = data[i + 3]
+
   for (const op of ops) {
-    if (op.kind === "matrix") applyMatrix(image.data, op.matrix)
-    else applyBlur(image.data, canvas.width, canvas.height, op.px)
+    if (op.kind === "matrix") applyMatrix(data, op.matrix)
+    else applyBlur(data, canvas.width, canvas.height, op.px)
   }
+
+  for (let i = 0, a = 0; i < data.length; i += 4, a++) data[i + 3] = alpha[a]
   ctx.putImageData(image, 0, 0)
 }

--- a/lib/editor/animation-export/video-media/frame-inner-lighting.ts
+++ b/lib/editor/animation-export/video-media/frame-inner-lighting.ts
@@ -34,6 +34,12 @@ export type VideoMediaFx = {
   /** Manual media colour grade. */
   adjustments?: MediaAdjustments | null
   /**
+   * The whole grade chain, already resolved, used instead of `filter` +
+   * `adjustments`. Animate mode blends both across a keyframe, and the result
+   * is a channel mix no `AssetFilter` names.
+   */
+  gradeCss?: string | null
+  /**
    * Export pixels per CSS pixel for the box being painted. Only `blur()` needs
    * it — it is the one length in the grade, and a 2D canvas at export scale
    * does not stretch it the way a rasterized CSS filter does.

--- a/lib/editor/animation-export/video-media/frame-range.ts
+++ b/lib/editor/animation-export/video-media/frame-range.ts
@@ -1,0 +1,144 @@
+/**
+ * Limited→full range repair for WebCodecs-decoded frames.
+ *
+ * Studio-swing video carries luma in 16–235, and whoever converts it to RGB is
+ * supposed to stretch that back to 0–255. WebKit's `VideoFrame` → canvas
+ * conversion does not: a probe of the same clip in one Safari run measured a
+ * black floor of 15 and a white ceiling of 234 from the decoded path, against 0
+ * from the very same file drawn through a native `<video>`. Blacks sitting at
+ * 16/255 grey with the highlights pulled down to 235 is exactly the "washed out"
+ * export — and it is the decoded path only, which is why Chromium (which
+ * rasterizes the `<video>` itself) was always fine.
+ *
+ * The repair is the stretch that was skipped. It is applied at the decode source
+ * so every consumer — the plain video export and the Animate keyframe export
+ * alike — gets corrected frames without knowing about any of this.
+ */
+
+/** Studio-swing luma bounds, the range the decoder left the pixels in. */
+const LIMITED_BLACK = 16
+const LIMITED_WHITE = 235
+const LIMITED_SPAN = LIMITED_WHITE - LIMITED_BLACK
+
+/**
+ * A decoded frame is judged limited-range by comparing it against the browser's
+ * OWN conversion of the same picture, so the test is about the conversion rather
+ * than the content — a dark clip does not read as limited-range, and a correct
+ * engine is never "corrected".
+ *
+ * The margin is wide: a genuine mismatch moves the floor by ~16 levels, while
+ * two correct conversions of one frame differ only by resampling noise.
+ */
+const BLACK_FLOOR_MARGIN = 8
+
+export type FrameLevels = { black: number; white: number }
+
+/** Mediabunny yields either kind depending on the engine. Both read the same. */
+export type FrameCanvas = HTMLCanvasElement | OffscreenCanvas
+
+/** The 2D context of either canvas kind, narrowed to what this module uses. */
+type Ctx2d = Pick<CanvasRenderingContext2D, "getImageData" | "putImageData">
+
+function context2d(canvas: FrameCanvas): Ctx2d | null {
+  return canvas.getContext("2d", { willReadFrequently: true })
+}
+
+/** Luma floor and ceiling over a sample of opaque pixels, or null if none. */
+export function canvasLevels(canvas: FrameCanvas): FrameLevels | null {
+  try {
+    const ctx = context2d(canvas)
+    if (!ctx || !canvas.width || !canvas.height) return null
+    const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height)
+    let black = 255
+    let white = 0
+    let seen = false
+    // Every 13th pixel: the extremes of a photographic frame survive this, and
+    // it keeps the setup probe off the critical path at 1080p.
+    for (let i = 0; i < data.length; i += 4 * 13) {
+      if (data[i + 3] < 250) continue
+      const luma =
+        0.2126 * data[i] + 0.7152 * data[i + 1] + 0.0722 * data[i + 2]
+      if (luma < black) black = luma
+      if (luma > white) white = luma
+      seen = true
+    }
+    return seen ? { black, white } : null
+  } catch {
+    return null
+  }
+}
+
+/** Narrow a decoded frame to the canvas kinds this module can measure. */
+export function isFrameCanvas(frame: unknown): frame is FrameCanvas {
+  return (
+    (typeof HTMLCanvasElement !== "undefined" &&
+      frame instanceof HTMLCanvasElement) ||
+    (typeof OffscreenCanvas !== "undefined" && frame instanceof OffscreenCanvas)
+  )
+}
+
+/** Draw `video`'s current frame small, via the engine's own conversion. */
+export function drawVideoReference(
+  video: HTMLVideoElement
+): HTMLCanvasElement | null {
+  try {
+    const w = video.videoWidth
+    const h = video.videoHeight
+    if (!w || !h) return null
+    const canvas = document.createElement("canvas")
+    canvas.width = Math.min(480, w)
+    canvas.height = Math.max(1, Math.round((canvas.width * h) / w))
+    const ctx = canvas.getContext("2d", { willReadFrequently: true })
+    if (!ctx) return null
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height)
+    return canvas
+  } catch {
+    return null
+  }
+}
+
+/**
+ * True when `decoded` sits in studio swing while `reference` — the same picture
+ * through the engine's native path — does not.
+ *
+ * Undecidable cases return false: correcting on a guess would crush the blacks
+ * of every engine that already converts properly.
+ */
+export function decodedNeedsRangeExpansion(
+  decoded: FrameCanvas,
+  reference: FrameCanvas
+): boolean {
+  const d = canvasLevels(decoded)
+  const r = canvasLevels(reference)
+  if (!d || !r) return false
+  // The decoded floor has to actually sit at studio black, not merely above the
+  // reference — a frame whose darkest pixel is legitimately mid-grey must not
+  // qualify however the two compare.
+  const atStudioBlack =
+    d.black >= LIMITED_BLACK - 4 && d.black <= LIMITED_BLACK + 4
+  return atStudioBlack && d.black - r.black >= BLACK_FLOOR_MARGIN
+}
+
+/**
+ * Stretch 16–235 back to 0–255, in place. Per-channel and affine, which is the
+ * correct inverse when the decoder applied the YUV→RGB matrix but skipped the
+ * range scaling — the omission is the same on all three channels.
+ */
+export function expandLimitedRange(canvas: FrameCanvas): void {
+  try {
+    const ctx = context2d(canvas)
+    if (!ctx || !canvas.width || !canvas.height) return
+    const image = ctx.getImageData(0, 0, canvas.width, canvas.height)
+    const { data } = image
+    const scale = 255 / LIMITED_SPAN
+    const offset = -LIMITED_BLACK * scale
+    for (let i = 0; i < data.length; i += 4) {
+      data[i] = data[i] * scale + offset
+      data[i + 1] = data[i + 1] * scale + offset
+      data[i + 2] = data[i + 2] * scale + offset
+    }
+    ctx.putImageData(image, 0, 0)
+  } catch {
+    // A tainted canvas can't be repaired; leave the frame as decoded.
+  }
+}

--- a/lib/editor/animation-export/video-media/frame-renderer.ts
+++ b/lib/editor/animation-export/video-media/frame-renderer.ts
@@ -23,6 +23,7 @@
 
 import { supportsObjectViewBox } from "../../crop-utils"
 import { mediaFilterCss, scaleFilterBlur } from "../../css-utils"
+import { applyGradeToCanvas, supportsCanvas2dFilter } from "./frame-grade"
 import type { AnimationCapture } from "../../export"
 import { drawPortraitDepthOfField } from "../capture"
 import { waitForPaint } from "../utils"
@@ -162,24 +163,32 @@ export function paintFrameToLocalBox(
     dy = parsePos(pos[1], buf.height - dh)
   }
 
-  try {
-    const grade = mediaFx
-      ? scaleFilterBlur(
+  // WebKit ignores `ctx.filter`, so there the grade is painted over the drawn
+  // pixels instead (see frame-grade). Resolved before the draw because the
+  // native path has to set `filter` on the same call.
+  const grade = mediaFx
+    ? scaleFilterBlur(
+        mediaFx.gradeCss ??
           mediaFilterCss({
             enhance: mediaFx.enhance,
             filter: mediaFx.filter,
             adjustments: mediaFx.adjustments,
           }),
-          mediaFx.pixelScale ?? 1
-        )
-      : ""
-    if (grade) ctx.filter = grade
+        mediaFx.pixelScale ?? 1
+      )
+    : ""
+  const nativeGrade = grade ? supportsCanvas2dFilter() : true
+
+  try {
+    if (grade && nativeGrade) ctx.filter = grade
     ctx.drawImage(frame, 0, 0, fw, fh, dx, dy, dw, dh)
   } catch {
     return null
   } finally {
     ctx.restore()
   }
+
+  if (grade && !nativeGrade) applyGradeToCanvas(buf, grade)
 
   return buf
 }

--- a/lib/editor/animation-export/video-media/index.ts
+++ b/lib/editor/animation-export/video-media/index.ts
@@ -127,6 +127,10 @@ async function encodeVideoMedia(
       ? null
       : await createDecodedFrameSource(canvas.screenshot, signal)
 
+    // The clone's <video> is loaded and parked at 0, and the decoded frame at 0
+    // is the same picture — the pairing the range test needs.
+    await decoded?.calibrateRange(cloneVideo, 0)
+
     const tilt = canvas.tilt
     const tilted = !!tilt && (tilt.rx !== 0 || tilt.ry !== 0 || tilt.rz !== 0)
     // The composite renderer owns the decoded pixels. Re-apply media effects

--- a/lib/editor/animation-playback.ts
+++ b/lib/editor/animation-playback.ts
@@ -9,6 +9,14 @@
 
 import { clipProgressEase, clipReleaseEase, clipReleaseMs } from "./clip-easing"
 import { hexToRgb } from "./color-utils"
+import {
+  assetFilterCss,
+  assetFilterVector,
+  filterVectorBetween,
+  filterVectorCss,
+  NEUTRAL_MEDIA_ADJUSTMENTS,
+  type FilterVector,
+} from "./css-utils"
 import { DEFAULT_CANVAS_BASE } from "./store/defaults"
 import type {
   AnimationClip,
@@ -23,6 +31,7 @@ import type {
   ClipBaseline,
   ClipSlotPose,
   CropRegion,
+  MediaAdjustments,
   Overlay,
   Portrait,
   ScreenshotPosition,
@@ -54,6 +63,9 @@ export const DEFAULT_BASELINE: ClipBaseline = {
   lighting: DEFAULT_CANVAS_BASE.backdrop.lighting,
   background: DEFAULT_CANVAS_BASE.background,
   filter: DEFAULT_CANVAS_BASE.backdrop.filter,
+  mediaAdjustments:
+    DEFAULT_CANVAS_BASE.mediaAdjustments ?? NEUTRAL_MEDIA_ADJUSTMENTS,
+  mediaFilter: DEFAULT_CANVAS_BASE.mediaFilter ?? "none",
   portrait: DEFAULT_CANVAS_BASE.portrait,
   pattern: DEFAULT_CANVAS_BASE.backdrop.pattern,
   overlay: DEFAULT_CANVAS_BASE.overlay,
@@ -550,6 +562,63 @@ export function backdropEffectsBetween(
     invert: lerp(from.invert, to.invert, p),
     opacity: lerp(from.opacity, to.opacity, p),
   }
+}
+
+/** Colour grade on the screenshot/video pixels at progress p, channel by channel. */
+export function mediaAdjustmentsBetween(
+  from: MediaAdjustments,
+  to: MediaAdjustments,
+  p: number
+): MediaAdjustments {
+  return {
+    blur: lerp(from.blur, to.blur, p),
+    brightness: lerp(from.brightness, to.brightness, p),
+    contrast: lerp(from.contrast, to.contrast, p),
+    saturation: lerp(from.saturation, to.saturation, p),
+    hue: lerp(from.hue, to.hue, p),
+    grayscale: lerp(from.grayscale, to.grayscale, p),
+    sepia: lerp(from.sepia, to.sepia, p),
+    invert: lerp(from.invert, to.invert, p),
+  }
+}
+
+/**
+ * A sampled media filter preset: either a named preset (the sample sits on a
+ * keyframe) or the channel mix between two of them.
+ *
+ * Keeping the preset name alongside the channels is what lets an unblended
+ * sample emit `assetFilterCss`'s own chain, so the value the player drives at
+ * the end of a keyframe is byte-identical to the committed one it settles into.
+ */
+export type MediaFilterBlend = {
+  preset: AssetFilter | null
+  vector: FilterVector
+}
+
+export function mediaFilterBlendOf(filter: AssetFilter): MediaFilterBlend {
+  return { preset: filter, vector: assetFilterVector(filter) }
+}
+
+export function mediaFilterBlendBetween(
+  from: MediaFilterBlend,
+  to: MediaFilterBlend,
+  p: number
+): MediaFilterBlend {
+  if (p <= 0) return from
+  if (p >= 1) return to
+  if (from.preset !== null && from.preset === to.preset) return from
+  return {
+    preset: null,
+    vector: filterVectorBetween(from.vector, to.vector, p),
+  }
+}
+
+export function mediaFilterBlendCss(
+  blend: MediaFilterBlend
+): string | undefined {
+  return blend.preset !== null
+    ? assetFilterCss(blend.preset)
+    : filterVectorCss(blend.vector)
 }
 
 /**
@@ -1172,10 +1241,23 @@ export function poseAtCut(
         p
       )
     }
+    if (owns("mediaEffects")) {
+      const from = fromPose.mediaAdjustments ?? NEUTRAL_MEDIA_ADJUSTMENTS
+      mid.mediaAdjustments = mediaAdjustmentsBetween(
+        from,
+        toPose.mediaAdjustments ?? from,
+        p
+      )
+    }
     if (owns("background")) {
       mid.background = disc(fromPose.background, toPose.background)
     }
     if (owns("filter")) mid.filter = disc(fromPose.filter, toPose.filter)
+    // The media filter blends channel-wise at playback, but a keyframe pose has
+    // to name one preset — so the cut lands on whichever half it is nearer.
+    if (owns("mediaFilter")) {
+      mid.mediaFilter = disc(fromPose.mediaFilter, toPose.mediaFilter)
+    }
     if (owns("portrait"))
       mid.portrait = disc(fromPose.portrait, toPose.portrait)
     if (owns("pattern")) mid.pattern = disc(fromPose.pattern, toPose.pattern)
@@ -1215,6 +1297,10 @@ export function poseAtCut(
     if (owns("lighting") && f.lighting && tp.lighting) {
       s.lighting = lightingBetween(f.lighting, tp.lighting, p)
     }
+    if (owns("mediaEffects") && f.adjustments && tp.adjustments) {
+      s.adjustments = mediaAdjustmentsBetween(f.adjustments, tp.adjustments, p)
+    }
+    if (owns("mediaFilter")) s.filter = disc(f.filter, tp.filter)
     mid.slots[id] = s
   }
 

--- a/lib/editor/apply-animation-frame.ts
+++ b/lib/editor/apply-animation-frame.ts
@@ -54,6 +54,11 @@ import {
   lightingEntranceRest,
   lightingBetween,
   lightingTargetMixAt,
+  mediaAdjustmentsBetween,
+  mediaFilterBlendBetween,
+  mediaFilterBlendCss,
+  mediaFilterBlendOf,
+  type MediaFilterBlend,
   NEUTRAL_SLOT_POSE,
   REST_LIGHTING,
   sampleKeyframes,
@@ -65,12 +70,20 @@ import {
   borderOffsetCss,
   borderOutlineCss,
   effectsFilterCss,
+  MAIN_MEDIA_FX_PREVIEW_VAR,
+  mediaFilterCss,
+  NEUTRAL_MEDIA_ADJUSTMENTS,
   SCREENSHOT_RADIUS_PREVIEW_VAR,
   shadowCss,
   shadowDropFilterCss,
   SHADOW_FILTER_PREVIEW_VAR,
   SHADOW_PREVIEW_VAR,
+  slotMediaFxPreviewVar,
 } from "@/lib/editor/css-utils"
+import {
+  resolveMainScreenshotStyle,
+  resolveSlotScreenshotStyle,
+} from "@/lib/editor/store/canvas-helpers"
 import {
   CROP_ANIMATION_VARS,
   CROP_FIT_ORIGIN_VAR,
@@ -96,14 +109,17 @@ import {
 import { captureClipPose } from "@/lib/editor/store"
 import type {
   AnimationClip,
+  AnimationEffect,
   AspectState,
   BackdropEffects,
   BackdropLighting,
   Border,
   CanvasState,
   ClipBaseline,
+  AssetFilter,
   ClipSlotPose,
   CropRegion,
+  MediaAdjustments,
   ScreenshotPosition,
   Shadow,
   Tilt,
@@ -114,6 +130,89 @@ const INVISIBLE_SHADOW: Shadow = {
   intensity: 0,
   color: "#000000",
   lightSource: "center",
+}
+
+/**
+ * One screenshot's whole grade chain (enhance → filter preset → colour grade)
+ * for this frame, in the form `buildScreenshotImageStyle`'s var expects.
+ *
+ * Both halves share one var, so a keyframe that animates only one of them still
+ * has to emit the committed value for the other — otherwise driving the var
+ * would silently drop it. A neutral result still writes `brightness(1)` rather
+ * than an empty string: the var has to WIN over the committed chain in its own
+ * fallback, and an empty value would let that chain back through.
+ */
+function mediaGradeChain(
+  enhance: CanvasState["enhance"],
+  blend: MediaFilterBlend | null,
+  adjustments: MediaAdjustments | null,
+  committed: { filter: AssetFilter; adjustments: MediaAdjustments }
+): string {
+  return (
+    mediaFilterCss({
+      enhance,
+      filter: blend ? undefined : committed.filter,
+      filterCss: blend ? (mediaFilterBlendCss(blend) ?? "") : undefined,
+      adjustments: adjustments ?? committed.adjustments,
+    }) || "brightness(1)"
+  )
+}
+
+/**
+ * The main screenshot's grade chain at `timeMs`, or null when no keyframe
+ * animates either half of it (the committed chain then shows through).
+ *
+ * Exported because a video export never renders the media through CSS: the
+ * decoded frames are drawn onto a 2D canvas and re-graded by hand, so the
+ * encoder has to ask for the very value the player would have written.
+ */
+export function sampleMainMediaGrade(
+  canvas: CanvasState,
+  mainClips: AnimationClip[],
+  poseOf: (clip: AnimationClip) => ClipBaseline,
+  timeMs: number
+): string | null {
+  const track = <V>(
+    effect: AnimationEffect,
+    value: (pose: ClipBaseline) => V,
+    lerpValue: (from: V, to: V, p: number) => V
+  ): V | null => {
+    const owners = mainClips
+      .filter((c) => clipOwns(c, effect))
+      .sort((a, b) => a.startMs - b.startMs)
+    if (owners.length === 0) return null
+    return sampleKeyframes<V>(
+      owners.map((c) => ({
+        startMs: c.startMs,
+        durationMs: c.durationMs,
+        value: value(poseOf(c)),
+        ease: clipProgressEase(c),
+        releaseMs: clipReleaseMs(c),
+        releaseEase: clipReleaseEase(c),
+      })),
+      timeMs,
+      value(clipBaseline(owners[0])),
+      lerpValue
+    )
+  }
+
+  const filterVal = track<MediaFilterBlend>(
+    "mediaFilter",
+    (pz) => mediaFilterBlendOf(pz.mediaFilter ?? "none"),
+    mediaFilterBlendBetween
+  )
+  const adjVal = track<MediaAdjustments>(
+    "mediaEffects",
+    (pz) => pz.mediaAdjustments ?? NEUTRAL_MEDIA_ADJUSTMENTS,
+    mediaAdjustmentsBetween
+  )
+  if (!filterVal && !adjVal) return null
+  return mediaGradeChain(
+    canvas.enhance,
+    filterVal,
+    adjVal,
+    resolveMainScreenshotStyle(canvas)
+  )
 }
 
 const tiltLerp = (a: Tilt, b: Tilt, p: number): Tilt => ({
@@ -148,6 +247,7 @@ const SCOPE_VARS = [
 const CROP_VARS = CROP_ANIMATION_VARS
 const CANVAS_FX_VARS = [
   BG_OPACITY_VAR,
+  MAIN_MEDIA_FX_PREVIEW_VAR,
   ...CROP_VARS,
   BACKDROP_FX_PREVIEW_VAR,
   BACKDROP_NOISE_PREVIEW_VAR,
@@ -229,6 +329,8 @@ export function clearAnimationFrameVars(
       for (const v of SLOT_FX_VARS) setVar(slotEl, v, null)
       setVar(slotEl, SHADOW_PREVIEW_VAR, null)
       setVar(slotEl, SHADOW_FILTER_PREVIEW_VAR, null)
+      const slotId = slotEl.dataset.screenshotSlotId
+      if (slotId) setVar(slotEl, slotMediaFxPreviewVar(slotId), null)
       clearPositionPreviewVars(slotEl)
     })
 }
@@ -765,6 +867,13 @@ export function applyAnimationFrameAtTime({
       setVar(canvasEl, BACKDROP_NOISE_PREVIEW_VAR, null)
     }
 
+    // media grade (screenshot/video pixels)
+    setVar(
+      canvasEl,
+      MAIN_MEDIA_FX_PREVIEW_VAR,
+      sampleMainMediaGrade(canvas, mainClips, poseOf, playheadMs)
+    )
+
     // crop (video only) — the source rect, never the laid-out box: the canvas
     // aspect keeps reading the committed region so the encoder's frame size is
     // constant. Both render paths get their var because browser support for
@@ -860,6 +969,7 @@ export function applyAnimationFrameAtTime({
       for (const v of SLOT_FX_VARS) setVar(slotEl, v, null)
       setVar(slotEl, SHADOW_PREVIEW_VAR, null)
       setVar(slotEl, SHADOW_FILTER_PREVIEW_VAR, null)
+      setVar(slotEl, slotMediaFxPreviewVar(slot.id), null)
       clearPositionPreviewVars(slotEl)
       continue
     }
@@ -1110,5 +1220,50 @@ export function applyAnimationFrameAtTime({
       setVar(slotEl, `${LIGHTING_IMAGE_VAR}-in`, null)
       setVar(slotEl, `${LIGHTING_OPACITY_VAR}-in`, null)
     }
+
+    const slotMedia = resolveSlotScreenshotStyle(slot, canvas)
+    const slotFilterVal = sampleKeyframes<MediaFilterBlend>(
+      slotClips
+        .filter((c) => clipOwns(c, "mediaFilter"))
+        .map((c) => ({
+          startMs: c.startMs,
+          durationMs: c.durationMs,
+          value: mediaFilterBlendOf(slotPoseOf(c).filter ?? slotMedia.filter),
+          ease: clipProgressEase(c),
+          releaseMs: clipReleaseMs(c),
+          releaseEase: clipReleaseEase(c),
+        })),
+      playheadMs,
+      mediaFilterBlendOf(
+        slotRestFor("mediaFilter", (sp) => sp?.filter, slotMedia.filter)
+      ),
+      mediaFilterBlendBetween
+    )
+    const slotAdjVal = sampleKeyframes<MediaAdjustments>(
+      slotClips
+        .filter((c) => clipOwns(c, "mediaEffects"))
+        .map((c) => ({
+          startMs: c.startMs,
+          durationMs: c.durationMs,
+          value: slotPoseOf(c).adjustments ?? slotMedia.adjustments,
+          ease: clipProgressEase(c),
+          releaseMs: clipReleaseMs(c),
+          releaseEase: clipReleaseEase(c),
+        })),
+      playheadMs,
+      slotRestFor(
+        "mediaEffects",
+        (sp) => sp?.adjustments,
+        slotMedia.adjustments
+      ),
+      mediaAdjustmentsBetween
+    )
+    setVar(
+      slotEl,
+      slotMediaFxPreviewVar(slot.id),
+      slotFilterVal || slotAdjVal
+        ? mediaGradeChain(canvas.enhance, slotFilterVal, slotAdjVal, slotMedia)
+        : null
+    )
   }
 }

--- a/lib/editor/css-utils.ts
+++ b/lib/editor/css-utils.ts
@@ -40,6 +40,125 @@ export function assetFilterCss(filter: AssetFilter): string | undefined {
   }
 }
 
+/**
+ * A filter preset expressed as numbers so two presets can be blended.
+ * `assetFilterCss` hands back a ready-made string, and there is no way to ease
+ * one string into another — Animate mode needs the channels.
+ *
+ * Multiplier channels are 1 at neutral, amount channels 0, `hueRotate` in
+ * degrees and `blur` in px.
+ */
+export type FilterVector = {
+  blur: number
+  grayscale: number
+  sepia: number
+  saturate: number
+  hueRotate: number
+  brightness: number
+  contrast: number
+  invert: number
+}
+
+export const NEUTRAL_FILTER_VECTOR: FilterVector = {
+  blur: 0,
+  grayscale: 0,
+  sepia: 0,
+  saturate: 1,
+  hueRotate: 0,
+  brightness: 1,
+  contrast: 1,
+  invert: 0,
+}
+
+const filterVector = (v: Partial<FilterVector>): FilterVector => ({
+  ...NEUTRAL_FILTER_VECTOR,
+  ...v,
+})
+
+/** The channel values behind each preset in `assetFilterCss`. */
+export function assetFilterVector(filter: AssetFilter): FilterVector {
+  switch (filter) {
+    case "bw":
+      return filterVector({ grayscale: 1, contrast: 1.05 })
+    case "sepia":
+      return filterVector({ sepia: 0.85, saturate: 1.1 })
+    case "vintage":
+      return filterVector({
+        sepia: 0.4,
+        contrast: 0.95,
+        saturate: 0.9,
+        hueRotate: -10,
+      })
+    case "warm":
+      return filterVector({ saturate: 1.15, hueRotate: -12, brightness: 1.04 })
+    case "cool":
+      return filterVector({ saturate: 1.1, hueRotate: 15, brightness: 1.02 })
+    case "fade":
+      return filterVector({ contrast: 0.85, brightness: 1.08, saturate: 0.85 })
+    case "vivid":
+      return filterVector({ saturate: 1.5, contrast: 1.15 })
+    case "noir":
+      return filterVector({ grayscale: 1, contrast: 1.35, brightness: 0.9 })
+    case "dream":
+      return filterVector({
+        blur: 0.5,
+        saturate: 1.2,
+        brightness: 1.05,
+        contrast: 0.95,
+      })
+    case "mono":
+      return filterVector({ grayscale: 1, sepia: 0.3, contrast: 1.05 })
+    case "invert":
+      return filterVector({ invert: 1, hueRotate: 180 })
+    case "none":
+    default:
+      return NEUTRAL_FILTER_VECTOR
+  }
+}
+
+export function filterVectorBetween(
+  from: FilterVector,
+  to: FilterVector,
+  p: number
+): FilterVector {
+  const mix = (a: number, b: number) => a + (b - a) * p
+  return {
+    blur: mix(from.blur, to.blur),
+    grayscale: mix(from.grayscale, to.grayscale),
+    sepia: mix(from.sepia, to.sepia),
+    saturate: mix(from.saturate, to.saturate),
+    hueRotate: mix(from.hueRotate, to.hueRotate),
+    brightness: mix(from.brightness, to.brightness),
+    contrast: mix(from.contrast, to.contrast),
+    invert: mix(from.invert, to.invert),
+  }
+}
+
+const round3 = (n: number) => Number(n.toFixed(3))
+
+/**
+ * A blended preset as a filter chain.
+ *
+ * The leg order is not the one `assetFilterCss` writes per preset, because a
+ * single fixed order has to serve every blend. `grayscale` stays ahead of
+ * `sepia` (the reverse would flatten "mono"'s tint to plain grey); the rest are
+ * a linear matrix, a scalar, and an affine, which commute closely enough that
+ * the two chains agree to well under a 1/255 step. Only used mid-blend anyway —
+ * a sample sitting on one preset emits that preset's own chain verbatim.
+ */
+export function filterVectorCss(v: FilterVector): string | undefined {
+  const parts: string[] = []
+  if (v.blur > 0) parts.push(`blur(${round3(v.blur)}px)`)
+  if (v.grayscale > 0) parts.push(`grayscale(${round3(v.grayscale)})`)
+  if (v.sepia > 0) parts.push(`sepia(${round3(v.sepia)})`)
+  if (v.saturate !== 1) parts.push(`saturate(${round3(v.saturate)})`)
+  if (v.hueRotate !== 0) parts.push(`hue-rotate(${round3(v.hueRotate)}deg)`)
+  if (v.brightness !== 1) parts.push(`brightness(${round3(v.brightness)})`)
+  if (v.contrast !== 1) parts.push(`contrast(${round3(v.contrast)})`)
+  if (v.invert > 0) parts.push(`invert(${round3(v.invert)})`)
+  return parts.length ? parts.join(" ") : undefined
+}
+
 export function patternCssFor(
   id: number,
   color: string,
@@ -208,15 +327,26 @@ export function scaleFilterBlur(filter: string, scale: number): string {
 export function mediaFilterCss({
   enhance,
   filter,
+  filterCss,
   adjustments,
 }: {
   enhance?: EnhancePreset | null
   filter?: AssetFilter | null
+  /**
+   * Ready-made filter-preset legs, used instead of resolving `filter`. Animate
+   * mode blends between two presets, and the result is a channel mix that no
+   * single `AssetFilter` names.
+   */
+  filterCss?: string | null
   adjustments?: MediaAdjustments | null
 }): string {
   return [
     enhance ? enhanceFilterCss(enhance) : undefined,
-    filter ? assetFilterCss(filter) : undefined,
+    filterCss !== undefined && filterCss !== null
+      ? filterCss || undefined
+      : filter
+        ? assetFilterCss(filter)
+        : undefined,
     adjustments ? effectsFilterCss(adjustments) : undefined,
   ]
     .filter(Boolean)

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -414,6 +414,8 @@ export type AnimationEffect =
   | "canvasRadius"
   | "lighting"
   | "filter"
+  | "mediaEffects"
+  | "mediaFilter"
   | "portrait"
   | "pattern"
   | "overlay"
@@ -452,6 +454,10 @@ export type ClipSlotPose = {
   borderRadius?: number
   padding?: number
   lighting?: BackdropLighting
+  /** Filter preset on this slot's own pixels. */
+  filter?: AssetFilter
+  /** Colour grade on this slot's own pixels. */
+  adjustments?: MediaAdjustments
 }
 
 export type ClipBaseline = {
@@ -466,6 +472,10 @@ export type ClipBaseline = {
   lighting?: BackdropLighting
   background: Background
   filter?: AssetFilter
+  /** Colour grade on the screenshot/video pixels (not the backdrop). */
+  mediaAdjustments?: MediaAdjustments
+  /** Filter preset on the screenshot/video pixels (not the backdrop). */
+  mediaFilter?: AssetFilter
   portrait?: Portrait
   pattern?: BackdropPattern
   overlay?: Overlay

--- a/lib/editor/store.tsx
+++ b/lib/editor/store.tsx
@@ -4,6 +4,7 @@ import { create } from "zustand"
 
 import { DEFAULT_CLIP_DURATION_MS } from "./animation-motion"
 import { NEW_CLIP_EASING } from "./clip-easing"
+import { NEUTRAL_MEDIA_ADJUSTMENTS } from "./css-utils"
 import {
   clipAffectsMain,
   clipAffectsSlot,
@@ -126,6 +127,8 @@ const SLOT_ANIMATABLE_EFFECTS: AnimationEffect[] = [
   "borderRadius",
   "padding",
   "lighting",
+  "mediaEffects",
+  "mediaFilter",
 ]
 
 /** Canvas.animation is optional (older drafts) — always read through this. */
@@ -149,6 +152,8 @@ export const captureClipPose = (canvas: CanvasState): ClipBaseline => {
     lighting: main.lighting,
     background: canvas.background,
     filter: canvas.backdrop.filter,
+    mediaAdjustments: main.adjustments,
+    mediaFilter: main.filter,
     portrait: canvas.portrait,
     pattern: canvas.backdrop.pattern,
     overlay: canvas.overlay,
@@ -175,6 +180,8 @@ export const captureClipPose = (canvas: CanvasState): ClipBaseline => {
             borderRadius: style.borderRadius,
             padding: style.padding,
             lighting: style.lighting,
+            filter: style.filter,
+            adjustments: style.adjustments,
           },
         ]
       })
@@ -217,6 +224,10 @@ const applyPoseToCanvas = (
   border: pose.border ?? canvas.border,
   // Fall back to the live value for poses captured before radius animated.
   borderRadius: pose.borderRadius ?? canvas.borderRadius,
+  // Fall back to the live values for poses captured before the media grade
+  // animated.
+  mediaAdjustments: pose.mediaAdjustments ?? canvas.mediaAdjustments,
+  mediaFilter: pose.mediaFilter ?? canvas.mediaFilter,
   lastCropRegion: poseCrop(pose, canvas.lastCropRegion),
   backdrop: {
     ...canvas.backdrop,
@@ -250,69 +261,108 @@ const applyPoseToCanvas = (
       ...(sp.borderRadius != null ? { borderRadius: sp.borderRadius } : {}),
       ...(sp.padding != null ? { padding: sp.padding } : {}),
       ...(sp.lighting ? { lighting: sp.lighting } : {}),
+      ...(sp.filter ? { filter: sp.filter } : {}),
+      ...(sp.adjustments ? { adjustments: sp.adjustments } : {}),
     }
   }),
 })
 
-/** Overlay only the xPct/yPct of `from` onto each matching slot in `slots`,
- * keeping every other slot field. Lets a slot rest at one point while carrying
- * another pose's tilt/scale/shadow. */
-const overlaySlotPositions = (
-  slots: Record<string, ClipSlotPose>,
-  from: Record<string, ClipSlotPose>
-): Record<string, ClipSlotPose> =>
-  Object.fromEntries(
-    Object.entries(slots).map(([id, sp]) => {
-      const p = from[id]
-      return [
-        id,
-        p && p.xPct != null && p.yPct != null
-          ? { ...sp, xPct: p.xPct, yPct: p.yPct }
-          : sp,
-      ]
-    })
-  )
-
 /**
- * The pose the static/committed canvas holds while it carries an animation.
- * Every effect rests at the animation's FINAL frame (the last clip's pose) so
- * reveals settle into their end look — EXCEPT position, which is a "move", not an
- * entrance: a screenshot that animates center → bottom must sit at its START
- * (center) statically and in PNG export, then travel away on play. So position
- * resolves to the first position clip's baseline while every other field keeps
- * the end frame.
+ * The pose the static/committed canvas holds while it carries an animation:
+ * where the animation STARTS.
+ *
+ * Every effect resolves to the first keyframe that owns it — the value that
+ * keyframe eases FROM — and an effect no keyframe owns keeps the canvas's own
+ * committed value. So an animation stays a *description of motion* rather than
+ * a style edit: leaving Animate mode never repaints the document with the last
+ * keyframe's look, and the still/PNG export shows the composition the user
+ * built, not the end of its animation. (Position always worked this way; the
+ * rest used to rest at the final frame.)
  */
 const buildRestingPose = (
+  canvas: CanvasState,
   clips: readonly AnimationClip[]
 ): ClipBaseline | null => {
+  if (clips.length === 0) return null
   const sorted = [...clips].sort((a, b) => a.startMs - b.startMs)
-  const last = sorted[sorted.length - 1]
-  if (!last) return null
-  const end = clipPose(last)
-  const posClips = sorted.filter((c) => (c.effects ?? []).includes("position"))
-  if (posClips.length === 0) return end
+  const committed = captureClipPose(canvas)
+  const rest: ClipBaseline = { ...committed, slots: { ...committed.slots } }
+  const restRec = rest as Record<string, unknown>
 
-  const firstMainPos = posClips.find((c) => clipAffectsMain(c))
-  const mainStart = firstMainPos ? clipBaseline(firstMainPos) : null
-
-  const startSlots: Record<string, ClipSlotPose> = {}
-  for (const id of Object.keys(end.slots)) {
-    const first = posClips.find(
-      (c) => clipAffectsSlot(c, id) && clipBaseline(c).slots[id]
+  for (const effect of ANIMATION_EFFECTS) {
+    const firstMain = sorted.find(
+      (c) => clipAffectsMain(c) && clipOwnsEffect(c, effect)
     )
-    if (first) startSlots[id] = clipBaseline(first).slots[id]
+    if (firstMain) {
+      const base = clipBaseline(firstMain) as unknown as Record<string, unknown>
+      for (const field of EFFECT_MAIN_POSE_FIELDS[effect]) {
+        if (base[field] !== undefined) restRec[field] = base[field]
+      }
+    }
+
+    const slotFields = EFFECT_SLOT_POSE_FIELDS[effect]
+    if (!slotFields) continue
+    for (const slotId of Object.keys(rest.slots)) {
+      const firstSlot = sorted.find(
+        (c) => clipAffectsSlot(c, slotId) && clipOwnsEffect(c, effect)
+      )
+      if (!firstSlot) continue
+      const from = clipBaseline(firstSlot).slots[slotId] as
+        | Record<string, unknown>
+        | undefined
+      if (!from) continue
+      const next = { ...rest.slots[slotId] } as Record<string, unknown>
+      for (const field of slotFields) {
+        if (from[field] !== undefined) next[field] = from[field]
+      }
+      rest.slots[slotId] = next as unknown as ClipSlotPose
+    }
   }
 
-  return {
-    ...end,
-    ...(mainStart
-      ? {
-          screenshotPosition: mainStart.screenshotPosition,
-          screenshotOffset: mainStart.screenshotOffset,
-        }
-      : {}),
-    slots: overlaySlotPositions(end.slots, startSlots),
+  return rest
+}
+
+const clipOwnsEffect = (clip: AnimationClip, effect: AnimationEffect) =>
+  (clip.effects ?? []).includes(effect)
+
+/**
+ * Copy `from`'s value for every effect `owns` selects onto a copy of `base`,
+ * field by field (main pose and per-slot alike). `clips` is scanned for the
+ * ownership test, so a caller can ask "whatever ANY of these clips animates" or
+ * narrow it to one clip's own effects.
+ */
+const overlayEffectFields = (
+  base: ClipBaseline,
+  from: ClipBaseline,
+  clips: readonly AnimationClip[],
+  owns: (clip: AnimationClip, effect: AnimationEffect) => boolean
+): ClipBaseline => {
+  const next: ClipBaseline = { ...base, slots: { ...base.slots } }
+  const nextRec = next as unknown as Record<string, unknown>
+  const fromRec = from as unknown as Record<string, unknown>
+
+  for (const effect of ANIMATION_EFFECTS) {
+    if (clips.some((c) => clipAffectsMain(c) && owns(c, effect))) {
+      for (const field of EFFECT_MAIN_POSE_FIELDS[effect]) {
+        if (fromRec[field] !== undefined) nextRec[field] = fromRec[field]
+      }
+    }
+    const slotFields = EFFECT_SLOT_POSE_FIELDS[effect]
+    if (!slotFields) continue
+    for (const slotId of Object.keys(next.slots)) {
+      if (!clips.some((c) => clipAffectsSlot(c, slotId) && owns(c, effect))) {
+        continue
+      }
+      const src = from.slots[slotId] as Record<string, unknown> | undefined
+      if (!src) continue
+      const merged = { ...next.slots[slotId] } as Record<string, unknown>
+      for (const field of slotFields) {
+        if (src[field] !== undefined) merged[field] = src[field]
+      }
+      next.slots[slotId] = merged as unknown as ClipSlotPose
+    }
   }
+  return next
 }
 
 /** Main-pose fields each animation effect owns. Used to copy just the edited
@@ -331,6 +381,8 @@ const EFFECT_MAIN_POSE_FIELDS: Record<
   canvasRadius: ["canvasBorderRadius"],
   lighting: ["lighting"],
   filter: ["filter"],
+  mediaEffects: ["mediaAdjustments"],
+  mediaFilter: ["mediaFilter"],
   portrait: ["portrait"],
   pattern: ["pattern"],
   overlay: ["overlay"],
@@ -338,6 +390,10 @@ const EFFECT_MAIN_POSE_FIELDS: Record<
   borderRadius: ["borderRadius"],
   crop: ["crop"],
 }
+
+const ANIMATION_EFFECTS = Object.keys(
+  EFFECT_MAIN_POSE_FIELDS
+) as AnimationEffect[]
 
 /** Per-slot pose fields an effect owns (only the slot-animatable ones). */
 const EFFECT_SLOT_POSE_FIELDS: Partial<
@@ -351,6 +407,8 @@ const EFFECT_SLOT_POSE_FIELDS: Partial<
   border: ["border"],
   borderRadius: ["borderRadius"],
   lighting: ["lighting"],
+  mediaEffects: ["adjustments"],
+  mediaFilter: ["filter"],
 }
 
 const poseValueEq = (a: unknown, b: unknown): boolean =>
@@ -572,6 +630,17 @@ const resolveKeyframePose = (
     // keyframe, else the value they reveal FROM (first owner's baseline) — never
     // the final look, so an earlier keyframe never inherits a later edit.
     filter: mainReveal("filter", (p) => p.filter ?? "none"),
+    mediaFilter: mainReveal(
+      "mediaFilter",
+      (p) => p.mediaFilter ?? canvas.mediaFilter ?? "none"
+    ),
+    mediaAdjustments: mainReveal(
+      "mediaEffects",
+      (p) =>
+        p.mediaAdjustments ??
+        canvas.mediaAdjustments ??
+        NEUTRAL_MEDIA_ADJUSTMENTS
+    ),
     portrait: mainReveal("portrait", (p) => p.portrait ?? canvas.portrait),
     pattern: mainReveal("pattern", (p) => p.pattern ?? canvas.backdrop.pattern),
     overlay: mainReveal("overlay", (p) => p.overlay ?? canvas.overlay),
@@ -662,6 +731,12 @@ const resolveKeyframePose = (
               "lighting",
               (sp) => sp?.lighting,
               s.lighting ?? canvas.backdrop.lighting
+            ),
+            filter: slotReveal("mediaFilter", (sp) => sp?.filter, s.filter),
+            adjustments: slotReveal(
+              "mediaEffects",
+              (sp) => sp?.adjustments,
+              s.adjustments ?? canvas.mediaAdjustments
             ),
           },
         ]
@@ -1839,7 +1914,7 @@ export const useEditorStore = create<EditorStore>((set, get) => {
             }
             // Rest at the animation's final frame, but position sits at its START
             // (see buildRestingPose) so a "move" preset shows where it begins.
-            const restingPose = buildRestingPose(repairedAnimation.clips)
+            const restingPose = buildRestingPose(next, repairedAnimation.clips)
             const posePatch = restingPose
               ? applyPoseToCanvas(next, restingPose)
               : {}
@@ -2925,47 +3000,38 @@ export const useEditorStore = create<EditorStore>((set, get) => {
           return
         }
         const pose = captureClipPose(canvas)
-        const posClips = sorted.filter((c) =>
-          (c.effects ?? []).includes("position")
+        // The committed canvas holds the animation's START, so folding it
+        // wholesale would flatten every keyframe into its own origin. Keep the
+        // last clip's stored pose for anything a keyframe animates; only a
+        // property nothing animates carries an outside edit onto that keyframe.
+        const foldedPose = overlayEffectFields(
+          pose,
+          clipPose(last),
+          sorted,
+          (c, e) => clipOwnsEffect(c, e)
         )
-        const hasPosition = posClips.length > 0
-        // The committed canvas shows the position START, so folding it wholesale
-        // would flatten the move. Keep the last clip's stored position pose (its
-        // END) and route the outside resting-position edit to the first position
-        // clip's baseline (the animation's start) instead.
-        const lastPose = clipPose(last)
-        const foldedPose: ClipBaseline =
-          hasPosition && (last.effects ?? []).includes("position")
-            ? {
-                ...pose,
-                screenshotPosition: lastPose.screenshotPosition,
-                screenshotOffset: lastPose.screenshotOffset,
-                slots: overlaySlotPositions(pose.slots, lastPose.slots),
-              }
-            : pose
+        // The outside edit belongs at the animation's start instead: each
+        // effect's FIRST owning keyframe is the one that eases from it.
         let nextClips = animation.clips.map((c) =>
           c.id === last.id ? { ...c, pose: foldedPose } : c
         )
-        const firstMainPos = posClips.find((c) => clipAffectsMain(c))
-        if (firstMainPos) {
-          nextClips = nextClips.map((c) =>
-            c.id === firstMainPos.id
-              ? {
-                  ...c,
-                  baseline: {
-                    ...clipBaseline(c),
-                    screenshotPosition: pose.screenshotPosition,
-                    screenshotOffset: pose.screenshotOffset,
-                  },
-                }
-              : c
+        nextClips = nextClips.map((c) => {
+          const startsHere = ANIMATION_EFFECTS.filter(
+            (e) =>
+              clipOwnsEffect(c, e) &&
+              sorted.find((o) => clipOwnsEffect(o, e))?.id === c.id
           )
-        }
-        // When position animates, the committed canvas holds the START; load the
-        // open (last) keyframe's END pose so editing that keyframe works as before.
-        const canvasPatch = hasPosition
-          ? applyPoseToCanvas(canvas, foldedPose)
-          : {}
+          if (startsHere.length === 0) return c
+          return {
+            ...c,
+            baseline: overlayEffectFields(clipBaseline(c), pose, [c], (_c, e) =>
+              startsHere.includes(e)
+            ),
+          }
+        })
+        // Load the open (last) keyframe's pose so editing it works on its own
+        // values rather than on the resting start the canvas is showing.
+        const canvasPatch = applyPoseToCanvas(canvas, foldedPose)
         const canvases = state.present.canvases.map((c) =>
           c.id === canvas.id
             ? {
@@ -2984,17 +3050,17 @@ export const useEditorStore = create<EditorStore>((set, get) => {
         return
       }
       // Exiting: persist the open clip's edits, then restore the committed canvas
-      // to the resting pose — the animation's final frame for every effect except
-      // position, which rests at its START (see buildRestingPose) — so the static
-      // editor and exports show the end look but a "move" sits where it begins.
-      // Clear the clip selection.
+      // to the resting pose — where the animation STARTS (see buildRestingPose).
+      // Keyframes describe motion; they must not leave their look baked into the
+      // document, so the static editor and the still export show the composition
+      // the user built. Clear the clip selection.
       const openId = state.selectedAnimationClipId
       let nextClips = animation.clips
       if (openId && nextClips.some((c) => c.id === openId)) {
         const pose = captureClipPose(canvas)
         nextClips = nextClips.map((c) => (c.id === openId ? { ...c, pose } : c))
       }
-      const restingPose = buildRestingPose(nextClips)
+      const restingPose = buildRestingPose(canvas, nextClips)
       const canvasPatch = restingPose
         ? applyPoseToCanvas(canvas, restingPose)
         : {}

--- a/lib/editor/store/canvas-helpers.ts
+++ b/lib/editor/store/canvas-helpers.ts
@@ -505,6 +505,8 @@ const SCREENSHOT_STYLE_EFFECT: Partial<
   borderRadius: "borderRadius",
   padding: "padding",
   lighting: "lighting",
+  filter: "mediaFilter",
+  adjustments: "mediaEffects",
 }
 
 export function screenshotStyleEffects(

--- a/tests/components/editor/shapes-section.test.tsx
+++ b/tests/components/editor/shapes-section.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("motion/react", async () => {
+  const React = await import("react")
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+    motion: new Proxy(
+      {},
+      {
+        get:
+          (_t, tag: string) =>
+          ({ children, ...props }: Record<string, unknown>) =>
+            React.createElement(
+              tag,
+              Object.fromEntries(
+                Object.entries(props).filter(
+                  ([k]) =>
+                    ![
+                      "initial",
+                      "animate",
+                      "exit",
+                      "transition",
+                      "variants",
+                      "layoutId",
+                    ].includes(k)
+                )
+              ),
+              children as React.ReactNode
+            ),
+      }
+    ),
+  }
+})
+
+const mocks = vi.hoisted(() => ({
+  SHAPES: Array.from({ length: 14 }, (_, i) => ({
+    id: `s${i}`,
+    name: `Shape ${i}`,
+    full: `full-${i}.png`,
+    thumb: `thumb-${i}.png`,
+    width: 100,
+    height: 100,
+  })),
+  editor: {
+    addAsset: vi.fn(() => "asset-1"),
+    setSelectedAssetId: vi.fn(),
+    setSelectedTextId: vi.fn(),
+    setSelectedScreenshotSlotId: vi.fn(),
+    setIsScreenshotSelected: vi.fn(),
+    setActiveTool: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/editor/presets", () => ({ SHAPE_LIBRARY: mocks.SHAPES }))
+vi.mock("@/lib/editor/store", () => ({ useEditor: () => mocks.editor }))
+
+const editor = mocks.editor
+
+import { ShapesSection } from "@/components/editor/inspector/shapes-section"
+
+/** Shape tiles are the only buttons titled "Add …"; the toggle is separate. */
+const shapeTiles = () => screen.getAllByTitle(/^Add Shape/)
+
+describe("ShapesSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows a preview grid, not the whole library, before expanding", () => {
+    render(<ShapesSection />)
+    expect(shapeTiles()).toHaveLength(8)
+    expect(screen.getByTitle("Add Shape 0")).toBeInTheDocument()
+    expect(screen.queryByTitle("Add Shape 8")).not.toBeInTheDocument()
+  })
+
+  it("offers a load-more toggle counting the shapes it hides", () => {
+    render(<ShapesSection />)
+    const toggle = screen.getByTitle("Show all 14 shapes")
+    expect(toggle).toHaveAttribute("aria-expanded", "false")
+    expect(screen.getByText("+6")).toBeInTheDocument()
+  })
+
+  it("reveals the rest of the library when the toggle is used", async () => {
+    const user = userEvent.setup()
+    render(<ShapesSection />)
+
+    await user.click(screen.getByTitle("Show all 14 shapes"))
+
+    expect(shapeTiles()).toHaveLength(14)
+    expect(screen.getByTitle("Add Shape 13")).toBeInTheDocument()
+    expect(screen.getByTitle("Show fewer shapes")).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    )
+  })
+
+  it("collapses back to the preview grid", async () => {
+    const user = userEvent.setup()
+    render(<ShapesSection />)
+
+    await user.click(screen.getByTitle("Show all 14 shapes"))
+    await user.click(screen.getByTitle("Show fewer shapes"))
+
+    expect(shapeTiles()).toHaveLength(8)
+  })
+
+  it("only mounts the capped scroller once expanded", async () => {
+    const user = userEvent.setup()
+    const { container } = render(<ShapesSection />)
+    const wrap = container.querySelector("[class*='contain:layout_paint']")!
+
+    expect(wrap.className).not.toContain("overflow-y-auto")
+    await user.click(screen.getByTitle("Show all 14 shapes"))
+    expect(wrap.className).toContain("overflow-y-auto")
+  })
+
+  it("drops a shape onto the canvas and selects it", async () => {
+    const user = userEvent.setup()
+    render(<ShapesSection />)
+
+    await user.click(screen.getByTitle("Add Shape 2"))
+
+    expect(editor.addAsset).toHaveBeenCalledWith("full-2.png")
+    expect(editor.setSelectedAssetId).toHaveBeenCalledWith("asset-1")
+    expect(editor.setIsScreenshotSelected).toHaveBeenCalledWith(false)
+    expect(editor.setActiveTool).toHaveBeenCalledWith("pointer")
+  })
+
+  it("keeps the toggle when the panel scrolls in an ancestor (flat)", async () => {
+    const user = userEvent.setup()
+    render(<ShapesSection flat />)
+
+    expect(shapeTiles()).toHaveLength(8)
+    await user.click(screen.getByTitle("Show all 14 shapes"))
+    expect(shapeTiles()).toHaveLength(14)
+  })
+})

--- a/tests/lib/editor/animation-export/capture-stable-frame.test.ts
+++ b/tests/lib/editor/animation-export/capture-stable-frame.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   captureLayeredAnimationFrame: vi.fn(),
   applyAnimationFrameAtTime: vi.fn(),
   measureBareStageDims: vi.fn(() => null),
+  sampleMainMediaGrade: vi.fn(() => null),
 }))
 
 vi.mock("@/lib/editor/animation-export/webkit-layered-frame", () => ({
@@ -12,6 +13,7 @@ vi.mock("@/lib/editor/animation-export/webkit-layered-frame", () => ({
 vi.mock("@/lib/editor/apply-animation-frame", () => ({
   applyAnimationFrameAtTime: mocks.applyAnimationFrameAtTime,
   measureBareStageDims: mocks.measureBareStageDims,
+  sampleMainMediaGrade: mocks.sampleMainMediaGrade,
 }))
 vi.mock("@/lib/editor/export", () => ({
   prepareAnimationCapture: vi.fn(),

--- a/tests/lib/editor/animation-export/decoded-frames-range.test.ts
+++ b/tests/lib/editor/animation-export/decoded-frames-range.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type * as FrameRange from "@/lib/editor/animation-export/video-media/frame-range"
+
+/**
+ * `createDecodedFrameSource` is wrapped around mediabunny, so the decoder,
+ * container parsing and WebCodecs are all stubbed out. What is under test is the
+ * repair flow this project added on top: the range check has to measure a frame
+ * BEFORE it is repaired, and a canvas handed out for several output frames must
+ * only be expanded once.
+ */
+
+const mocks = vi.hoisted(() => ({
+  canvases: vi.fn(),
+  expandLimitedRange: vi.fn(),
+  decodedNeedsRangeExpansion: vi.fn(() => true),
+  drawVideoReference: vi.fn(() => ({ reference: true })),
+}))
+
+vi.mock("mediabunny", () => ({
+  ALL_FORMATS: [],
+  BlobSource: class {},
+  Input: class {
+    getPrimaryVideoTrack() {
+      return Promise.resolve({
+        getCodec: () => Promise.resolve("avc"),
+        getDecoderConfig: () => Promise.resolve({ codec: "avc1.42001f" }),
+        canDecode: () => Promise.resolve(true),
+      })
+    }
+    dispose() {}
+  },
+  CanvasSink: class {
+    canvases(from: number) {
+      return mocks.canvases(from) as unknown
+    }
+  },
+}))
+
+vi.mock("@/lib/editor/animation-export/video-media/dav1d-av1-decoder", () => ({
+  isSupportedAv1Profile: () => false,
+  registerDav1dAv1Decoder: () => {},
+}))
+
+vi.mock("@/lib/editor/animation-export/video-media/frame-range", async () => {
+  const actual = await vi.importActual<typeof FrameRange>(
+    "@/lib/editor/animation-export/video-media/frame-range"
+  )
+  return {
+    ...actual,
+    expandLimitedRange: mocks.expandLimitedRange,
+    decodedNeedsRangeExpansion: mocks.decodedNeedsRangeExpansion,
+    drawVideoReference: mocks.drawVideoReference,
+  }
+})
+
+import { createDecodedFrameSource } from "@/lib/editor/animation-export/video-media/decoded-frames"
+
+/** A canvas the range helpers will accept as a measurable frame. */
+const frameCanvas = (id: string) => {
+  const canvas = document.createElement("canvas")
+  canvas.width = 4
+  canvas.height = 4
+  canvas.dataset.id = id
+  return canvas
+}
+
+/** An async iterator of `{ timestamp, canvas }` like mediabunny's CanvasSink. */
+const sinkOf = (frames: { timestamp: number; canvas: HTMLCanvasElement }[]) =>
+  vi.fn(() => {
+    let i = 0
+    return {
+      next: () =>
+        Promise.resolve(
+          i < frames.length
+            ? { done: false, value: frames[i++] }
+            : { done: true, value: undefined }
+        ),
+      return: () => Promise.resolve({ done: true, value: undefined }),
+    }
+  })
+
+const video = { videoWidth: 640, videoHeight: 360 } as HTMLVideoElement
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.decodedNeedsRangeExpansion.mockReturnValue(true)
+  mocks.drawVideoReference.mockReturnValue({ reference: true })
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => Promise.resolve({ ok: true, blob: () => Promise.resolve({}) }))
+  )
+  vi.stubGlobal("VideoDecoder", {
+    isConfigSupported: () => Promise.resolve({ supported: true }),
+  })
+})
+
+describe("createDecodedFrameSource range repair", () => {
+  it("measures the frame before repairing it", async () => {
+    const first = frameCanvas("a")
+    mocks.canvases = sinkOf([{ timestamp: 0, canvas: first }])
+    const order: string[] = []
+    mocks.decodedNeedsRangeExpansion.mockImplementation(() => {
+      order.push("measure")
+      return true
+    })
+    mocks.expandLimitedRange.mockImplementation(() => {
+      order.push("expand")
+    })
+
+    const source = await createDecodedFrameSource("blob:clip")
+    await source!.calibrateRange(video, 0)
+
+    // Reversed, the check would read already-expanded pixels and conclude the
+    // engine was fine — the repair would disable itself after one frame.
+    expect(order).toEqual(["measure", "expand"])
+  })
+
+  it("expands a canvas once however many output frames land on it", async () => {
+    const shared = frameCanvas("shared")
+    mocks.canvases = sinkOf([{ timestamp: 0, canvas: shared }])
+
+    const source = await createDecodedFrameSource("blob:clip")
+    await source!.calibrateRange(video, 0)
+    // Exporting above the source's frame rate replays one decoded frame.
+    await source!.getFrameAt(0.01)
+    await source!.getFrameAt(0.02)
+    await source!.getFrameAt(0.03)
+
+    expect(mocks.expandLimitedRange).toHaveBeenCalledTimes(1)
+    expect(mocks.expandLimitedRange).toHaveBeenCalledWith(shared)
+  })
+
+  it("expands each distinct frame once", async () => {
+    const a = frameCanvas("a")
+    const b = frameCanvas("b")
+    mocks.canvases = sinkOf([
+      { timestamp: 0, canvas: a },
+      { timestamp: 1, canvas: b },
+    ])
+
+    const source = await createDecodedFrameSource("blob:clip")
+    await source!.calibrateRange(video, 0)
+    await source!.getFrameAt(1)
+    await source!.getFrameAt(1)
+
+    expect(mocks.expandLimitedRange).toHaveBeenCalledTimes(2)
+    const graded = mocks.expandLimitedRange.mock.calls.map(
+      (call) => call[0] as HTMLCanvasElement
+    )
+    expect(graded).toEqual([a, b])
+  })
+
+  it("repairs nothing when the engine converts correctly", async () => {
+    mocks.decodedNeedsRangeExpansion.mockReturnValue(false)
+    mocks.canvases = sinkOf([{ timestamp: 0, canvas: frameCanvas("a") }])
+
+    const source = await createDecodedFrameSource("blob:clip")
+    await source!.calibrateRange(video, 0)
+    await source!.getFrameAt(0)
+
+    expect(mocks.expandLimitedRange).not.toHaveBeenCalled()
+  })
+
+  it("repairs nothing when calibration never runs", async () => {
+    mocks.canvases = sinkOf([{ timestamp: 0, canvas: frameCanvas("a") }])
+
+    const source = await createDecodedFrameSource("blob:clip")
+    await source!.getFrameAt(0)
+
+    expect(mocks.decodedNeedsRangeExpansion).not.toHaveBeenCalled()
+    expect(mocks.expandLimitedRange).not.toHaveBeenCalled()
+  })
+
+  it("declines when the reference frame cannot be drawn", async () => {
+    mocks.drawVideoReference.mockReturnValue(
+      null as unknown as { reference: boolean }
+    )
+    mocks.canvases = sinkOf([{ timestamp: 0, canvas: frameCanvas("a") }])
+
+    const source = await createDecodedFrameSource("blob:clip")
+    await source!.calibrateRange(video, 0)
+    await source!.getFrameAt(0)
+
+    expect(mocks.decodedNeedsRangeExpansion).not.toHaveBeenCalled()
+    expect(mocks.expandLimitedRange).not.toHaveBeenCalled()
+  })
+})

--- a/tests/lib/editor/animation-export/frame-grade.test.ts
+++ b/tests/lib/editor/animation-export/frame-grade.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { parseGradeChain } from "@/lib/editor/animation-export/video-media/frame-grade"
+import {
+  applyGradeToCanvas,
+  parseGradeChain,
+} from "@/lib/editor/animation-export/video-media/frame-grade"
 
 type Rgb = [number, number, number]
 
@@ -139,5 +142,81 @@ describe("filter maths matches the CSS spec", () => {
       expected,
       expected,
     ])
+  })
+})
+
+/**
+ * jsdom has no 2D context, so this fakes the slice `applyGradeToCanvas` uses:
+ * a canvas backed by an RGBA buffer read and written through
+ * getImageData/putImageData.
+ */
+function fakeCanvas(pixels: number[][]): HTMLCanvasElement {
+  const data = new Uint8ClampedArray(pixels.length * 4)
+  pixels.forEach(([r, g, b, a], i) => {
+    data[i * 4] = r
+    data[i * 4 + 1] = g
+    data[i * 4 + 2] = b
+    data[i * 4 + 3] = a
+  })
+  const image = { data, width: pixels.length, height: 1 }
+  return {
+    width: pixels.length,
+    height: 1,
+    getContext: () => ({
+      getImageData: () => image,
+      putImageData: (next: { data: Uint8ClampedArray }) => data.set(next.data),
+    }),
+  } as unknown as HTMLCanvasElement
+}
+
+const rgbaOf = (canvas: HTMLCanvasElement) => {
+  const { data } = canvas.getContext("2d")!.getImageData(0, 0, 1, 1)
+  const out: number[][] = []
+  for (let i = 0; i < data.length; i += 4) {
+    out.push([data[i], data[i + 1], data[i + 2], data[i + 3]])
+  }
+  return out
+}
+
+describe("applyGradeToCanvas", () => {
+  it("grades the colour channels", () => {
+    const canvas = fakeCanvas([[100, 100, 100, 255]])
+    applyGradeToCanvas(canvas, "brightness(1.5)")
+    expect(rgbaOf(canvas)[0].slice(0, 3)).toEqual([150, 150, 150])
+  })
+
+  it("leaves the alpha mask exactly as the clipped draw left it", () => {
+    // The rounded media box: opaque inside, a soft edge, transparent padding.
+    const canvas = fakeCanvas([
+      [200, 200, 200, 255],
+      [200, 200, 200, 128],
+      [0, 0, 0, 0],
+    ])
+    applyGradeToCanvas(canvas, "blur(2px) contrast(1.4)")
+    expect(rgbaOf(canvas).map((p) => p[3])).toEqual([255, 128, 0])
+  })
+
+  it("does not let blur spread the media into transparent padding", () => {
+    // blur() moves alpha in a plain CSS filter; here the clip has already been
+    // popped, so a spread would round off the corners the clip cut.
+    const canvas = fakeCanvas([
+      [255, 255, 255, 255],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ])
+    applyGradeToCanvas(canvas, "blur(1px)")
+    expect(rgbaOf(canvas).map((p) => p[3])).toEqual([255, 0, 0])
+  })
+
+  it("leaves the buffer untouched for a chain it cannot model", () => {
+    const canvas = fakeCanvas([[10, 20, 30, 255]])
+    applyGradeToCanvas(canvas, "drop-shadow(0 0 4px black)")
+    expect(rgbaOf(canvas)[0]).toEqual([10, 20, 30, 255])
+  })
+
+  it("leaves the buffer untouched for an empty chain", () => {
+    const canvas = fakeCanvas([[10, 20, 30, 255]])
+    applyGradeToCanvas(canvas, "")
+    expect(rgbaOf(canvas)[0]).toEqual([10, 20, 30, 255])
   })
 })

--- a/tests/lib/editor/animation-export/frame-grade.test.ts
+++ b/tests/lib/editor/animation-export/frame-grade.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest"
+
+import { parseGradeChain } from "@/lib/editor/animation-export/video-media/frame-grade"
+
+type Rgb = [number, number, number]
+
+/**
+ * Run a chain over one colour the way `applyGradeToCanvas` does, so the maths is
+ * checked without a real canvas (jsdom has no 2D context).
+ */
+function grade(chain: string, rgb: Rgb): Rgb {
+  const ops = parseGradeChain(chain)
+  if (!ops) throw new Error(`chain not parsed: ${chain}`)
+  let [r, g, b] = rgb
+  for (const op of ops) {
+    if (op.kind !== "matrix") continue
+    const { m, o } = op.matrix
+    const nr = m[0] * r + m[1] * g + m[2] * b + o[0] * 255
+    const ng = m[3] * r + m[4] * g + m[5] * b + o[1] * 255
+    const nb = m[6] * r + m[7] * g + m[8] * b + o[2] * 255
+    r = nr
+    g = ng
+    b = nb
+  }
+  return [r, g, b]
+}
+
+const near = (actual: Rgb, expected: Rgb, tol = 0.6) => {
+  actual.forEach((v, i) => expect(v).toBeCloseTo(expected[i], -Math.log10(tol)))
+}
+
+describe("parseGradeChain", () => {
+  it("returns no ops for an empty chain", () => {
+    expect(parseGradeChain("")).toEqual([])
+    expect(parseGradeChain("none")).toEqual([])
+  })
+
+  it("refuses a chain with a leg it cannot model", () => {
+    expect(parseGradeChain("drop-shadow(0 0 4px black)")).toBeNull()
+    expect(parseGradeChain("brightness(1.2) url(#x)")).toBeNull()
+  })
+
+  it("collapses a run of colour legs into a single matrix", () => {
+    const ops = parseGradeChain("brightness(1.1) contrast(0.9) saturate(1.2)")!
+    expect(ops).toHaveLength(1)
+    expect(ops[0].kind).toBe("matrix")
+  })
+
+  it("keeps blur as its own op, in chain order", () => {
+    const ops = parseGradeChain("blur(2px) grayscale(1)")!
+    expect(ops.map((o) => o.kind)).toEqual(["blur", "matrix"])
+    expect(ops[0]).toEqual({ kind: "blur", px: 2 })
+  })
+
+  it("drops a zero-width blur and an identity colour run", () => {
+    expect(parseGradeChain("blur(0px)")).toEqual([])
+    expect(parseGradeChain("brightness(1) saturate(1)")).toEqual([])
+  })
+
+  it("reads both percentage and multiplier arguments", () => {
+    const pct = grade("brightness(50%)", [200, 100, 40])
+    const mult = grade("brightness(0.5)", [200, 100, 40])
+    near(pct, mult)
+    near(pct, [100, 50, 20])
+  })
+})
+
+describe("filter maths matches the CSS spec", () => {
+  it("brightness scales each channel", () => {
+    near(grade("brightness(1.5)", [100, 50, 20]), [150, 75, 30])
+  })
+
+  it("contrast pivots around mid grey", () => {
+    // c·k + (0.5 − 0.5k) in 0..1 → 127.5 stays put, the rest spreads.
+    near(grade("contrast(2)", [127.5, 200, 55]), [127.5, 272.5, -17.5])
+  })
+
+  it("invert(1) flips the channel", () => {
+    near(grade("invert(1)", [200, 100, 0]), [55, 155, 255])
+  })
+
+  it("invert(0.5) collapses everything to mid grey", () => {
+    near(grade("invert(0.5)", [200, 100, 0]), [127.5, 127.5, 127.5])
+  })
+
+  it("grayscale(1) produces the Rec.709 luma on every channel", () => {
+    const luma = 0.2126 * 200 + 0.7152 * 100 + 0.0722 * 50
+    near(grade("grayscale(1)", [200, 100, 50]), [luma, luma, luma])
+  })
+
+  it("saturate(0) matches grayscale(1)", () => {
+    near(
+      grade("saturate(0)", [200, 100, 50]),
+      grade("grayscale(1)", [200, 100, 50])
+    )
+  })
+
+  it("leaves grey untouched under saturate and hue-rotate", () => {
+    near(grade("saturate(3)", [128, 128, 128]), [128, 128, 128])
+    near(grade("hue-rotate(90deg)", [128, 128, 128]), [128, 128, 128])
+  })
+
+  it("hue-rotate(0) and hue-rotate(360) are the identity", () => {
+    near(grade("hue-rotate(0deg)", [200, 100, 50]), [200, 100, 50])
+    near(grade("hue-rotate(360deg)", [200, 100, 50]), [200, 100, 50])
+  })
+
+  it("sepia(1) warms a white pixel the way the spec matrix does", () => {
+    near(grade("sepia(1)", [255, 255, 255]), [
+      255 * 1.351,
+      255 * 1.203,
+      255 * 0.937,
+    ])
+  })
+
+  it("an amount of 0 is the identity for every amount filter", () => {
+    for (const leg of ["grayscale(0)", "sepia(0)", "invert(0)"]) {
+      near(grade(leg, [200, 100, 50]), [200, 100, 50])
+    }
+  })
+
+  it("composes legs in order, not commutatively", () => {
+    const a = grade("brightness(2) contrast(2)", [100, 100, 100])
+    const b = grade("contrast(2) brightness(2)", [100, 100, 100])
+    expect(a[0]).not.toBeCloseTo(b[0], 1)
+    // brightness then contrast: (200/255·2 − 0.5)·255 = 272.5
+    near(a, [272.5, 272.5, 272.5])
+    // contrast then brightness: ((100/255·2 − 0.5)·2)·255 = 145
+    near(b, [145, 145, 145])
+  })
+
+  it("matches the full committed chain for a real preset", () => {
+    // noir = grayscale(1) contrast(1.35) brightness(0.9)
+    const luma = 0.2126 * 200 + 0.7152 * 100 + 0.0722 * 50
+    const contrasted = (luma / 255) * 1.35 + (0.5 - 0.5 * 1.35)
+    const expected = contrasted * 0.9 * 255
+    near(grade("grayscale(1) contrast(1.35) brightness(0.9)", [200, 100, 50]), [
+      expected,
+      expected,
+      expected,
+    ])
+  })
+})

--- a/tests/lib/editor/animation-export/frame-range.test.ts
+++ b/tests/lib/editor/animation-export/frame-range.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  canvasLevels,
+  decodedNeedsRangeExpansion,
+  expandLimitedRange,
+} from "@/lib/editor/animation-export/video-media/frame-range"
+
+/** `canvasLevels` reads every 13th pixel, so each value has to fill a run. */
+const RUN = 13
+
+/**
+ * jsdom has no 2D context, so these fake just enough of one: a canvas backed by
+ * an RGBA buffer the helpers read and write through getImageData/putImageData.
+ * Each supplied colour fills one sampling run, so all of them get measured.
+ */
+function fakeCanvas(pixels: number[][]): HTMLCanvasElement {
+  const width = pixels.length * RUN
+  const data = new Uint8ClampedArray(width * 4)
+  pixels.forEach(([r, g, b], i) => {
+    for (let k = 0; k < RUN; k++) {
+      const at = (i * RUN + k) * 4
+      data[at] = r
+      data[at + 1] = g
+      data[at + 2] = b
+      data[at + 3] = 255
+    }
+  })
+  const image = { data, width, height: 1 }
+  const ctx = {
+    getImageData: () => image,
+    putImageData: (next: { data: Uint8ClampedArray }) => {
+      data.set(next.data)
+    },
+    drawImage: vi.fn(),
+  }
+  return {
+    width,
+    height: 1,
+    getContext: () => ctx,
+  } as unknown as HTMLCanvasElement
+}
+
+/** The RGB triple at the head of each run — one per colour originally given. */
+const pixelsOf = (canvas: HTMLCanvasElement) => {
+  const ctx = canvas.getContext("2d")!
+  const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height)
+  const out: number[][] = []
+  for (let i = 0; i < data.length; i += 4 * RUN) {
+    out.push([data[i], data[i + 1], data[i + 2]])
+  }
+  return out
+}
+
+const grey = (v: number) => [v, v, v]
+
+describe("canvasLevels", () => {
+  it("reports the luma floor and ceiling", () => {
+    const levels = canvasLevels(fakeCanvas([grey(16), grey(120), grey(235)]))
+    expect(levels?.black).toBeCloseTo(16, 0)
+    expect(levels?.white).toBeCloseTo(235, 0)
+  })
+
+  it("returns null when nothing is opaque enough to measure", () => {
+    expect(canvasLevels(fakeCanvas([]))).toBeNull()
+  })
+})
+
+describe("expandLimitedRange", () => {
+  it("stretches studio swing back to full range", () => {
+    const canvas = fakeCanvas([grey(16), grey(235)])
+    expandLimitedRange(canvas)
+    const [black, white] = pixelsOf(canvas)
+    expect(black).toEqual([0, 0, 0])
+    expect(white.every((c) => c >= 254)).toBe(true)
+  })
+
+  it("keeps mid grey near the middle", () => {
+    const canvas = fakeCanvas([grey(126)])
+    expandLimitedRange(canvas)
+    // (126 − 16) · 255/219 = 128.1
+    expect(pixelsOf(canvas)[0][0]).toBeCloseTo(128, -1)
+  })
+
+  it("clamps rather than wrapping below studio black", () => {
+    const canvas = fakeCanvas([grey(0), grey(8)])
+    expandLimitedRange(canvas)
+    expect(pixelsOf(canvas).map((p) => p[0])).toEqual([0, 0])
+  })
+
+  it("leaves alpha untouched", () => {
+    const canvas = fakeCanvas([grey(100)])
+    expandLimitedRange(canvas)
+    const { data } = canvas.getContext("2d")!.getImageData(0, 0, 1, 1)
+    expect(data[3]).toBe(255)
+  })
+})
+
+describe("decodedNeedsRangeExpansion", () => {
+  const fullRange = fakeCanvas([grey(0), grey(128), grey(255)])
+  const studioSwing = fakeCanvas([grey(16), grey(128), grey(235)])
+
+  it("detects a studio-swing decode against a full-range reference", () => {
+    expect(decodedNeedsRangeExpansion(studioSwing, fullRange)).toBe(true)
+  })
+
+  it("leaves a correct engine alone", () => {
+    expect(decodedNeedsRangeExpansion(fullRange, fullRange)).toBe(false)
+  })
+
+  it("does not fire when both paths agree on studio swing", () => {
+    // The source itself is lifted — the export is faithful and must not be
+    // "corrected" into crushed blacks.
+    expect(decodedNeedsRangeExpansion(studioSwing, studioSwing)).toBe(false)
+  })
+
+  it("does not fire on a dark frame that simply has no true blacks", () => {
+    const noBlacks = fakeCanvas([grey(64), grey(120), grey(200)])
+    const reference = fakeCanvas([grey(64), grey(120), grey(200)])
+    expect(decodedNeedsRangeExpansion(noBlacks, reference)).toBe(false)
+  })
+
+  it("does not fire when the floor is above studio black by chance", () => {
+    // A 40-level floor is not studio black, however it compares to the
+    // reference — expanding here would wreck the frame.
+    const lifted = fakeCanvas([grey(40), grey(128), grey(220)])
+    expect(decodedNeedsRangeExpansion(lifted, fullRange)).toBe(false)
+  })
+
+  it("declines to guess when a canvas cannot be measured", () => {
+    expect(decodedNeedsRangeExpansion(studioSwing, fakeCanvas([]))).toBe(false)
+    expect(decodedNeedsRangeExpansion(fakeCanvas([]), fullRange)).toBe(false)
+  })
+
+  it("round-trips: a detected frame expands to match the reference", () => {
+    const decoded = fakeCanvas([grey(16), grey(235)])
+    expect(decodedNeedsRangeExpansion(decoded, fullRange)).toBe(true)
+    expandLimitedRange(decoded)
+    const levels = canvasLevels(decoded)
+    expect(levels?.black).toBeCloseTo(0, 0)
+    expect(levels?.white).toBeGreaterThanOrEqual(254)
+    expect(decodedNeedsRangeExpansion(decoded, fullRange)).toBe(false)
+  })
+})

--- a/tests/lib/editor/animation-export/video-layer.test.ts
+++ b/tests/lib/editor/animation-export/video-layer.test.ts
@@ -190,6 +190,7 @@ describe("prepareCloneVideoLayer — Animate export frame bridge", () => {
     decodedFrame.height = 1080
     const decoded = {
       getFrameAt: vi.fn().mockResolvedValue(decodedFrame),
+      calibrateRange: vi.fn(),
       cleanup: vi.fn(),
     }
     mocks.createDecodedFrameSource.mockResolvedValue(decoded)
@@ -242,6 +243,7 @@ describe("prepareCloneVideoLayer — Animate export frame bridge", () => {
     frame.height = 180
     const decoded = {
       getFrameAt: vi.fn().mockResolvedValue(frame),
+      calibrateRange: vi.fn(),
       cleanup: vi.fn(),
     }
     mocks.createDecodedFrameSource.mockResolvedValue(decoded)

--- a/tests/lib/editor/animation-media-grade.test.ts
+++ b/tests/lib/editor/animation-media-grade.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  mediaFilterBlendBetween,
+  mediaFilterBlendCss,
+  mediaFilterBlendOf,
+} from "@/lib/editor/animation-playback"
+import { applyAnimationFrameAtTime } from "@/lib/editor/apply-animation-frame"
+import {
+  assetFilterCss,
+  MAIN_MEDIA_FX_PREVIEW_VAR,
+  mediaFilterCss,
+  NEUTRAL_MEDIA_ADJUSTMENTS,
+  slotMediaFxPreviewVar,
+} from "@/lib/editor/css-utils"
+import { captureClipPose, useEditorStore } from "@/lib/editor/store"
+import type {
+  AnimationClip,
+  AnimationEffect,
+  CanvasState,
+  MediaAdjustments,
+} from "@/lib/editor/state-types"
+
+const activeCanvas = (): CanvasState => {
+  const s = useEditorStore.getState().present
+  return s.canvases.find((c) => c.id === s.activeCanvasId)!
+}
+
+const GRADED: MediaAdjustments = {
+  ...NEUTRAL_MEDIA_ADJUSTMENTS,
+  brightness: 140,
+  saturation: 60,
+}
+
+/** A keyframe easing the media grade from the canvas's committed look to `to`. */
+const gradeClip = (
+  canvas: CanvasState,
+  effects: AnimationEffect[],
+  to: {
+    mediaFilter?: CanvasState["mediaFilter"]
+    mediaAdjustments?: MediaAdjustments
+  }
+): AnimationClip => {
+  const base = captureClipPose(canvas)
+  return {
+    id: "c1",
+    startMs: 0,
+    durationMs: 1000,
+    easing: "linear",
+    effects,
+    baseline: base,
+    pose: { ...base, ...to },
+  }
+}
+
+const applyAt = (
+  el: HTMLElement,
+  canvas: CanvasState,
+  clips: AnimationClip[],
+  timeMs: number
+) =>
+  applyAnimationFrameAtTime({
+    canvasEl: el,
+    canvas,
+    globalAspect: { id: "auto", w: 16, h: 9 },
+    clips,
+    timeMs,
+  })
+
+const mainVar = (el: HTMLElement) =>
+  el.style.getPropertyValue(MAIN_MEDIA_FX_PREVIEW_VAR)
+
+describe("media filter blending", () => {
+  it("keeps a preset's own chain while it is not blending", () => {
+    const noir = mediaFilterBlendOf("noir")
+    const vivid = mediaFilterBlendOf("vivid")
+    expect(mediaFilterBlendCss(mediaFilterBlendBetween(noir, vivid, 0))).toBe(
+      assetFilterCss("noir")
+    )
+    expect(mediaFilterBlendCss(mediaFilterBlendBetween(noir, vivid, 1))).toBe(
+      assetFilterCss("vivid")
+    )
+    // Same preset on both ends is not a transition at all.
+    expect(mediaFilterBlendCss(mediaFilterBlendBetween(noir, noir, 0.5))).toBe(
+      assetFilterCss("noir")
+    )
+  })
+
+  it("crosses between two presets channel by channel rather than snapping", () => {
+    const mid = mediaFilterBlendBetween(
+      mediaFilterBlendOf("none"),
+      mediaFilterBlendOf("noir"),
+      0.5
+    )
+    expect(mid.preset).toBeNull()
+    // noir is grayscale(1) contrast(1.35) brightness(0.9) — halfway there.
+    expect(mid.vector.grayscale).toBeCloseTo(0.5)
+    expect(mid.vector.contrast).toBeCloseTo(1.175)
+    expect(mid.vector.brightness).toBeCloseTo(0.95)
+    expect(mediaFilterBlendCss(mid)).toBe(
+      "grayscale(0.5) brightness(0.95) contrast(1.175)"
+    )
+  })
+
+  it("blends out of a preset back to neutral", () => {
+    const mid = mediaFilterBlendBetween(
+      mediaFilterBlendOf("bw"),
+      mediaFilterBlendOf("none"),
+      0.5
+    )
+    expect(mid.vector.grayscale).toBeCloseTo(0.5)
+    expect(mid.vector.contrast).toBeCloseTo(1.025)
+  })
+})
+
+describe("media grade on the animate timeline", () => {
+  let el: HTMLElement
+
+  beforeEach(() => {
+    useEditorStore.getState().reset()
+    el = document.createElement("div")
+    document.body.appendChild(el)
+  })
+
+  it("leaves the var alone when no keyframe animates the grade", () => {
+    const canvas = activeCanvas()
+    const clips = [gradeClip(canvas, ["tilt"], {})]
+    applyAt(el, canvas, clips, 500)
+    expect(mainVar(el)).toBe("")
+  })
+
+  it("settles on exactly the committed chain the keyframe's preset renders", () => {
+    const canvas = activeCanvas()
+    const clips = [gradeClip(canvas, ["mediaFilter"], { mediaFilter: "noir" })]
+
+    applyAt(el, canvas, clips, 1000)
+    expect(mainVar(el)).toBe(
+      mediaFilterCss({
+        enhance: canvas.enhance,
+        filter: "noir",
+        adjustments: NEUTRAL_MEDIA_ADJUSTMENTS,
+      })
+    )
+  })
+
+  it("reveals from the committed grade, not from neutral", () => {
+    const canvas: CanvasState = { ...activeCanvas(), mediaFilter: "sepia" }
+    const clips = [gradeClip(canvas, ["mediaFilter"], { mediaFilter: "noir" })]
+
+    applyAt(el, canvas, clips, 0)
+    expect(mainVar(el)).toContain(assetFilterCss("sepia"))
+
+    applyAt(el, canvas, clips, 500)
+    const mid = mainVar(el)
+    expect(mid).not.toContain(assetFilterCss("sepia"))
+    expect(mid).not.toContain(assetFilterCss("noir"))
+  })
+
+  it("carries the committed colour grade through a filter-only keyframe", () => {
+    const canvas: CanvasState = {
+      ...activeCanvas(),
+      mediaAdjustments: GRADED,
+    }
+    const clips = [gradeClip(canvas, ["mediaFilter"], { mediaFilter: "noir" })]
+
+    applyAt(el, canvas, clips, 1000)
+    // The two halves share one var, so animating the preset must not silently
+    // drop the grade the user committed.
+    expect(mainVar(el)).toBe(
+      mediaFilterCss({
+        enhance: canvas.enhance,
+        filter: "noir",
+        adjustments: GRADED,
+      })
+    )
+  })
+
+  it("carries the committed filter preset through a grade-only keyframe", () => {
+    const canvas: CanvasState = { ...activeCanvas(), mediaFilter: "vivid" }
+    const clips = [
+      gradeClip(canvas, ["mediaEffects"], { mediaAdjustments: GRADED }),
+    ]
+
+    applyAt(el, canvas, clips, 1000)
+    expect(mainVar(el)).toBe(
+      mediaFilterCss({
+        enhance: canvas.enhance,
+        filter: "vivid",
+        adjustments: GRADED,
+      })
+    )
+  })
+
+  it("eases each colour-grade channel across the keyframe", () => {
+    const canvas = activeCanvas()
+    const clips = [
+      gradeClip(canvas, ["mediaEffects"], { mediaAdjustments: GRADED }),
+    ]
+
+    applyAt(el, canvas, clips, 500)
+    expect(mainVar(el)).toBe(
+      mediaFilterCss({
+        enhance: canvas.enhance,
+        filter: "none",
+        adjustments: {
+          ...NEUTRAL_MEDIA_ADJUSTMENTS,
+          brightness: 120,
+          saturation: 80,
+        },
+      })
+    )
+  })
+
+  it("holds the final grade past the end of a keyframe that does not release", () => {
+    const canvas = activeCanvas()
+    const clips = [
+      {
+        ...gradeClip(canvas, ["mediaFilter"], { mediaFilter: "noir" }),
+        returnToDefault: false,
+      },
+    ]
+
+    applyAt(el, canvas, clips, 1000)
+    const atEnd = mainVar(el)
+    applyAt(el, canvas, clips, 9000)
+    expect(mainVar(el)).toBe(atEnd)
+  })
+})
+
+describe("media grade on an extra screenshot slot", () => {
+  let el: HTMLElement
+  let slotEl: HTMLElement
+
+  beforeEach(() => {
+    useEditorStore.getState().reset()
+    el = document.createElement("div")
+    slotEl = document.createElement("div")
+    el.appendChild(slotEl)
+    document.body.appendChild(el)
+  })
+
+  it("drives the slot's own grade var from a slot-targeted keyframe", () => {
+    const slotId = useEditorStore.getState().addScreenshotSlot()!
+    slotEl.dataset.screenshotSlotId = slotId
+    const canvas = activeCanvas()
+    const base = captureClipPose(canvas)
+    const clips: AnimationClip[] = [
+      {
+        id: "c1",
+        startMs: 0,
+        durationMs: 1000,
+        easing: "linear",
+        target: { scope: "slot", slotId },
+        effects: ["mediaFilter"],
+        baseline: base,
+        pose: {
+          ...base,
+          slots: {
+            ...base.slots,
+            [slotId]: { ...base.slots[slotId], filter: "noir" },
+          },
+        },
+      },
+    ]
+
+    applyAt(el, canvas, clips, 1000)
+    expect(slotEl.style.getPropertyValue(slotMediaFxPreviewVar(slotId))).toBe(
+      mediaFilterCss({
+        enhance: canvas.enhance,
+        filter: "noir",
+        adjustments: NEUTRAL_MEDIA_ADJUSTMENTS,
+      })
+    )
+    // A slot keyframe must not repaint the main screenshot.
+    expect(mainVar(el)).toBe("")
+  })
+})

--- a/tests/lib/editor/animation-media-grade.test.ts
+++ b/tests/lib/editor/animation-media-grade.test.ts
@@ -275,3 +275,64 @@ describe("media grade on an extra screenshot slot", () => {
     expect(mainVar(el)).toBe("")
   })
 })
+
+/**
+ * An unbound ("all") keyframe binds to the slot an edit targets, but only for
+ * effects a slot can actually animate — `SLOT_ANIMATABLE_EFFECTS`. Leaving the
+ * media grade out of that list would silently scope a per-slot grade to the
+ * whole canvas.
+ */
+describe("a media-grade edit binds an unbound keyframe to the selected slot", () => {
+  beforeEach(() => {
+    useEditorStore.getState().reset()
+  })
+
+  const openUnboundClip = () => {
+    const id = useEditorStore.getState().addAnimationClip()
+    useEditorStore.getState().setIsAnimateMode(true)
+    useEditorStore.getState().selectAnimationClip(id)
+    return id
+  }
+  const clipById = (id: string) =>
+    activeCanvas().animation!.clips.find((c) => c.id === id)!
+
+  it("scopes a filter edit to the selected slot", () => {
+    const slotId = useEditorStore.getState().addScreenshotSlot()!
+    const clipId = openUnboundClip()
+    expect(clipById(clipId).target ?? { scope: "all" }).toEqual({
+      scope: "all",
+    })
+
+    useEditorStore.getState().setSelectedScreenshotSlotId(slotId)
+    useEditorStore
+      .getState()
+      .applyScreenshotStyle({ slotId }, { filter: "noir" })
+
+    expect(clipById(clipId).target).toEqual({ scope: "slot", slotId })
+    expect(clipById(clipId).effects).toContain("mediaFilter")
+  })
+
+  it("scopes a colour-grade edit to the selected slot", () => {
+    const slotId = useEditorStore.getState().addScreenshotSlot()!
+    const clipId = openUnboundClip()
+
+    useEditorStore.getState().setSelectedScreenshotSlotId(slotId)
+    useEditorStore
+      .getState()
+      .applyScreenshotStyle({ slotId }, { adjustments: GRADED })
+
+    expect(clipById(clipId).target).toEqual({ scope: "slot", slotId })
+    expect(clipById(clipId).effects).toContain("mediaEffects")
+  })
+
+  it("leaves the keyframe canvas-wide when no slot is selected", () => {
+    useEditorStore.getState().addScreenshotSlot()
+    const clipId = openUnboundClip()
+
+    useEditorStore.getState().applyScreenshotStyle("all", { filter: "noir" })
+
+    expect(clipById(clipId).target ?? { scope: "all" }).toEqual({
+      scope: "all",
+    })
+  })
+})

--- a/tests/lib/editor/animation-release-frame.test.ts
+++ b/tests/lib/editor/animation-release-frame.test.ts
@@ -14,6 +14,10 @@ import {
   portraitLayerOpacityVar,
   REST_LIGHTING,
 } from "@/lib/editor/animation-playback"
+import {
+  MAIN_MEDIA_FX_PREVIEW_VAR,
+  NEUTRAL_MEDIA_ADJUSTMENTS,
+} from "@/lib/editor/css-utils"
 import { captureClipPose, useEditorStore } from "@/lib/editor/store"
 import type {
   AnimationClip,
@@ -48,6 +52,8 @@ const ALL_EFFECTS: AnimationEffect[] = [
   "border",
   "borderRadius",
   "crop",
+  "mediaEffects",
+  "mediaFilter",
 ]
 
 /** Every var the clip below drives, across all of those sampling paths. */
@@ -77,6 +83,7 @@ const VARS = [
   PATTERN_BASE_OPACITY_VAR,
   overlayLayerOpacityVar("c1"),
   OVERLAY_BASE_OPACITY_VAR,
+  MAIN_MEDIA_FX_PREVIEW_VAR,
 ]
 
 const baseCanvas = (): CanvasState => {
@@ -131,6 +138,8 @@ const everythingClip = (over: Partial<AnimationClip> = {}): AnimationClip => {
       portrait: { ...portrait, mode: "off" },
       pattern: { ...pattern, ids: [] },
       overlay: { ...overlay, opacity: 0 },
+      mediaFilter: "none",
+      mediaAdjustments: NEUTRAL_MEDIA_ADJUSTMENTS,
     },
     pose: {
       ...base,
@@ -154,6 +163,8 @@ const everythingClip = (over: Partial<AnimationClip> = {}): AnimationClip => {
       portrait: { ...portrait, mode: "studio", intensity: 70 },
       pattern: { ...pattern, ids: [1] },
       overlay: { ...overlay, id: 3, opacity: 60 },
+      mediaFilter: "noir",
+      mediaAdjustments: { ...NEUTRAL_MEDIA_ADJUSTMENTS, brightness: 140 },
     },
     ...over,
   }

--- a/tests/lib/editor/store/animation-resting-frame.test.ts
+++ b/tests/lib/editor/store/animation-resting-frame.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { useEditorStore } from "@/lib/editor/store"
+import type { Background, Shadow } from "@/lib/editor/state-types"
+
+const store = useEditorStore
+const activeCanvas = () => {
+  const s = store.getState().present
+  return s.canvases.find((c) => c.id === s.activeCanvasId)!
+}
+const clipsOf = () => activeCanvas().animation!.clips
+
+const RED: Background = { type: "solid", value: "#ff0000" }
+const GLOW: Shadow = {
+  type: "glow",
+  intensity: 80,
+  lightSource: "center",
+  color: "#00ff00",
+}
+
+/** Open a fresh keyframe for editing and return its id. */
+const openClip = () => {
+  store.getState().addAnimationClip()
+  store.getState().setIsAnimateMode(true)
+  const id = clipsOf()[0].id
+  store.getState().selectAnimationClip(id)
+  return id
+}
+
+/**
+ * A keyframe describes motion; it must not leave its look baked into the
+ * document. Exiting Animate mode restores the canvas to where the animation
+ * STARTS for every effect — not just position, which always behaved this way.
+ */
+describe("animation resting frame", () => {
+  beforeEach(() => store.getState().reset())
+
+  it("does not bind an animated background to the committed canvas", () => {
+    const before = activeCanvas().background
+    openClip()
+    store.getState().setBackground(RED)
+    expect(clipsOf()[0].effects).toContain("background")
+
+    store.getState().setIsAnimateMode(false)
+
+    expect(activeCanvas().background).toEqual(before)
+    expect(clipsOf()[0].pose?.background).toEqual(RED)
+  })
+
+  it("does not bind an animated shadow to the committed canvas", () => {
+    const before = activeCanvas().shadow
+    openClip()
+    store.getState().setShadow(GLOW)
+
+    store.getState().setIsAnimateMode(false)
+
+    expect(activeCanvas().shadow).toEqual(before)
+    expect(clipsOf()[0].pose?.shadow).toEqual(GLOW)
+  })
+
+  it("does not bind an animated media grade to the committed canvas", () => {
+    openClip()
+    store.getState().applyScreenshotStyle("main", { filter: "noir" })
+    expect(clipsOf()[0].effects).toContain("mediaFilter")
+
+    store.getState().setIsAnimateMode(false)
+
+    expect(activeCanvas().mediaFilter ?? "none").toBe("none")
+    expect(clipsOf()[0].pose?.mediaFilter).toBe("noir")
+  })
+
+  it("survives an animate-mode round trip without flattening the keyframe", () => {
+    const before = activeCanvas().background
+    openClip()
+    store.getState().setBackground(RED)
+    store.getState().setIsAnimateMode(false)
+
+    store.getState().setIsAnimateMode(true)
+    store.getState().setIsAnimateMode(false)
+
+    expect(activeCanvas().background).toEqual(before)
+    expect(clipsOf()[0].pose?.background).toEqual(RED)
+    expect(clipsOf()[0].baseline?.background).toEqual(before)
+  })
+
+  it("routes an edit made outside animate mode to where the animation starts", () => {
+    openClip()
+    store.getState().setBackground(RED)
+    store.getState().setIsAnimateMode(false)
+
+    // Outside Animate mode the canvas shows the start, so restyling it must move
+    // the animation's origin — not overwrite the keyframe it travels to.
+    const blue: Background = { type: "solid", value: "#0000ff" }
+    store.getState().setBackground(blue)
+    store.getState().setIsAnimateMode(true)
+    store.getState().setIsAnimateMode(false)
+
+    expect(clipsOf()[0].baseline?.background).toEqual(blue)
+    expect(clipsOf()[0].pose?.background).toEqual(RED)
+    expect(activeCanvas().background).toEqual(blue)
+  })
+
+  it("still carries an outside edit to a property no keyframe animates", () => {
+    openClip()
+    store.getState().setBackground(RED)
+    store.getState().setIsAnimateMode(false)
+
+    // Nothing animates the shadow, so it is plain document style and must stick.
+    store.getState().setShadow(GLOW)
+    store.getState().setIsAnimateMode(true)
+    store.getState().setIsAnimateMode(false)
+
+    expect(activeCanvas().shadow).toEqual(GLOW)
+    expect(clipsOf()[0].pose?.shadow).toEqual(GLOW)
+  })
+
+  it("leaves the canvas alone entirely when the timeline is empty", () => {
+    const before = activeCanvas()
+    store.getState().setIsAnimateMode(true)
+    store.getState().setIsAnimateMode(false)
+
+    expect(activeCanvas().background).toEqual(before.background)
+    expect(activeCanvas().shadow).toEqual(before.shadow)
+  })
+
+  it("rests at the FIRST keyframe's baseline across several keyframes", () => {
+    const first = openClip()
+    store.getState().setBackground(RED)
+
+    const second = store.getState().addAnimationClip()
+    store.getState().selectAnimationClip(second)
+    const green: Background = { type: "solid", value: "#00ff00" }
+    store.getState().setBackground(green)
+
+    store.getState().setIsAnimateMode(false)
+
+    const clips = clipsOf()
+    expect(clips.find((c) => c.id === first)?.pose?.background).toEqual(RED)
+    expect(clips.find((c) => c.id === second)?.pose?.background).toEqual(green)
+    // The canvas holds what the FIRST keyframe eases from, not the last look.
+    expect(activeCanvas().background).not.toEqual(green)
+    expect(activeCanvas().background).not.toEqual(RED)
+  })
+})

--- a/tests/lib/editor/store/animation-resting-frame.test.ts
+++ b/tests/lib/editor/store/animation-resting-frame.test.ts
@@ -124,6 +124,7 @@ describe("animation resting frame", () => {
   })
 
   it("rests at the FIRST keyframe's baseline across several keyframes", () => {
+    const before = activeCanvas().background
     const first = openClip()
     store.getState().setBackground(RED)
 
@@ -137,8 +138,8 @@ describe("animation resting frame", () => {
     const clips = clipsOf()
     expect(clips.find((c) => c.id === first)?.pose?.background).toEqual(RED)
     expect(clips.find((c) => c.id === second)?.pose?.background).toEqual(green)
-    // The canvas holds what the FIRST keyframe eases from, not the last look.
-    expect(activeCanvas().background).not.toEqual(green)
-    expect(activeCanvas().background).not.toEqual(RED)
+    // The canvas holds what the FIRST keyframe eases from — the pre-animation
+    // look — rather than either keyframe's.
+    expect(activeCanvas().background).toEqual(before)
   })
 })

--- a/tests/lib/editor/store/canvas-helpers.test.ts
+++ b/tests/lib/editor/store/canvas-helpers.test.ts
@@ -381,12 +381,19 @@ describe("canvas store helpers", () => {
 
     it("emits no effect for non-animatable fields like objectFit", () => {
       expect(screenshotStyleEffects({ objectFit: "cover" })).toEqual([])
+    })
+
+    it("maps the media grade onto its two effects", () => {
+      expect(screenshotStyleEffects({ filter: "bw" })).toEqual(["mediaFilter"])
+      expect(
+        screenshotStyleEffects({ adjustments: NEUTRAL_MEDIA_ADJUSTMENTS })
+      ).toEqual(["mediaEffects"])
       expect(
         screenshotStyleEffects({
           filter: "bw",
           adjustments: NEUTRAL_MEDIA_ADJUSTMENTS,
         })
-      ).toEqual([])
+      ).toEqual(["mediaFilter", "mediaEffects"])
     })
 
     it("groups by sorted field set so unlike edits don't merge in history", () => {

--- a/wiki/core/animate-mode.md
+++ b/wiki/core/animate-mode.md
@@ -51,9 +51,11 @@ AnimationClip {
 
 `AnimationEffect` union (`state-types.ts`):
 
-`position` · `zoom` · `tilt` · `padding` · `shadow` · `background` · `backdrop` · `canvasRadius` · `lighting` · `filter` · `portrait` · `pattern` · `overlay` · `border` · `borderRadius` · `crop`
+`position` · `zoom` · `tilt` · `padding` · `shadow` · `background` · `backdrop` · `canvasRadius` · `lighting` · `filter` · `mediaEffects` · `mediaFilter` · `portrait` · `pattern` · `overlay` · `border` · `borderRadius` · `crop`
 
-Slot-limited set: `tilt` · `zoom` · `shadow` · `position` · `border` · `borderRadius` · `padding` · `lighting` — see `SLOT_ANIMATABLE_EFFECTS` in `store.tsx`. Everything else is main-canvas only.
+`backdrop`/`filter` grade the canvas backdrop; `mediaEffects`/`mediaFilter` grade the screenshot or video's own pixels.
+
+Slot-limited set: `tilt` · `zoom` · `shadow` · `position` · `border` · `borderRadius` · `padding` · `lighting` · `mediaEffects` · `mediaFilter` — see `SLOT_ANIMATABLE_EFFECTS` in `store.tsx`. Everything else is main-canvas only.
 
 ### Easing
 
@@ -102,11 +104,11 @@ Renderers read `var(--anim-…, <committed fallback>)` so committed style shows 
 
 ---
 
-## Two interpolation shapes
+## Three interpolation shapes
 
 ### Numeric / interpolatable tracks
 
-tilt, zoom, padding, canvasRadius, shadow, border, lighting, crop, …  
+tilt, zoom, padding, canvasRadius, shadow, border, lighting, crop, mediaEffects, …  
 
 `sampleKeyframes` + a `lerpValue` (`shadowBetween`, `borderBetween`, `lightingBetween`, …).
 
@@ -122,6 +124,22 @@ background, filter, portrait, pattern, overlay — each keyframe owns a layer; p
 Resolvers: `resolveAnimateXStack` in `animation-playback.ts`. Render: `canvas-backdrop.tsx` (+ overlay over/under in `canvas-view.tsx`).
 
 Invisible rest constants: `INVISIBLE_BORDER`, `INVISIBLE_SHADOW`, `lightingEntranceRest`, etc.
+
+### Channel blends
+
+`mediaFilter` — the filter preset on the screenshot/video pixels. Stacking layers is not an option there (a video would have to be decoded once per layer), so `assetFilterVector` turns each preset into its channels and the player eases between them, emitting one chain into the media-grade var.
+
+A sample that is still sitting on one preset keeps that preset's name (`MediaFilterBlend.preset`) and emits `assetFilterCss`'s own chain, so the value the player holds at the end of a keyframe is byte-identical to the committed one it settles into. Only a genuine mid-transition falls back to the blended channels.
+
+---
+
+## The resting frame
+
+Leaving Animate mode restores the committed canvas to **where the animation starts**: every effect resolves to the first keyframe that owns it — the value that keyframe eases FROM — and an effect no keyframe owns keeps the canvas's own value. `buildRestingPose` in `store.tsx` builds it; `setIsAnimateMode(false)` applies it.
+
+Keyframes describe motion, so they must not leave their look baked into the document. The static editor, the still/PNG export, the share image and the draft thumbnail all read the committed canvas, and they show the composition the user built rather than the last frame of its animation.
+
+Entering Animate mode is the mirror: the committed canvas is the animation's start, so an edit made outside is routed to each effect's *first* owning keyframe (moving where the animation begins) instead of being folded onto the last keyframe. Only a property nothing animates carries onto that last keyframe, since for those the canvas value is plain document style.
 
 ---
 


### PR DESCRIPTION
Makes the screenshot/video grade animatable, and fixes two things found while getting it to survive an export.

## Keyframe the media grade

Colour grading and filter presets for the screenshot/video landed in #52, but only ever applied to the committed canvas — Animate mode could keyframe the *backdrop's* grade and not the media's. This adds `mediaEffects` (the colour grade) and `mediaFilter` (the filter preset) as animatable effects, on the main screenshot and on extra slots.

Both halves share one CSS var, so a keyframe animating only one of them still emits the committed value for the other rather than silently dropping it.

Filter presets can't stack layers the way the backdrop's do — a video would have to be decoded once per layer — so `assetFilterVector` turns each preset into its channels and the player eases between them. A sample still sitting on one preset keeps that preset's name and emits `assetFilterCss`'s own chain, so the value held at the end of a keyframe is byte-identical to the committed one it settles into. Only a genuine mid-transition uses the blended channels.

## Keyframes no longer bind their look to the canvas

Leaving Animate mode used to fold the animation's **final frame** onto the committed canvas, so a keyframe permanently restyled the document and a still/PNG export showed the end of the animation instead of the composition. Only `position` was exempt.

`buildRestingPose` now resolves every effect to the **first** keyframe that owns it — the value it eases FROM — and leaves an effect no keyframe owns at the canvas's own value. Entering is the mirror: an edit made outside Animate mode moves each effect's first owning keyframe rather than being folded onto the last one.

Driven by the exhaustive `EFFECT_MAIN_POSE_FIELDS` / `EFFECT_SLOT_POSE_FIELDS` maps, so any future effect gets it automatically.

> Worth knowing for review: the only existing coverage of this rule tested `position`, which already behaved this way — so the suite passing proved nothing about the change. `animation-resting-frame.test.ts` is new and covers the general rule.

## Safari exports

Two separate, pre-existing bugs, both on the WebKit-only decoded path.

**`ctx.filter` is ignored.** WebKit accepts the assignment and silently does nothing, so the grade vanished from every exported frame that paints decoded pixels by hand — which on that engine is every frame of a video export. Every leg of the chain except `blur()` is a per-pixel function from the Filter Effects spec and they compose into one affine colour matrix, so `frame-grade.ts` reimplements the chain and runs it where the native path doesn't work.

**Decoded frames are left in studio swing.** Exports came out lifted and low-contrast. Instrumenting both engines showed Safari contradicting *itself* in one run:

| stage | black | white |
|---|---|---|
| native `<video>` draw | 0 | — |
| html-to-image scene raster | 0 | — |
| **WebCodecs decoded frame** | **15** | **234** |

15 and 234 are 16 and 235 — the frames are never stretched back to full range, so blacks sit at 6% grey and highlights are pulled down 8%. Chromium never saw it because it rasterizes the `<video>` itself; the decoded path exists only because Safari can't seek an offscreen `<video>` reliably, so the workaround for one bug walked into another. Mediabunny's `CanvasSink` hands back a canvas, so the `VideoFrame`'s colour metadata is gone before anything downstream could have known.

The repair runs at the decode source, so the plain video export and the Animate keyframe export both get corrected frames.

It does **not** hardcode WebKit. `calibrateRange` compares the first decoded frame against the engine's own conversion of the same picture and expands only when the decoded floor actually sits at studio black *and* is well above the native one. Content cancels out because it's one frame converted two ways, so a dark clip doesn't read as limited-range and an engine that already converts correctly is never touched. Anything undecidable declines — better a washed frame than crushed blacks. Firefox also uses this path and gets whatever it measures.

Calibration is explicit rather than lazy because the two callers differ: the Animate path swaps the clone's `<video>` for an `<img>` before any frame is requested, and its first frame is a clip's start rather than 0 — a lazy check would have compared two different pictures and both false-positived and false-negatived depending on the clip.

## Shapes library

Unrelated, bundled here — say the word and I'll split it out.

The Shapes section paged all 106 shapes in on scroll from the moment it opened, so the inspector grew as you scrolled past it. It now shows 8 with an expand tile holding its own grid slot (the backgrounds idiom) and only arms the infinite scroll once expanded. Expanding used to push the rest of the inspector down; a `ResizeObserver` caps the expanded scroller to the collapsed grid's measured height so it scrolls in place, re-measuring on width change rather than freezing the first value.

## Verification

`pnpm typecheck`, `pnpm lint:strict`, `pnpm test` — 165 files, 1326 tests, clean.

Both Safari fixes were confirmed by hand in Safari 26.6 against Chrome 151, on the normal video export and the Animate export.

New: `animation-media-grade.test.ts`, `animation-resting-frame.test.ts`, `frame-grade.test.ts`, `frame-range.test.ts`, `shapes-section.test.tsx`. `animation-release-frame.test.ts` gained the two new effects, so its "every animated var moves during the release, none of them stall" contract now covers them.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes screenshot and video colour grades keyframeable, changes animated canvases to rest at their starting pose, and repairs Safari’s decoded-frame grading and limited-range conversion. It also adds a collapsed, expandable Shapes library and updates documentation and test coverage.
- Adds main and per-slot media grade/filter animation sampling, interpolation, state capture, and export support.
- Introduces software filter-chain rendering and calibrated limited-range expansion for decoded video frames.
- Reworks Animate-mode entry and exit pose handling around each effect’s first owning keyframe.
- Limits the initial Shapes grid and enables paging only after expansion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete changed-code defect remains after reviewing the animation state, export grading, range calibration, and Shapes expansion paths.

The media-grade tracks preserve first-owner baselines and slot scope across playback and export, the Safari fallbacks decline undecidable calibration and parsing cases safely, and the Shapes pagination remains reachable after explicit expansion.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/editor/store.tsx | Reworks Animate-mode resting poses and first-owner baseline propagation while adding media-grade fields to main and slot animation state. |
| lib/editor/apply-animation-frame.ts | Samples main and per-slot media filter and adjustment tracks into shared CSS grade variables for playback and export. |
| lib/editor/animation-playback.ts | Adds channel-wise media adjustment and preset interpolation, including stable preset output at keyframe boundaries. |
| lib/editor/animation-export/video-media/frame-grade.ts | Implements parsed software rendering of the supported CSS grade chain for engines where Canvas2D filters do not work. |
| lib/editor/animation-export/video-media/frame-range.ts | Detects decoded limited-range frames by comparison with the browser-native rendering and conditionally expands them to full range. |
| lib/editor/animation-export/video-media/decoded-frames.ts | Integrates explicit range calibration and idempotent repair into the decoded-frame source. |
| lib/editor/animation-export/video-media/frame-renderer.ts | Applies resolved animated grades through native Canvas2D filters or the software fallback when painting decoded frames. |
| components/editor/inspector/shapes-section.tsx | Adds an eight-shape collapsed preview, fixed-height expansion, and expansion-gated incremental loading. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(inspector): gate the shapes library ..."](https://github.com/shivabhattacharjee/tokokino/commit/b4e53ca9ac86d44873fce208cfb28818c488f960) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51426250)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animate screenshot and video color grades, filters, and adjustments, including effects on individual slots.
  * Added Safari export support for media grades and filters.
  * Expanded the Shapes panel with a compact preview and expandable library.
  * Improved video export color accuracy across supported media.

* **Bug Fixes**
  * Exiting Animate mode now restores the canvas to the correct starting appearance.

* **Documentation**
  * Updated animation guidance for media effects, interpolation, slots, and resting-frame behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->