### PR TITLE
fix: address editor store review follow-ups

### DIFF
--- a/components/editor/enhance-presets.tsx
+++ b/components/editor/enhance-presets.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 
 import { enhanceFilterCss } from "@/lib/editor/css-utils"
+import { fullPageCaptureMediaStyle } from "@/lib/editor/full-page-capture"
 import { isVideoSrc } from "@/lib/editor/media-type"
 import { useVideoRegistry } from "@/lib/editor/video-registry"
 import {
@@ -60,14 +61,21 @@ function videoFrameDataUrl(video: HTMLVideoElement): string | null {
 export function EnhancePresetGrid({ className }: { className?: string }) {
   const enhance = useActiveCanvasField((c) => c.enhance)
   const screenshot = useActiveCanvasField((c) => c.screenshot)
+  const fullPageCapture = useActiveCanvasField((c) => c.fullPageCapture)
   const slots = useActiveCanvasField((c) => c.screenshotSlots)
   const activeCanvasId = useActiveCanvasId()
   const setEnhance = useEditorStore((s) => s.setEnhance)
 
-  const stillSrc =
-    screenshot && !isVideoSrc(screenshot)
-      ? screenshot
-      : (slots.find((slot) => slot.src && !isVideoSrc(slot.src))?.src ?? null)
+  const stillFromMain = Boolean(screenshot && !isVideoSrc(screenshot))
+  const stillSlot = stillFromMain
+    ? null
+    : (slots.find((slot) => slot.src && !isVideoSrc(slot.src)) ?? null)
+  const stillSrc = stillFromMain ? screenshot : (stillSlot?.src ?? null)
+  // Long screenshots crop via object-position on the canvas — match that so
+  // thumbs show the same band, not the vertical center of the full page.
+  const samplePosition = fullPageCaptureMediaStyle(
+    stillFromMain ? fullPageCapture : stillSlot?.fullPageCapture
+  )?.objectPosition
 
   const needsVideoFrame = !stillSrc && isVideoSrc(screenshot)
   // Grabbed once when the panel mounts — the popover/sheet opens fresh each
@@ -99,10 +107,13 @@ export function EnhancePresetGrid({ className }: { className?: string }) {
           >
             <span className="block w-full overflow-hidden rounded-[5px]">
               <span
-                className="block aspect-[4/3] w-full bg-cover bg-center"
+                className="block aspect-[4/3] w-full bg-cover"
                 style={{
                   ...(sample
-                    ? { backgroundImage: `url(${sample})` }
+                    ? {
+                        backgroundImage: `url(${sample})`,
+                        backgroundPosition: samplePosition ?? "center",
+                      }
                     : CHART_STYLE),
                   filter: enhanceFilterCss(preset.id),
                 }}

--- a/lib/editor/store/actions/animation.ts
+++ b/lib/editor/store/actions/animation.ts
@@ -393,22 +393,24 @@ export const createAnimationActions = ({
       const state = get().present
       const resolvedId = canvasId ?? state.activeCanvasId
       const canvas = state.canvases.find((c) => c.id === resolvedId)
-      const source = canvas
-        ? getCanvasAnimation(canvas).clips.find((clip) => clip.id === id)
-        : undefined
+      const animation = canvas ? getCanvasAnimation(canvas) : null
+      if (!animation) return null
+      const source = animation.clips.find((clip) => clip.id === id)
       if (!source) return null
       const newId = makeId()
+      const clips = insertClipCopy(animation.clips, source.id, newId)
+      if (clips === animation.clips) return null
       commitCanvas(
-        canvasId,
+        resolvedId,
         (c) => {
-          const animation = getCanvasAnimation(c)
-          // The copy sits immediately after the original (clamped to the max
-          // range; it may land past the set duration and render faded). Duration
-          // is user-controlled — the copy never grows it.
+          const current = getCanvasAnimation(c)
+          // The copy sits immediately after the original (it may land past the
+          // set duration and render faded). Duration is user-controlled — the
+          // copy never grows it.
           return {
             animation: {
-              ...animation,
-              clips: insertClipCopy(animation.clips, source.id, newId),
+              ...current,
+              clips,
             },
           }
         },
@@ -525,16 +527,19 @@ export const createAnimationActions = ({
         .sort((a, b) => a.startMs - b.startMs)
       if (sources.length === 0) return []
       const newIds: string[] = []
+      let clips = existing
+      for (const source of sources) {
+        const newId = makeId()
+        const inserted = insertClipCopy(clips, source.id, newId)
+        if (inserted === clips) continue
+        clips = inserted
+        newIds.push(newId)
+      }
+      if (newIds.length === 0) return []
       commitCanvas(
-        canvasId,
+        resolvedId,
         (c) => {
           const animation = getCanvasAnimation(c)
-          let clips = animation.clips
-          for (const source of sources) {
-            const newId = makeId()
-            newIds.push(newId)
-            clips = insertClipCopy(clips, source.id, newId)
-          }
           return { animation: { ...animation, clips } }
         },
         null
@@ -658,7 +663,12 @@ export const createAnimationActions = ({
       // Hand the open-clip role to the second half (its pose is the live canvas,
       // so the canvas already shows it — no reload needed). A later
       // selectAnimationClip(newId) then no-ops instead of re-saving over the cut.
-      if (wasOpen) set({ selectedAnimationClipId: newId })
+      if (wasOpen) {
+        set({
+          selectedAnimationClipId: newId,
+          selectedAnimationClipIds: [newId],
+        })
+      }
       return newId
     },
     clearAnimationClips: (canvasId) =>

--- a/lib/editor/store/actions/animation.ts
+++ b/lib/editor/store/actions/animation.ts
@@ -531,11 +531,13 @@ export const createAnimationActions = ({
       for (const source of sources) {
         const newId = makeId()
         const inserted = insertClipCopy(clips, source.id, newId)
-        if (inserted === clips) continue
+        // Bulk duplicate is atomic for the valid selected clips: if any copy
+        // cannot fit, keep the timeline unchanged instead of committing a
+        // partial group while reporting overall success.
+        if (inserted === clips) return []
         clips = inserted
         newIds.push(newId)
       }
-      if (newIds.length === 0) return []
       commitCanvas(
         resolvedId,
         (c) => {

--- a/lib/editor/store/actions/canvas-style.ts
+++ b/lib/editor/store/actions/canvas-style.ts
@@ -116,9 +116,7 @@ export const createCanvasStyleActions = ({
               scale:
                 shouldReapply && activeGeometry
                   ? activeGeometry.canvasScale
-                  : activeSinglePreset
-                    ? canvas.scale
-                    : canvas.scale,
+                  : canvas.scale,
               screenshotOffset,
               screenshotSlots,
               annotations: scaleAnnotationStrokesForAspectChange(
@@ -202,9 +200,7 @@ export const createCanvasStyleActions = ({
             scale:
               shouldReapply && activeGeometry
                 ? activeGeometry.canvasScale
-                : activeSinglePreset
-                  ? canvas.scale
-                  : canvas.scale,
+                : canvas.scale,
             screenshotOffset:
               shouldReapply && activeGeometry
                 ? resolveMainOffsetPx(activeGeometry.mainOffset)

--- a/lib/editor/store/actions/project.ts
+++ b/lib/editor/store/actions/project.ts
@@ -2,6 +2,7 @@ import { clipBaseline, clipPose } from "../../animation-playback"
 import { mergeCanvasStyle } from "../../preset-fields"
 import { resolveMainOffsetPx } from "../../preset-geometry"
 import { remapAnimationForApply } from "../../custom-preset-snapshot"
+import { presetGeometrySchema } from "../../../schemas/preset"
 import type {
   CanvasState,
   EditorState,
@@ -19,6 +20,30 @@ import type { CustomPresetSummary, EditorActions } from "../types"
 // is stale (logout, account switch, or a superseding sort request).
 let customPresetsRequestToken = 0
 let customPresetsInFlightUserId: string | null = null
+
+const isPresetSummary = (preset: unknown): preset is CustomPresetSummary => {
+  if (typeof preset !== "object" || preset === null) return false
+  const candidate = preset as Record<string, unknown>
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.name === "string" &&
+    Number.isInteger(candidate.slotCount) &&
+    Number(candidate.slotCount) >= 0 &&
+    (candidate.type === undefined ||
+      candidate.type === "style" ||
+      candidate.type === "animate") &&
+    presetGeometrySchema.safeParse(candidate.geometry).success
+  )
+}
+
+const isPresetResponse = (
+  body: unknown
+): body is { presets: CustomPresetSummary[] } =>
+  typeof body === "object" &&
+  body !== null &&
+  "presets" in body &&
+  Array.isArray(body.presets) &&
+  body.presets.every(isPresetSummary)
 
 export const createProjectActions = ({ set, get, commit }: CommitContext) =>
   ({
@@ -88,7 +113,10 @@ export const createProjectActions = ({ set, get, commit }: CommitContext) =>
       void fetch(`/api/presets?sort=${nextSort}`, { credentials: "include" })
         .then(async (res) => {
           if (!res.ok) throw new Error(`Preset load failed: ${res.status}`)
-          const body: { presets: CustomPresetSummary[] } = await res.json()
+          const body: unknown = await res.json()
+          if (!isPresetResponse(body)) {
+            throw new Error("Preset load returned an invalid response")
+          }
           return body.presets
         })
         .then((presets) => {
@@ -218,6 +246,9 @@ export const createProjectActions = ({ set, get, commit }: CommitContext) =>
             screenshotSlots: canvas.screenshotSlots.map((slot) => ({
               ...slot,
               src: null,
+              originalSrc: null,
+              lastCropRegion: null,
+              fullPageCapture: null,
             })),
           }
           if (canvas.id === incoming.activeCanvasId && prevActive) {

--- a/lib/editor/store/actions/slots.ts
+++ b/lib/editor/store/actions/slots.ts
@@ -82,9 +82,9 @@ export const createSlotActions = ({
           slot.id === id ? { ...slot, ...patch } : slot
         ),
       })
-      // A slot's transform + shadow + position + border/radius/padding/lighting
-      // edits become owned effects on the open keyframe; other slot changes (fit,
-      // filter…) don't animate, so they commit normally.
+      // A slot's transform, styling, lighting, and media-grade edits become
+      // owned effects on the open keyframe; non-animated changes (such as fit)
+      // commit normally.
       const effects: AnimationEffect[] = []
       if ("tilt" in patch || "rotation" in patch) effects.push("tilt")
       if ("scale" in patch) effects.push("zoom")
@@ -94,6 +94,8 @@ export const createSlotActions = ({
       if ("borderRadius" in patch) effects.push("borderRadius")
       if ("padding" in patch) effects.push("padding")
       if ("lighting" in patch) effects.push("lighting")
+      if ("adjustments" in patch) effects.push("mediaEffects")
+      if ("filter" in patch) effects.push("mediaFilter")
       if (effects.length === 0) {
         commitCanvas(canvasId, apply, `screenshot-slot-${id}`)
       } else {

--- a/lib/editor/store/animation-helpers.ts
+++ b/lib/editor/store/animation-helpers.ts
@@ -697,34 +697,36 @@ export const insertClipCopy = (
   const source = clips.find((c) => c.id === sourceId)
   if (!source) return clips
   const dur = source.durationMs
-  const insertStart = Math.min(
-    source.startMs + dur,
-    Math.max(0, MAX_DURATION_MS - dur)
+  const insertStart = source.startMs + dur
+  if (insertStart + dur > MAX_DURATION_MS) return clips
+  const later = clips.filter(
+    (clip) => clip.id !== source.id && clip.startMs >= insertStart
   )
-  const nextStart = clips
-    .filter((clip) => clip.id !== source.id && clip.startMs >= insertStart)
-    .reduce((min, clip) => Math.min(min, clip.startMs), Infinity)
+  const nextStart = later.reduce(
+    (min, clip) => Math.min(min, clip.startMs),
+    Infinity
+  )
   const shift = Number.isFinite(nextStart)
     ? Math.max(0, insertStart + dur - nextStart)
     : 0
+  const availableShift = later.reduce(
+    (available, clip) =>
+      Math.min(available, MAX_DURATION_MS - (clip.startMs + clip.durationMs)),
+    Infinity
+  )
+  // The cap leaves no legal room for a duplicate. Partially clamping individual
+  // clips would collapse their spacing and overlap the copy, so decline instead.
+  if (shift > availableShift) return clips
   const shifted = clips.map((clip) =>
     clip.id !== source.id && clip.startMs >= insertStart
       ? {
           ...clip,
-          startMs: Math.min(
-            clip.startMs + shift,
-            Math.max(0, MAX_DURATION_MS - clip.durationMs)
-          ),
+          startMs: clip.startMs + shift,
         }
       : clip
   )
   const copy: AnimationClip = { ...source, id: newId, startMs: insertStart }
-  const sourceIndex = shifted.findIndex((cl) => cl.id === source.id)
-  return [
-    ...shifted.slice(0, sourceIndex + 1),
-    copy,
-    ...shifted.slice(sourceIndex + 1),
-  ]
+  return [...shifted, copy].sort((a, b) => a.startMs - b.startMs)
 }
 
 /**

--- a/tests/components/editor/enhance-panel.test.tsx
+++ b/tests/components/editor/enhance-panel.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const store = vi.hoisted(() => ({
   enhance: "off",
   screenshot: null as string | null,
+  fullPageCapture: null as { scrollPosition: number } | null,
   setEnhance: vi.fn(),
 }))
 
@@ -16,6 +17,7 @@ vi.mock("@/lib/editor/store", () => ({
     selector({
       enhance: store.enhance,
       screenshot: store.screenshot,
+      fullPageCapture: store.fullPageCapture,
       screenshotSlots: [],
     }),
   useActiveCanvasId: () => "canvas-1",
@@ -29,6 +31,7 @@ import { ENHANCE_PRESETS } from "@/components/editor/enhance-presets"
 beforeEach(() => {
   store.enhance = "off"
   store.screenshot = null
+  store.fullPageCapture = null
 })
 afterEach(() => vi.clearAllMocks())
 
@@ -65,6 +68,16 @@ describe("MobileEnhancePanel", () => {
     expect(previews[0].style.backgroundImage).toContain(
       "data:image/png;base64,AAAA"
     )
+  })
+
+  it("matches the long-screenshot scroll crop in preset thumbs", () => {
+    store.screenshot = "data:image/png;base64,AAAA"
+    store.fullPageCapture = { scrollPosition: 12 }
+    const { container } = render(<MobileEnhancePanel />)
+    const previews = container.querySelectorAll<HTMLElement>(
+      "[style*='background-image']"
+    )
+    expect(previews[0].style.backgroundPosition).toBe("50% 12%")
   })
 
   it("applies a preset on click", async () => {

--- a/tests/lib/editor/animation-media-grade.test.ts
+++ b/tests/lib/editor/animation-media-grade.test.ts
@@ -325,6 +325,30 @@ describe("a media-grade edit binds an unbound keyframe to the selected slot", ()
     expect(clipById(clipId).effects).toContain("mediaEffects")
   })
 
+  it("registers direct slot filter updates on the open keyframe", () => {
+    const slotId = useEditorStore.getState().addScreenshotSlot()!
+    const clipId = openUnboundClip()
+
+    useEditorStore.getState().setSelectedScreenshotSlotId(slotId)
+    useEditorStore.getState().updateScreenshotSlot(slotId, { filter: "noir" })
+
+    expect(clipById(clipId).target).toEqual({ scope: "slot", slotId })
+    expect(clipById(clipId).effects).toContain("mediaFilter")
+  })
+
+  it("registers direct slot colour-grade updates on the open keyframe", () => {
+    const slotId = useEditorStore.getState().addScreenshotSlot()!
+    const clipId = openUnboundClip()
+
+    useEditorStore.getState().setSelectedScreenshotSlotId(slotId)
+    useEditorStore
+      .getState()
+      .updateScreenshotSlot(slotId, { adjustments: GRADED })
+
+    expect(clipById(clipId).target).toEqual({ scope: "slot", slotId })
+    expect(clipById(clipId).effects).toContain("mediaEffects")
+  })
+
   it("leaves the keyframe canvas-wide when no slot is selected", () => {
     useEditorStore.getState().addScreenshotSlot()
     const clipId = openUnboundClip()

--- a/tests/lib/editor/store/custom-presets-load.test.ts
+++ b/tests/lib/editor/store/custom-presets-load.test.ts
@@ -63,6 +63,39 @@ describe("loadCustomPresets", () => {
     expect(store.getState().customPresetsError).toBe(true)
   })
 
+  it("flags an error when the response has no presets array", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ presets: { id: "not-an-array" } }),
+      })
+    )
+
+    store.getState().loadCustomPresets("user_1")
+    await flush()
+
+    expect(store.getState().customPresetsError).toBe(true)
+    expect(store.getState().customPresets).toEqual([])
+    expect(store.getState().customPresetsLoading).toBe(false)
+  })
+
+  it("flags an error when the presets array contains malformed entries", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ presets: [null] }),
+      })
+    )
+
+    store.getState().loadCustomPresets("user_1")
+    await flush()
+
+    expect(store.getState().customPresetsError).toBe(true)
+    expect(store.getState().customPresets).toEqual([])
+  })
+
   it("lets a retry through after a failure", async () => {
     const fetchMock = vi
       .fn()

--- a/tests/lib/editor/store/duplicate-refusals.test.ts
+++ b/tests/lib/editor/store/duplicate-refusals.test.ts
@@ -81,6 +81,24 @@ describe("duplicateAnimationClips refusals", () => {
     expect(store.getState().duplicateAnimationClips([sourceId])).toEqual([])
     expect(clips()).toHaveLength(2)
   })
+
+  it("refuses the whole bulk duplicate when any selected clip cannot fit", () => {
+    const firstId = store.getState().addAnimationClip()
+    const saturatedId = store.getState().addAnimationClip()
+    store.getState().updateAnimationClip(firstId, {
+      startMs: 0,
+      durationMs: 1_000,
+    })
+    store.getState().updateAnimationClip(saturatedId, {
+      startMs: MAX_DURATION_MS - 1_000,
+      durationMs: 1_000,
+    })
+
+    expect(
+      store.getState().duplicateAnimationClips([firstId, saturatedId])
+    ).toEqual([])
+    expect(clips().map((clip) => clip.id)).toEqual([firstId, saturatedId])
+  })
 })
 
 describe("duplicateVideoClip refusals", () => {

--- a/tests/lib/editor/store/duplicate-refusals.test.ts
+++ b/tests/lib/editor/store/duplicate-refusals.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest"
 
 import { useEditorStore } from "@/lib/editor/store"
+import { MAX_DURATION_MS } from "@/lib/editor/animation-timeline"
 
 /**
  * The timeline's Duplicate actions can decline, and the UI now reports that
@@ -44,6 +45,41 @@ describe("duplicateAnimationClips refusals", () => {
     expect(store.getState().duplicateAnimationClips([id], "missing")).toEqual(
       []
     )
+  })
+
+  it("refuses a copy when later clips cannot ripple without overlap", () => {
+    const sourceId = store.getState().addAnimationClip()
+    const laterId = store.getState().addAnimationClip()
+    store.getState().updateAnimationClip(sourceId, {
+      startMs: MAX_DURATION_MS - 2_000,
+      durationMs: 1_000,
+    })
+    store.getState().updateAnimationClip(laterId, {
+      startMs: MAX_DURATION_MS - 1_000,
+      durationMs: 1_000,
+    })
+
+    expect(store.getState().duplicateAnimationClip(sourceId)).toBeNull()
+    expect(clips()).toHaveLength(2)
+    expect(clips().find((clip) => clip.id === laterId)?.startMs).toBe(
+      MAX_DURATION_MS - 1_000
+    )
+  })
+
+  it("skips saturated clips in bulk duplication", () => {
+    const sourceId = store.getState().addAnimationClip()
+    const laterId = store.getState().addAnimationClip()
+    store.getState().updateAnimationClip(sourceId, {
+      startMs: MAX_DURATION_MS - 2_000,
+      durationMs: 1_000,
+    })
+    store.getState().updateAnimationClip(laterId, {
+      startMs: MAX_DURATION_MS - 1_000,
+      durationMs: 1_000,
+    })
+
+    expect(store.getState().duplicateAnimationClips([sourceId])).toEqual([])
+    expect(clips()).toHaveLength(2)
   })
 })
 

--- a/tests/lib/editor/store/split-multi-screenshot.test.ts
+++ b/tests/lib/editor/store/split-multi-screenshot.test.ts
@@ -48,5 +48,6 @@ describe("splitAnimationClip with a multi-screenshot row", () => {
     expect(second.pose?.slots[slotId!].scale).toBe(300)
     expect(second.effects).toContain("zoom")
     expect(store.getState().selectedAnimationClipId).toBe(newId)
+    expect(store.getState().selectedAnimationClipIds).toEqual([newId])
   })
 })

--- a/tests/lib/editor/store/template-load.test.ts
+++ b/tests/lib/editor/store/template-load.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { useEditorStore } from "@/lib/editor/store"
+
+const store = useEditorStore
+
+describe("loadTemplateState", () => {
+  beforeEach(() => store.getState().reset())
+
+  it("removes every media and crop field from template screenshot slots", () => {
+    const slotId = store.getState().addScreenshotSlot()!
+    const incoming = structuredClone(store.getState().present)
+    const canvas = incoming.canvases.find(
+      (item) => item.id === incoming.activeCanvasId
+    )!
+    const slot = canvas.screenshotSlots.find((item) => item.id === slotId)!
+    slot.src = "template-crop.png"
+    slot.originalSrc = "template-original.png"
+    slot.lastCropRegion = { x: 1, y: 2, width: 300, height: 200 }
+    slot.fullPageCapture = { scrollPosition: 480 }
+
+    store.getState().loadTemplateState(incoming)
+
+    const loaded = store
+      .getState()
+      .present.canvases.find((item) => item.id === incoming.activeCanvasId)!
+      .screenshotSlots.find((item) => item.id === slotId)!
+    expect(loaded.src).toBeNull()
+    expect(loaded.originalSrc).toBeNull()
+    expect(loaded.lastCropRegion).toBeNull()
+    expect(loaded.fullPageCapture).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Follow up on the modular editor-store refactor by verifying the post-merge review comments and fixing only the behavior issues that still reproduce.

## Type of Change

- [x] fix
- [x] refactor
- [ ] delete
- [ ] optimised
- [ ] docs

## Related Issues

Follow-up to #54.

## Changes Made

- keep single and multi clip selection synchronized after splitting an open keyframe
- clear screenshot-slot source, crop, and full-page metadata when applying templates
- validate custom preset response envelopes, entries, and geometry before updating store state
- register direct slot filter and adjustment edits as animated media effects
- preserve canvas scale while simplifying redundant aspect-change branches
- ripple duplicated clips as a coordinated group and refuse copies that cannot fit before the one-hour cap without overlap
- add focused regressions for every corrected behavior

The remaining review suggestions were cleanup-only abstractions, API churn for an unreachable normal path, or timeout policy changes outside this focused fix, so they were intentionally left unchanged.

## Screenshots / Recordings (if UI)

Not applicable; these are state-management correctness fixes with no visual redesign.

## Checklist

- [x] I ran `pnpm lint`
- [x] I ran `pnpm typecheck`
- [x] I ran `pnpm test` (1,348 tests across 167 files)
- [x] I did not include secrets or sensitive data
- [x] Documentation is not required for these internal behavior fixes
- [x] I kept this PR focused and reasonably small

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This follow-up corrects editor-store state handling and validates the previously reported bulk-duplication fix.
- Makes bulk clip duplication atomic and rejects copies that cannot fit without overlap.
- Synchronizes clip selection after splitting an open keyframe.
- Clears stale slot-media metadata when applying templates.
- Validates custom-preset responses before updating store state.
- Registers slot filter and adjustment edits as animated effects.
- Preserves canvas scale during aspect changes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/editor/store/actions/animation.ts | Bulk duplication now computes the complete result before committing, so an insertion refusal leaves the timeline unchanged. |
| lib/editor/store/animation-helpers.ts | Clip-copy insertion now rejects cap and ripple-overlap violations instead of clamping clips into invalid positions. |
| lib/editor/store/actions/project.ts | Adds response validation and clears stale screenshot-slot media metadata during template loading. |
| lib/editor/store/actions/slots.ts | Records direct slot adjustment and filter updates as their corresponding animation effects. |
| lib/editor/store/actions/canvas-style.ts | Simplifies redundant aspect-change branches without changing canvas-scale behavior. |
| components/editor/enhance-presets.tsx | Aligns enhancement thumbnails with full-page screenshot positioning. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: make bulk duplication atomic"](https://github.com/shivabhattacharjee/tokokino/commit/9580e74ea8dfa719789d6258b175039d0ca521ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51440409)</sub>

<!-- /greptile_comment -->