### PR TITLE
perf(export): move GIF and video encoding off the main thread

### DIFF
--- a/components/editor/top-bar/export-controls.tsx
+++ b/components/editor/top-bar/export-controls.tsx
@@ -129,6 +129,23 @@ const ANIMATION_CAPTURE_MODE_LABELS: Record<AnimationCaptureMode, string> = {
 }
 const ANIMATION_BUTTON_MAX_LABEL = `Export ${ANIMATION_RESOLUTION_LABELS.fullhd} • ${ANIMATION_FORMAT_LABELS.webm}`
 
+/**
+ * Confirmation naming the file that actually landed in Downloads, the way the
+ * still-image export does. The download paths hand back their resolved
+ * filename — which follows the user's filename format — so falling back to the
+ * format label only happens on the `asBlob` branch these callers never take.
+ */
+function animationSavedMessage(
+  savedAs: string | { extension: string },
+  format: AnimationExportFormat
+): string {
+  const filename =
+    typeof savedAs === "string"
+      ? savedAs
+      : `${ANIMATION_FORMAT_LABELS[format]}${ANIMATION_FORMAT_EXTENSION[format]}`
+  return `Saved as ${filename}`
+}
+
 /** Phase copy — GIF encode is palette work, not "video". */
 function animationExportPhaseLabel(
   phase: AnimationExportProgress["phase"] | "idle" | undefined,
@@ -137,6 +154,8 @@ function animationExportPhaseLabel(
   switch (phase) {
     case "preparing":
       return "Preparing canvas"
+    case "audio":
+      return "Adding audio"
     case "capturing":
       return "Rendering frames"
     case "encoding":
@@ -149,9 +168,17 @@ function animationExportPhaseLabel(
 }
 
 /**
- * Map phase-local counters onto one continuous bar so GIF (and video) don't
- * jump back to 0% when capture ends and encode begins.
- * Preparing stays at 0 (no fake "4%"); capture then encode share the bar.
+ * Map phase-local counters onto one continuous bar, in the order the phases
+ * run, so none of them jumps the fill backwards as they hand over.
+ *
+ * `capturing` owns nearly the whole bar because it owns nearly all the work:
+ * each frame is palette-mapped (GIF) or handed to the video encoder as it is
+ * captured, so by the time the loop ends only the container flush is left. The
+ * old 70/28 split reserved a third of the bar for that flush, which is why every
+ * export sat at 70% until the file dropped.
+ *
+ * `preparing` gets a small band rather than a flat 0: for GIF it is the palette
+ * sampling pass, which is real frame captures with real per-frame counts.
  */
 function overallExportProgressRatio(
   progress: AnimationExportProgress | null
@@ -161,13 +188,15 @@ function overallExportProgressRatio(
   const phaseRatio = total > 0 ? Math.min(1, Math.max(0, current / total)) : 0
   switch (phase) {
     case "preparing":
-      return 0
+      return phaseRatio * 0.04
+    case "audio":
+      return 0.04 + phaseRatio * 0.04
     case "capturing":
-      return phaseRatio * 0.7
+      return 0.08 + phaseRatio * 0.88
     case "encoding":
-      return 0.7 + phaseRatio * 0.28
+      return 0.96 + phaseRatio * 0.03
     case "finishing":
-      return 0.98 + phaseRatio * 0.02
+      return 0.99 + phaseRatio * 0.01
     default:
       return 0
   }
@@ -716,7 +745,7 @@ export function ExportControls({
       setAnimProgress({ phase: "preparing", current: 0, total: 1, etaMs: null })
       setOpen(false)
       try {
-        await exportVideoMedia(activeCanvasId, {
+        const savedAs = await exportVideoMedia(activeCanvasId, {
           format: animFormat,
           fps: effectiveAnimFps,
           targetWidth: ANIMATION_RESOLUTION_WIDTHS[animResolution],
@@ -746,9 +775,7 @@ export function ExportControls({
           fps: effectiveAnimFps,
           export_type: "video",
         })
-        toast.success(
-          `Saved as ${ANIMATION_FORMAT_LABELS[animFormat]}${ANIMATION_FORMAT_EXTENSION[animFormat]}`
-        )
+        toast.success(animationSavedMessage(savedAs, animFormat))
       } catch (err) {
         if (
           err instanceof AnimationExportAbortedError ||
@@ -800,7 +827,7 @@ export function ExportControls({
       })
       setOpen(false)
       try {
-        await exportAnimation(activeCanvasId, {
+        const savedAs = await exportAnimation(activeCanvasId, {
           format: animFormat,
           fps: effectiveAnimFps,
           targetWidth: ANIMATION_RESOLUTION_WIDTHS[animResolution],
@@ -833,9 +860,7 @@ export function ExportControls({
           export_type: "animation",
           capture_mode: animCapture,
         })
-        toast.success(
-          `Saved as ${ANIMATION_FORMAT_LABELS[animFormat]}${ANIMATION_FORMAT_EXTENSION[animFormat]}`
-        )
+        toast.success(animationSavedMessage(savedAs, animFormat))
       } catch (err) {
         if (
           err instanceof AnimationExportAbortedError ||

--- a/components/editor/top-bar/index.tsx
+++ b/components/editor/top-bar/index.tsx
@@ -66,7 +66,7 @@ import {
   exportAnimationBlob,
   type AnimationExportProgress,
 } from "@/lib/editor/animation-export"
-import { exportVideoMedia } from "@/lib/editor/animation-export/video-media"
+import { exportVideoMediaBlob } from "@/lib/editor/animation-export/video-media"
 import {
   createVideoObjectUrl,
   isVideoFile,
@@ -652,10 +652,7 @@ export function TopBar() {
           setShareProgress(toShareProgress(p)),
       }
       const videoResult = isPlainVideoCanvas
-        ? await exportVideoMedia(activeCanvasId, {
-            ...exportOptions,
-            asBlob: true,
-          })
+        ? await exportVideoMediaBlob(activeCanvasId, exportOptions)
         : null
       const animationResult = isPlainVideoCanvas
         ? null

--- a/components/editor/top-bar/share-controls.tsx
+++ b/components/editor/top-bar/share-controls.tsx
@@ -49,21 +49,24 @@ export type ShareProgressState = {
 const PHASE_STEP: Record<ShareProgressState["phase"], number> = {
   idle: 0,
   preparing: 0.05,
-  capturing: 0.15,
-  encoding: 0.75,
-  finishing: 0.92,
-  uploading: 0.95,
+  audio: 0.08,
+  capturing: 0.1,
+  encoding: 0.8,
+  finishing: 0.9,
+  uploading: 0.92,
 }
 
 function progressPercent(progress: ShareProgressState | null): number {
   if (!progress) return 8
   const { phase, current, total } = progress
   if (phase === "capturing" && total > 0) {
-    // 15% → 75% while frames render
-    return Math.min(75, 15 + (current / total) * 60)
+    // 10% → 80% while frames render. Capture is the bulk of the encode too —
+    // each frame is encoded as it is captured — so the phase that follows is a
+    // container flush, not another pass, and gets a correspondingly thin band.
+    return Math.min(80, 10 + (current / total) * 70)
   }
   if (phase === "encoding" && total > 0) {
-    return Math.min(92, 75 + (current / Math.max(total, 1)) * 17)
+    return Math.min(90, 80 + (current / Math.max(total, 1)) * 10)
   }
   if (phase === "uploading" && total > 0) {
     return Math.min(100, 92 + (current / total) * 8)
@@ -355,7 +358,9 @@ function ShareContent({
                   ? "Encoding"
                   : progress?.phase === "capturing"
                     ? "Rendering"
-                    : "Preparing"}
+                    : progress?.phase === "audio"
+                      ? "Adding audio"
+                      : "Preparing"}
             </span>
           </div>
         </div>

--- a/lib/editor/animation-export/abort.ts
+++ b/lib/editor/animation-export/abort.ts
@@ -16,3 +16,18 @@ export class AnimationExportAbortedError extends Error {
 export function throwIfAborted(signal?: AbortSignal) {
   if (signal?.aborted) throw new AnimationExportAbortedError()
 }
+
+/**
+ * Whether `err` is an export cancellation.
+ *
+ * The name check is not redundant: the error can cross a worker boundary, where
+ * it is rebuilt from the wire and is no longer an instance of the class here.
+ * Callers use this to decide between rethrowing and falling back to another
+ * encoder — getting it wrong restarts a whole export the user just cancelled.
+ */
+export function isAnimationExportAborted(err: unknown): boolean {
+  return (
+    err instanceof AnimationExportAbortedError ||
+    (err instanceof Error && err.name === "AnimationExportAbortedError")
+  )
+}

--- a/lib/editor/animation-export/abort.ts
+++ b/lib/editor/animation-export/abort.ts
@@ -1,0 +1,18 @@
+/**
+ * Abort primitives shared by the export pipeline.
+ *
+ * Split out of `utils.ts` because the encode workers need these and `utils.ts`
+ * reaches into `../export` and `@/lib/download` — pulling html-to-image and the
+ * whole DOM capture path into a worker bundle that has no `document`.
+ */
+
+export class AnimationExportAbortedError extends Error {
+  constructor(message = "Export cancelled") {
+    super(message)
+    this.name = "AnimationExportAbortedError"
+  }
+}
+
+export function throwIfAborted(signal?: AbortSignal) {
+  if (signal?.aborted) throw new AnimationExportAbortedError()
+}

--- a/lib/editor/animation-export/animation-audio.ts
+++ b/lib/editor/animation-export/animation-audio.ts
@@ -26,7 +26,7 @@ import {
   type WebMOutputFormat,
 } from "mediabunny"
 
-import { throwIfAborted } from "./utils"
+import { throwIfAborted } from "./abort"
 import type { VideoSegment } from "./video-layer"
 import {
   containerAudioCodecs,
@@ -72,14 +72,14 @@ export function audioWindowSec(
  * the export then proceeds silently rather than failing.
  */
 export async function prepareAnimationAudio({
-  src,
+  source,
   format,
   outputFormat,
   segments,
   exportDurationSec,
   signal,
 }: {
-  src: string
+  source: Blob
   format: "mp4" | "webm"
   outputFormat: Mp4OutputFormat | WebMOutputFormat
   segments: readonly VideoSegment[]
@@ -90,16 +90,13 @@ export async function prepareAnimationAudio({
   if (windowSec <= 0) return null
 
   if (isUntouchedTimeline(segments)) {
-    return prepareSourceAudio(src, format, outputFormat, windowSec, signal)
+    return prepareSourceAudio(source, format, outputFormat, windowSec, signal)
   }
 
   let input: Input | null = null
   try {
     throwIfAborted(signal)
-    const res = await fetch(src)
-    if (!res.ok) return null
-    const blob = await res.blob()
-    input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) })
+    input = new Input({ formats: ALL_FORMATS, source: new BlobSource(source) })
     const track = await input.getPrimaryAudioTrack()
     // Re-timing means re-encoding, so unlike the passthrough path this needs the
     // audio to be decodable here.

--- a/lib/editor/animation-export/gif-codec.ts
+++ b/lib/editor/animation-export/gif-codec.ts
@@ -148,11 +148,17 @@ export class GifStreamEncoder {
     }
     const combined = new Uint8Array(this.sampleBytes)
     let offset = 0
-    for (const sample of this.samples) {
+    // Drop each sample as it is copied rather than after the loop: both copies
+    // are live until then, and 16 sampled 1080p frames is ~130 MB per copy —
+    // right before quantize() wants a working set of its own.
+    for (
+      let sample = this.samples.shift();
+      sample;
+      sample = this.samples.shift()
+    ) {
       combined.set(sample, offset)
       offset += sample.length
     }
-    this.samples.length = 0
     this.sampleBytes = 0
     this.palette = quantize(combined, 256)
     this.ditherAmplitude = paletteDitherAmplitude(this.palette)

--- a/lib/editor/animation-export/gif-codec.ts
+++ b/lib/editor/animation-export/gif-codec.ts
@@ -1,0 +1,204 @@
+/**
+ * GIF encoding maths, with no DOM in sight — one shared 256-color palette built
+ * from sampled frames, ordered dithering, and streaming frame writes.
+ *
+ * Deliberately free of any browser-only API so the exact same code runs in the
+ * encode worker (`workers/gif-encoder.worker.ts`) and in the main-thread
+ * fallback used when workers are unavailable.
+ */
+
+import { GIFEncoder, quantize, applyPalette, type Palette } from "gifenc"
+
+/** Frames to sample when building the shared palette — enough to cover the
+ *  clip's color range without feeding every pixel of every frame to quantize. */
+export const GIF_PALETTE_SAMPLE_FRAMES = 16
+
+/**
+ * Fastest cadence a GIF can actually express. Delays are whole centiseconds and
+ * viewers clamp anything under 2cs to ~10cs, so 2cs (50fps) is the floor per
+ * frame. Asking for more doesn't play faster — the encoder still emits 2cs and
+ * the clip runs long (60fps would stretch it by 20%). Callers clamp to this.
+ */
+export const MAX_GIF_FPS = 50
+
+// Cap on GIF output volume = frames × pixels-per-frame. gifenc buffers the
+// whole compressed stream in memory, so this bounds peak usage regardless of
+// clip length or resolution. ~350M keeps the buffer comfortably under ~300 MB
+// even for poorly-compressing footage, while still allowing ~20 s at 1080p or
+// much longer at smaller sizes.
+export const MAX_GIF_TOTAL_PIXELS = 350_000_000
+
+/**
+ * True when a GIF export of this many frames at this size would risk exhausting
+ * memory (gifenc holds the entire compressed stream in RAM until finish()).
+ * Callers should fail fast with a clear message rather than crash the tab.
+ */
+export function gifExportExceedsMemory(
+  frameCount: number,
+  width: number,
+  height: number
+): boolean {
+  return frameCount * width * height > MAX_GIF_TOTAL_PIXELS
+}
+
+// 8×8 Bayer threshold matrix (values 0–63) for ordered dithering. Ordered
+// dithering is deterministic — the same spatial pattern every frame — so it
+// smooths the banding a 256-color palette produces on photographic/image
+// backgrounds without the temporal flicker that error-diffusion would add.
+// prettier-ignore
+const BAYER_8 = [
+   0, 32,  8, 40,  2, 34, 10, 42,
+  48, 16, 56, 24, 50, 18, 58, 26,
+  12, 44,  4, 36, 14, 46,  6, 38,
+  60, 28, 52, 20, 62, 30, 54, 22,
+   3, 35, 11, 43,  1, 33,  9, 41,
+  51, 19, 59, 27, 49, 17, 57, 25,
+  15, 47,  7, 39, 13, 45,  5, 37,
+  63, 31, 55, 23, 61, 29, 53, 21,
+]
+
+/**
+ * Pick a dither strength from the palette's own coarseness: the mean distance
+ * from each palette color to its nearest neighbor approximates the quantization
+ * step, so we dither by a bit less than that. A palette with big gaps (rich
+ * image, lots of banding) gets stronger dithering; a tight palette gets almost
+ * none, keeping flat UI areas clean.
+ */
+export function paletteDitherAmplitude(palette: Palette): number {
+  let sum = 0
+  let count = 0
+  for (let i = 0; i < palette.length; i++) {
+    const a = palette[i]
+    let nearest = Infinity
+    for (let j = 0; j < palette.length; j++) {
+      if (i === j) continue
+      const b = palette[j]
+      const dr = a[0] - b[0]
+      const dg = a[1] - b[1]
+      const db = a[2] - b[2]
+      const d = dr * dr + dg * dg + db * db
+      if (d < nearest) nearest = d
+    }
+    if (nearest < Infinity) {
+      sum += Math.sqrt(nearest)
+      count++
+    }
+  }
+  const meanStep = count ? sum / count : 24
+  return Math.max(6, Math.min(40, meanStep * 0.75))
+}
+
+/**
+ * Apply ordered (Bayer) dithering in place before palette mapping. Adds a
+ * per-pixel threshold offset so `applyPalette`'s nearest-color pick alternates
+ * between neighboring palette entries across a smooth region — the eye blends
+ * them back into a gradient instead of seeing hard bands. Uint8ClampedArray
+ * rounds/clamps on assignment, so no manual clamping is needed.
+ */
+export function orderedDither(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+  amplitude: number
+) {
+  for (let y = 0; y < height; y++) {
+    const bayerRow = (y & 7) << 3
+    for (let x = 0; x < width; x++) {
+      const t = (BAYER_8[bayerRow + (x & 7)] / 64 - 0.5) * amplitude
+      const p = (y * width + x) << 2
+      data[p] = data[p] + t
+      data[p + 1] = data[p + 1] + t
+      data[p + 2] = data[p + 2] + t
+    }
+  }
+}
+
+/**
+ * Two-pass GIF encoder: collect palette samples, build the shared palette, then
+ * stream frames through it. Only the current frame is ever held, so timeline
+ * length is bounded by {@link gifExportExceedsMemory} rather than by RAM.
+ *
+ * GIF delays are whole centiseconds (1/100 s), so the target frame duration is
+ * distributed across frames Bresenham-style: the average cadence matches the
+ * requested fps with no rounding drift, which is what removes the playback
+ * stutter versus naively truncating each delay.
+ */
+export class GifStreamEncoder {
+  private readonly samples: Uint8ClampedArray[] = []
+  private sampleBytes = 0
+  private palette: Palette | null = null
+  private ditherAmplitude = 0
+  private readonly gif = GIFEncoder()
+  private emittedCs = 0
+  private written = 0
+
+  addSample(data: Uint8ClampedArray) {
+    this.samples.push(data)
+    this.sampleBytes += data.length
+  }
+
+  get sampleCount() {
+    return this.samples.length
+  }
+
+  /** Quantize the collected samples into one palette. The heavy call. */
+  buildPalette() {
+    if (this.sampleBytes === 0) {
+      throw new Error("No frames captured for GIF export")
+    }
+    const combined = new Uint8Array(this.sampleBytes)
+    let offset = 0
+    for (const sample of this.samples) {
+      combined.set(sample, offset)
+      offset += sample.length
+    }
+    this.samples.length = 0
+    this.sampleBytes = 0
+    this.palette = quantize(combined, 256)
+    this.ditherAmplitude = paletteDitherAmplitude(this.palette)
+  }
+
+  /**
+   * Dither, map onto the shared palette, and write one frame. `elapsedMs` is the
+   * frame's end time on the timeline, from which the centisecond delay for this
+   * frame is derived.
+   */
+  writeFrame(
+    data: Uint8ClampedArray,
+    width: number,
+    height: number,
+    elapsedMs: number
+  ) {
+    const palette = this.palette
+    if (!palette) throw new Error("GIF palette has not been built")
+    orderedDither(data, width, height, this.ditherAmplitude)
+    const index = applyPalette(data, palette)
+    const targetCs = Math.round(elapsedMs / 10)
+    // Never below 2cs — most viewers clamp shorter delays to ~10cs, which would
+    // itself look like a stutter.
+    const delayCs = Math.max(2, targetCs - this.emittedCs)
+    this.emittedCs += delayCs
+    this.gif.writeFrame(index, width, height, {
+      palette,
+      delay: delayCs * 10,
+    })
+    this.written++
+  }
+
+  get frameCount() {
+    return this.written
+  }
+
+  finish(): Uint8Array<ArrayBuffer> {
+    if (this.written === 0) {
+      throw new Error("No frames captured for GIF export")
+    }
+    this.gif.finish()
+    // Copies out of gifenc's internal buffer, so the result owns its bytes and
+    // can be transferred back across the worker boundary.
+    const view = this.gif.bytesView()
+    const bytes = new Uint8Array(new ArrayBuffer(view.byteLength))
+    bytes.set(view)
+    return bytes
+  }
+}

--- a/lib/editor/animation-export/gif.ts
+++ b/lib/editor/animation-export/gif.ts
@@ -1,97 +1,18 @@
 /**
- * GIF encode (gifenc, pure JS). Builds one shared 256-color palette for the whole
- * clip from sampled frames, then ordered-dithers and writes each frame straight
- * into the encoder with centisecond-accurate delays so playback cadence matches
- * the requested fps — up to `MAX_GIF_FPS`, which callers must clamp to.
+ * GIF encode for the Animate-mode export. The main thread only rasterizes
+ * frames; the palette build, dithering, palette mapping and gifenc stream run in
+ * the encode worker (see `workers/gif-encoder-client.ts`), which both keeps the
+ * UI responsive and overlaps encoding with the next frame's capture.
  */
-
-import { GIFEncoder, quantize, applyPalette, type Palette } from "gifenc"
 
 import { captureStableFrame } from "./capture"
+import { GIF_PALETTE_SAMPLE_FRAMES, gifExportExceedsMemory } from "./gif-codec"
 import type { CaptureCtx } from "./types"
-import { throwIfAborted } from "./utils"
-import { gifExportExceedsMemory } from "./video-media/encode-gif"
+import { createUiYielder, throwIfAborted } from "./utils"
 import { drawWatermark } from "./watermark"
+import { createGifEncoderSession } from "./workers/gif-encoder-client"
 
-/** Frames to sample when building the shared palette — enough to cover the
- *  clip's color range without feeding every pixel of every frame to quantize. */
-const GIF_PALETTE_SAMPLE_FRAMES = 16
-
-/**
- * Fastest cadence a GIF can actually express. Delays are whole centiseconds and
- * viewers clamp anything under 2cs to ~10cs, so 2cs (50fps) is the floor per
- * frame. Asking for more doesn't play faster — the encoder still emits 2cs and
- * the clip runs long (60fps would stretch it by 20%). Callers clamp to this.
- */
-export const MAX_GIF_FPS = 50
-
-// 8×8 Bayer threshold matrix (values 0–63) for ordered dithering. Ordered
-// dithering is deterministic — the same spatial pattern every frame — so it
-// smooths the banding a 256-color palette produces on photographic/image
-// backgrounds without the temporal flicker that error-diffusion would add.
-// prettier-ignore
-const BAYER_8 = [
-   0, 32,  8, 40,  2, 34, 10, 42,
-  48, 16, 56, 24, 50, 18, 58, 26,
-  12, 44,  4, 36, 14, 46,  6, 38,
-  60, 28, 52, 20, 62, 30, 54, 22,
-   3, 35, 11, 43,  1, 33,  9, 41,
-  51, 19, 59, 27, 49, 17, 57, 25,
-  15, 47,  7, 39, 13, 45,  5, 37,
-  63, 31, 55, 23, 61, 29, 53, 21,
-]
-
-/**
- * Pick a dither strength from the palette's own coarseness: the mean distance
- * from each palette color to its nearest neighbor approximates the quantization
- * step, so we dither by a bit less than that. A palette with big gaps (rich
- * image, lots of banding) gets stronger dithering; a tight palette gets almost
- * none, keeping flat UI areas clean.
- */
-function paletteDitherAmplitude(palette: Palette): number {
-  let sum = 0
-  let count = 0
-  for (let i = 0; i < palette.length; i++) {
-    const a = palette[i]
-    let nearest = Infinity
-    for (let j = 0; j < palette.length; j++) {
-      if (i === j) continue
-      const b = palette[j]
-      const dr = a[0] - b[0]
-      const dg = a[1] - b[1]
-      const db = a[2] - b[2]
-      const d = dr * dr + dg * dg + db * db
-      if (d < nearest) nearest = d
-    }
-    if (nearest < Infinity) {
-      sum += Math.sqrt(nearest)
-      count++
-    }
-  }
-  const meanStep = count ? sum / count : 24
-  return Math.max(6, Math.min(40, meanStep * 0.75))
-}
-
-/**
- * Apply ordered (Bayer) dithering in place before palette mapping. Adds a
- * per-pixel threshold offset so `applyPalette`'s nearest-color pick alternates
- * between neighboring palette entries across a smooth region — the eye blends
- * them back into a gradient instead of seeing hard bands. Uint8ClampedArray
- * rounds/clamps on assignment, so no manual clamping is needed.
- */
-function orderedDither(img: ImageData, amplitude: number) {
-  const { data, width, height } = img
-  for (let y = 0; y < height; y++) {
-    const bayerRow = (y & 7) << 3
-    for (let x = 0; x < width; x++) {
-      const t = (BAYER_8[bayerRow + (x & 7)] / 64 - 0.5) * amplitude
-      const p = (y * width + x) << 2
-      data[p] = data[p] + t
-      data[p + 1] = data[p + 1] + t
-      data[p + 2] = data[p + 2] + t
-    }
-  }
-}
+export { MAX_GIF_FPS } from "./gif-codec"
 
 export async function encodeGif(ctx: CaptureCtx) {
   const {
@@ -133,80 +54,66 @@ export async function encodeGif(ctx: CaptureCtx) {
     return gctx.getImageData(0, 0, frameCanvas.width, frameCanvas.height)
   }
 
-  // Pass 1 — build ONE shared 256-color palette (a per-frame palette is what
-  // causes frame-to-frame color shimmer) from a handful of evenly spaced frames.
-  // Sampling rather than buffering every frame keeps peak memory flat, so the
-  // timeline can be arbitrarily long.
-  const sampleCount = Math.min(GIF_PALETTE_SAMPLE_FRAMES, frameCount)
-  progress.report("preparing", 0, sampleCount)
-  const sampleData: Uint8ClampedArray[] = []
-  let total = 0
-  for (let s = 0; s < sampleCount; s++) {
-    throwIfAborted(signal)
-    // Bias to frameCount - 1 on the last sample so end-state colors are covered.
-    const f =
-      s === sampleCount - 1
-        ? frameCount - 1
-        : Math.floor((s / sampleCount) * frameCount)
-    const frame = await renderFrame(f)
-    if (frame) {
-      sampleData.push(frame.data)
-      total += frame.data.length
+  const encoder = await createGifEncoderSession()
+  const yieldToUi = createUiYielder()
+
+  try {
+    // Pass 1 — build ONE shared 256-color palette (a per-frame palette is what
+    // causes frame-to-frame color shimmer) from a handful of evenly spaced frames.
+    // Sampling rather than buffering every frame keeps peak memory flat, so the
+    // timeline can be arbitrarily long.
+    const sampleCount = Math.min(GIF_PALETTE_SAMPLE_FRAMES, frameCount)
+    progress.report("preparing", 0, sampleCount)
+    let sampled = 0
+    for (let s = 0; s < sampleCount; s++) {
+      await yieldToUi()
+      throwIfAborted(signal)
+      // Bias to frameCount - 1 on the last sample so end-state colors are covered.
+      const f =
+        s === sampleCount - 1
+          ? frameCount - 1
+          : Math.floor((s / sampleCount) * frameCount)
+      const frame = await renderFrame(f)
+      if (frame) {
+        await encoder.addSample(frame.data)
+        sampled++
+      }
+      progress.report("preparing", s + 1, sampleCount)
     }
-    progress.report("preparing", s + 1, sampleCount)
-  }
-  if (total === 0) throw new Error("No frames captured for GIF export")
+    if (sampled === 0) throw new Error("No frames captured for GIF export")
 
-  const combined = new Uint8Array(total)
-  let offset = 0
-  for (const d of sampleData) {
-    combined.set(d, offset)
-    offset += d.length
-  }
-  sampleData.length = 0
-  const palette: Palette = quantize(combined, 256)
-  const ditherAmplitude = paletteDitherAmplitude(palette)
-
-  // Pass 2 — render each frame, map onto the shared palette, write it straight
-  // into the encoder. Only the current frame is ever held in memory.
-  //
-  // GIF delays are whole centiseconds (1/100 s). Distribute the target frame
-  // duration across frames (Bresenham-style) so the average cadence matches the
-  // requested fps with no rounding drift — this is what removes the playback
-  // stutter versus naively truncating each delay to centiseconds.
-  const gif = GIFEncoder()
-  let emittedCs = 0
-  let written = 0
-  progress.report("capturing", 0, frameCount)
-  for (let f = 0; f < frameCount; f++) {
     throwIfAborted(signal)
-    const frame = await renderFrame(f)
-    if (!frame) {
+    await yieldToUi()
+    await encoder.buildPalette()
+
+    // Pass 2 — render each frame and hand its pixels to the encoder. The buffer
+    // is transferred, so only the frames still in the worker's queue are held.
+    let written = 0
+    progress.report("capturing", 0, frameCount)
+    for (let f = 0; f < frameCount; f++) {
+      await yieldToUi()
+      throwIfAborted(signal)
+      const frame = await renderFrame(f)
+      if (frame) {
+        await encoder.writeFrame(
+          frame.data,
+          frame.width,
+          frame.height,
+          (f + 1) * frameDurationMs
+        )
+        written++
+      }
       progress.report("capturing", f + 1, frameCount)
-      continue
     }
-    // Ordered-dither before mapping to soften 256-color banding on image
-    // backgrounds; deterministic, so it doesn't reintroduce frame-to-frame flicker.
-    orderedDither(frame, ditherAmplitude)
-    const index = applyPalette(frame.data, palette)
-    const targetCs = Math.round(((f + 1) * frameDurationMs) / 10)
-    // Never below 2cs — most viewers clamp shorter delays to ~10cs, which would
-    // itself look like a stutter.
-    const delayCs = Math.max(2, targetCs - emittedCs)
-    emittedCs += delayCs
-    gif.writeFrame(index, frame.width, frame.height, {
-      palette,
-      delay: delayCs * 10,
-    })
-    written++
-    progress.report("capturing", f + 1, frameCount)
+
+    if (written === 0) throw new Error("No frames captured for GIF export")
+
+    throwIfAborted(signal)
+    progress.report("encoding", 0, 1)
+    const bytes = await encoder.finish()
+    progress.report("encoding", 1, 1)
+    return new Blob([bytes], { type: "image/gif" })
+  } finally {
+    encoder.dispose()
   }
-
-  if (written === 0) throw new Error("No frames captured for GIF export")
-
-  throwIfAborted(signal)
-  progress.report("encoding", 0, 1)
-  gif.finish()
-  progress.report("encoding", 1, 1)
-  return new Blob([new Uint8Array(gif.bytesView())], { type: "image/gif" })
 }

--- a/lib/editor/animation-export/gif.ts
+++ b/lib/editor/animation-export/gif.ts
@@ -54,7 +54,7 @@ export async function encodeGif(ctx: CaptureCtx) {
     return gctx.getImageData(0, 0, frameCanvas.width, frameCanvas.height)
   }
 
-  const encoder = await createGifEncoderSession()
+  const encoder = await createGifEncoderSession(signal)
   const yieldToUi = createUiYielder()
 
   try {

--- a/lib/editor/animation-export/index.ts
+++ b/lib/editor/animation-export/index.ts
@@ -34,6 +34,7 @@ import {
   resolveAnimationDownloadFilename,
   throwIfAborted,
   triggerDownload,
+  waitForPaint,
 } from "./utils"
 import { encodeWebmMediaRecorder, tryEncodeWithMediabunny } from "./video"
 import { loadWatermarkLogo, resolveWatermarkFontStack } from "./watermark"
@@ -52,11 +53,15 @@ export type {
 /**
  * Render the active canvas's animation timeline.
  * 100% on-device encode — download by default, or return a blob for Share.
+ *
+ * Returns the resolved download filename (matching `exportCanvas`) so callers
+ * can name the real file in their confirmation, rather than guessing it from the
+ * format label.
  */
 export async function exportAnimation(
   canvasId: string,
   options: AnimationExportOptions
-): Promise<void | AnimationExportBlobResult> {
+): Promise<string | AnimationExportBlobResult> {
   const result = await encodeAnimation(canvasId, options)
   if (options.asBlob) return result
   const targetWidth =
@@ -68,7 +73,11 @@ export async function exportAnimation(
     targetWidth,
     extension: result.extension,
   })
+  // The last progress reports land in the same task as the download, so without
+  // a paint the bar is still showing mid-capture when the dialog tears down.
+  await waitForPaint()
   triggerDownload(result.blob, filename)
+  return filename
 }
 
 /** Encode animation and always return the blob (for share uploads). */

--- a/lib/editor/animation-export/types.ts
+++ b/lib/editor/animation-export/types.ts
@@ -9,8 +9,15 @@ import type { CloneVideoLayer } from "./video-layer"
 
 export type AnimationExportFormat = "webm" | "mp4" | "gif"
 
+/**
+ * Export phases in the order they run. `audio` sits before `capturing` because
+ * the source clip's audio is muxed first (the muxer would otherwise buffer every
+ * video packet waiting on the first audio one) — reporting it as `encoding`
+ * pushed the bar to the encode band and then snapped it back when frames began.
+ */
 export type AnimationExportPhase =
   | "preparing"
+  | "audio"
   | "capturing"
   | "encoding"
   | "finishing"

--- a/lib/editor/animation-export/utils.ts
+++ b/lib/editor/animation-export/utils.ts
@@ -12,16 +12,7 @@ import { triggerAnchorDownload } from "@/lib/download"
 import { getCanvasRenderedDims } from "../export"
 import { resolveExportDownloadFilename } from "../export-filename"
 
-export class AnimationExportAbortedError extends Error {
-  constructor(message = "Export cancelled") {
-    super(message)
-    this.name = "AnimationExportAbortedError"
-  }
-}
-
-export function throwIfAborted(signal?: AbortSignal) {
-  if (signal?.aborted) throw new AnimationExportAbortedError()
-}
+export { AnimationExportAbortedError, throwIfAborted } from "./abort"
 
 export function triggerDownload(blob: Blob, filename: string) {
   const url = URL.createObjectURL(blob)
@@ -103,6 +94,48 @@ export function waitForPaint(): Promise<void> {
       requestAnimationFrame(() => resolve())
     })
   })
+}
+
+type SchedulerYield = { yield?: () => Promise<void> }
+
+/**
+ * Hand the main thread back to the browser mid-export so queued input (the
+ * dialog's Cancel button) and a progress repaint can actually run.
+ *
+ * `scheduler.yield()` resumes at the *front* of the task queue, so the export
+ * doesn't lose its slot to unrelated work. The MessageChannel fallback is a
+ * plain task; `setTimeout(0)` is not equivalent — it's clamped to 4ms+ once
+ * nested, which is real overhead at hundreds of frames.
+ */
+export function yieldToUi(): Promise<void> {
+  const scheduler = (globalThis as { scheduler?: SchedulerYield }).scheduler
+  if (typeof scheduler?.yield === "function") {
+    return scheduler.yield().catch(() => {})
+  }
+  if (typeof MessageChannel === "undefined") return Promise.resolve()
+  return new Promise((resolve) => {
+    const channel = new MessageChannel()
+    channel.port1.onmessage = () => {
+      channel.port1.close()
+      resolve()
+    }
+    channel.port2.postMessage(null)
+  })
+}
+
+/**
+ * Budgeted variant of {@link yieldToUi} for per-frame loops: yields only once
+ * `budgetMs` of uninterrupted work has gone by. A frame that already takes
+ * longer than the budget therefore yields every iteration, while cheap frames
+ * batch up instead of paying a task hop each.
+ */
+export function createUiYielder(budgetMs = 40): () => Promise<void> {
+  let lastYieldAt = performance.now()
+  return async () => {
+    if (performance.now() - lastYieldAt < budgetMs) return
+    await yieldToUi()
+    lastYieldAt = performance.now()
+  }
 }
 
 export type ProgressReporter = {

--- a/lib/editor/animation-export/utils.ts
+++ b/lib/editor/animation-export/utils.ts
@@ -88,10 +88,27 @@ export function animationMimeAndExt(format: AnimationExportFormat): {
   return { contentType: "video/webm", extension: "webm" }
 }
 
+/**
+ * Longest a paint wait may block. `requestAnimationFrame` does not fire at all
+ * in a backgrounded tab, so an unbounded wait would stall an export that the
+ * user switched away from — including the one just before the download, leaving
+ * a finished file that never lands. Two frames is ~32ms in the normal case, so
+ * this only ever trips when rAF is genuinely paused.
+ */
+const MAX_PAINT_WAIT_MS = 1_000
+
 export function waitForPaint(): Promise<void> {
   return new Promise((resolve) => {
+    let settled = false
+    const done = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve()
+    }
+    const timer = setTimeout(done, MAX_PAINT_WAIT_MS)
     requestAnimationFrame(() => {
-      requestAnimationFrame(() => resolve())
+      requestAnimationFrame(done)
     })
   })
 }

--- a/lib/editor/animation-export/video-media/audio.ts
+++ b/lib/editor/animation-export/video-media/audio.ts
@@ -32,13 +32,22 @@ import { throwIfAborted } from "../abort"
  * the URL: object URLs are minted against the page's environment and the export
  * can be racing a `revokeObjectURL` from the media registry. Returns null when
  * the source can't be read — audio is always best-effort.
+ *
+ * A cancelled export is the one failure that must not read as "no audio":
+ * returning null there would carry on into a silent encode instead of stopping,
+ * so an abort is rethrown rather than swallowed with the rest.
  */
-export async function loadAudioSourceBlob(src: string): Promise<Blob | null> {
+export async function loadAudioSourceBlob(
+  src: string,
+  signal?: AbortSignal
+): Promise<Blob | null> {
+  throwIfAborted(signal)
   try {
-    const res = await fetch(src)
+    const res = await fetch(src, { signal })
     if (!res.ok) return null
     return await res.blob()
   } catch {
+    throwIfAborted(signal)
     return null
   }
 }

--- a/lib/editor/animation-export/video-media/audio.ts
+++ b/lib/editor/animation-export/video-media/audio.ts
@@ -23,7 +23,25 @@ import {
   type WebMOutputFormat,
 } from "mediabunny"
 
-import { throwIfAborted } from "../utils"
+import { throwIfAborted } from "../abort"
+
+/**
+ * Fetch a media src into a Blob for the audio readers.
+ *
+ * The muxer runs in a worker, and handing it the bytes is safer than handing it
+ * the URL: object URLs are minted against the page's environment and the export
+ * can be racing a `revokeObjectURL` from the media registry. Returns null when
+ * the source can't be read — audio is always best-effort.
+ */
+export async function loadAudioSourceBlob(src: string): Promise<Blob | null> {
+  try {
+    const res = await fetch(src)
+    if (!res.ok) return null
+    return await res.blob()
+  } catch {
+    return null
+  }
+}
 
 /**
  * Preferred audio codecs for an export container, in preference order.
@@ -131,7 +149,7 @@ export type SourceAudioFeed = {
  * video export still proceeds silently.
  */
 export async function prepareSourceAudio(
-  src: string,
+  source: Blob,
   format: "mp4" | "webm",
   outputFormat: Mp4OutputFormat | WebMOutputFormat,
   durationSec: number,
@@ -140,10 +158,7 @@ export async function prepareSourceAudio(
   let input: Input | null = null
   try {
     throwIfAborted(signal)
-    const res = await fetch(src)
-    if (!res.ok) return null
-    const blob = await res.blob()
-    input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) })
+    input = new Input({ formats: ALL_FORMATS, source: new BlobSource(source) })
     const track = await input.getPrimaryAudioTrack()
     if (!track) {
       input.dispose()

--- a/lib/editor/animation-export/video-media/encode-gif.ts
+++ b/lib/editor/animation-export/video-media/encode-gif.ts
@@ -1,34 +1,24 @@
 /**
- * GIF encode for the video-media export (gifenc, pure JS): one shared palette
- * built from sampled frames, then a second pass that maps and writes each frame
- * straight into the encoder so only the current frame is ever in memory.
+ * GIF encode for the video-media export. Same two-pass shared-palette scheme as
+ * the Animate-mode GIF path, and the same worker: the main thread only renders
+ * frames, everything downstream of `getImageData` runs off-thread.
  */
 
-import { GIFEncoder, quantize, applyPalette } from "gifenc"
-
+import {
+  GIF_PALETTE_SAMPLE_FRAMES,
+  gifExportExceedsMemory,
+  MAX_GIF_TOTAL_PIXELS,
+} from "../gif-codec"
 import type { WatermarkAssets } from "../types"
-import { type createProgressReporter, throwIfAborted } from "../utils"
+import {
+  type createProgressReporter,
+  createUiYielder,
+  throwIfAborted,
+} from "../utils"
+import { createGifEncoderSession } from "../workers/gif-encoder-client"
 import { blitFrame, type FramePlan, type RenderFrame } from "./frames"
 
-// Cap on GIF output volume = frames × pixels-per-frame. gifenc buffers the
-// whole compressed stream in memory, so this bounds peak usage regardless of
-// clip length or resolution. ~350M keeps the buffer comfortably under ~300 MB
-// even for poorly-compressing footage, while still allowing ~20 s at 1080p or
-// much longer at smaller sizes.
-export const MAX_GIF_TOTAL_PIXELS = 350_000_000
-
-/**
- * True when a GIF export of this many frames at this size would risk exhausting
- * memory (gifenc holds the entire compressed stream in RAM until finish()).
- * Callers should fail fast with a clear message rather than crash the tab.
- */
-export function gifExportExceedsMemory(
-  frameCount: number,
-  width: number,
-  height: number
-): boolean {
-  return frameCount * width * height > MAX_GIF_TOTAL_PIXELS
-}
+export { MAX_GIF_TOTAL_PIXELS, gifExportExceedsMemory }
 
 export async function encodeGif(
   ctx: CanvasRenderingContext2D,
@@ -54,46 +44,48 @@ export async function encodeGif(
     )
   }
 
-  // Pass 1 — build ONE shared 256-color palette (kills frame-to-frame color
-  // shimmer) from a handful of evenly-spaced frames. We re-render for these
-  // rather than buffering every frame, so memory stays flat regardless of length.
-  const sampleCount = Math.min(16, plan.frameCount)
-  const sampleData: Uint8ClampedArray[] = []
-  let total = 0
-  for (let s = 0; s < sampleCount; s++) {
-    throwIfAborted(signal)
-    const f = Math.floor((s / sampleCount) * plan.frameCount)
-    blitFrame(ctx, await renderFrame(f), w, h, watermark)
-    const data = ctx.getImageData(0, 0, w, h).data
-    sampleData.push(data)
-    total += data.length
-    progress.report("preparing", s + 1, sampleCount)
-  }
-  const combined = new Uint8Array(total)
-  let offset = 0
-  for (const d of sampleData) {
-    combined.set(d, offset)
-    offset += d.length
-  }
-  const palette = quantize(combined, 256)
-  sampleData.length = 0
-
-  // Pass 2 — re-render each frame, map onto the shared palette, and write it
-  // straight into the encoder. Only the current frame is ever in memory.
-  const gif = GIFEncoder()
+  const encoder = await createGifEncoderSession()
+  const yieldToUi = createUiYielder()
   const delayMs = plan.frameDurationSec * 1000
-  let emittedCs = 0
-  progress.report("capturing", 0, plan.frameCount)
-  for (let f = 0; f < plan.frameCount; f++) {
+
+  try {
+    // Pass 1 — build ONE shared 256-color palette (kills frame-to-frame color
+    // shimmer) from a handful of evenly-spaced frames. We re-render for these
+    // rather than buffering every frame, so memory stays flat regardless of length.
+    const sampleCount = Math.min(GIF_PALETTE_SAMPLE_FRAMES, plan.frameCount)
+    for (let s = 0; s < sampleCount; s++) {
+      await yieldToUi()
+      throwIfAborted(signal)
+      const f = Math.floor((s / sampleCount) * plan.frameCount)
+      blitFrame(ctx, await renderFrame(f), w, h, watermark)
+      await encoder.addSample(ctx.getImageData(0, 0, w, h).data)
+      progress.report("preparing", s + 1, sampleCount)
+    }
+
     throwIfAborted(signal)
-    blitFrame(ctx, await renderFrame(f), w, h, watermark)
-    const index = applyPalette(ctx.getImageData(0, 0, w, h).data, palette)
-    const targetCs = Math.round(((f + 1) * delayMs) / 10)
-    const delayCs = Math.max(2, targetCs - emittedCs)
-    emittedCs += delayCs
-    gif.writeFrame(index, w, h, { palette, delay: delayCs * 10 })
-    progress.report("capturing", f + 1, plan.frameCount)
+    await yieldToUi()
+    await encoder.buildPalette()
+
+    // Pass 2 — re-render each frame and hand its pixels over. The buffer is
+    // transferred, so only the frames still queued in the worker are held.
+    progress.report("capturing", 0, plan.frameCount)
+    for (let f = 0; f < plan.frameCount; f++) {
+      await yieldToUi()
+      throwIfAborted(signal)
+      blitFrame(ctx, await renderFrame(f), w, h, watermark)
+      await encoder.writeFrame(
+        ctx.getImageData(0, 0, w, h).data,
+        w,
+        h,
+        (f + 1) * delayMs
+      )
+      progress.report("capturing", f + 1, plan.frameCount)
+    }
+
+    throwIfAborted(signal)
+    const bytes = await encoder.finish()
+    return new Blob([bytes], { type: "image/gif" })
+  } finally {
+    encoder.dispose()
   }
-  gif.finish()
-  return new Blob([new Uint8Array(gif.bytesView())], { type: "image/gif" })
 }

--- a/lib/editor/animation-export/video-media/encode-gif.ts
+++ b/lib/editor/animation-export/video-media/encode-gif.ts
@@ -44,7 +44,7 @@ export async function encodeGif(
     )
   }
 
-  const encoder = await createGifEncoderSession()
+  const encoder = await createGifEncoderSession(signal)
   const yieldToUi = createUiYielder()
   const delayMs = plan.frameDurationSec * 1000
 
@@ -56,7 +56,12 @@ export async function encodeGif(
     for (let s = 0; s < sampleCount; s++) {
       await yieldToUi()
       throwIfAborted(signal)
-      const f = Math.floor((s / sampleCount) * plan.frameCount)
+      // Bias to frameCount - 1 on the last sample so end-state colors are
+      // covered, matching the Animate-mode GIF path.
+      const f =
+        s === sampleCount - 1
+          ? plan.frameCount - 1
+          : Math.floor((s / sampleCount) * plan.frameCount)
       blitFrame(ctx, await renderFrame(f), w, h, watermark)
       await encoder.addSample(ctx.getImageData(0, 0, w, h).data)
       progress.report("preparing", s + 1, sampleCount)

--- a/lib/editor/animation-export/video-media/encode-video.ts
+++ b/lib/editor/animation-export/video-media/encode-video.ts
@@ -79,7 +79,7 @@ async function tryEncodeInWorker(
   sourceSrc: string,
   signal?: AbortSignal
 ): Promise<Blob | null> {
-  const audioBlob = await loadAudioSourceBlob(sourceSrc)
+  const audioBlob = await loadAudioSourceBlob(sourceSrc, signal)
   // Audio is decoded and re-encoded inside the worker during init, so report the
   // phase around the handshake rather than around a separate feed step.
   if (audioBlob) progress.report("audio", 0, 1)
@@ -183,7 +183,7 @@ export async function encodeMp4OrWebm(
   const outputFormat =
     format === "mp4" ? new Mp4OutputFormat() : new WebMOutputFormat()
   // Best-effort: missing/unusable audio → silent video, never fail the export.
-  const audioBlob = await loadAudioSourceBlob(sourceSrc)
+  const audioBlob = await loadAudioSourceBlob(sourceSrc, signal)
   const sourceAudio = audioBlob
     ? await prepareSourceAudio(
         audioBlob,

--- a/lib/editor/animation-export/video-media/encode-video.ts
+++ b/lib/editor/animation-export/video-media/encode-video.ts
@@ -1,6 +1,11 @@
 /**
  * MP4/WebM encode via WebCodecs (mediabunny): styled frames on the video track,
  * the source clip's audio remuxed or re-encoded alongside it.
+ *
+ * Preferred path hands the muxer and the audio to a worker (see
+ * `workers/video-muxer-client.ts`) and keeps only the frame rasterization here,
+ * since that needs the DOM. The in-process encoder below is the fallback for
+ * browsers without workers or when the worker can't start.
  */
 
 import {
@@ -19,10 +24,106 @@ import type { WatermarkAssets } from "../types"
 import {
   AnimationExportAbortedError,
   type createProgressReporter,
+  createUiYielder,
   throwIfAborted,
 } from "../utils"
-import { prepareSourceAudio } from "./audio"
+import { createVideoMuxSession } from "../workers/video-muxer-client"
+import { loadAudioSourceBlob, prepareSourceAudio } from "./audio"
 import { blitFrame, type FramePlan, type RenderFrame } from "./frames"
+
+type Progress = ReturnType<typeof createProgressReporter>
+
+/**
+ * Render each planned frame into `encodeCanvas` and hand it to `addFrame`.
+ * Shared by the worker and in-process encoders — the render half is main-thread
+ * either way.
+ */
+async function pumpFrames(
+  ctx: CanvasRenderingContext2D,
+  encodeCanvas: HTMLCanvasElement,
+  renderFrame: RenderFrame,
+  watermark: WatermarkAssets | null,
+  plan: FramePlan,
+  progress: Progress,
+  signal: AbortSignal | undefined,
+  addFrame: (timestampSec: number, durationSec: number) => Promise<void>
+) {
+  const yieldToUi = createUiYielder()
+  progress.report("capturing", 0, plan.frameCount)
+  for (let f = 0; f < plan.frameCount; f++) {
+    // Rasterizing a frame is main-thread DOM work; yield between frames so
+    // Cancel stays clickable and the progress bar can repaint.
+    await yieldToUi()
+    throwIfAborted(signal)
+    blitFrame(
+      ctx,
+      await renderFrame(f),
+      encodeCanvas.width,
+      encodeCanvas.height,
+      watermark
+    )
+    await addFrame(plan.timeForFrame(f), plan.frameDurationSec)
+    progress.report("capturing", f + 1, plan.frameCount)
+  }
+}
+
+async function tryEncodeInWorker(
+  format: "mp4" | "webm",
+  ctx: CanvasRenderingContext2D,
+  encodeCanvas: HTMLCanvasElement,
+  renderFrame: RenderFrame,
+  watermark: WatermarkAssets | null,
+  plan: FramePlan,
+  progress: Progress,
+  durationSec: number,
+  sourceSrc: string,
+  signal?: AbortSignal
+): Promise<Blob | null> {
+  const audioBlob = await loadAudioSourceBlob(sourceSrc)
+  // Audio is decoded and re-encoded inside the worker during init, so report the
+  // phase around the handshake rather than around a separate feed step.
+  if (audioBlob) progress.report("audio", 0, 1)
+
+  const session = await createVideoMuxSession(
+    {
+      format,
+      width: encodeCanvas.width,
+      height: encodeCanvas.height,
+      fps: Math.round(1 / plan.frameDurationSec),
+      keyFrameIntervalSec: ENCODE_KEY_FRAME_INTERVAL_SEC,
+      // This export plays the clip start to finish, so source and export time
+      // already agree — no timeline re-timing, hence no segments.
+      audio: audioBlob
+        ? { blob: audioBlob, durationSec, segments: null }
+        : null,
+    },
+    signal
+  )
+  if (!session) return null
+
+  try {
+    await pumpFrames(
+      ctx,
+      encodeCanvas,
+      renderFrame,
+      watermark,
+      plan,
+      progress,
+      signal,
+      (timestampSec, frameDurationSec) =>
+        session.addFrame(encodeCanvas, timestampSec, frameDurationSec)
+    )
+    throwIfAborted(signal)
+    progress.report("encoding", 0, 1)
+    const buffer = await session.finalize()
+    progress.report("encoding", 1, 1)
+    return new Blob([buffer], {
+      type: format === "mp4" ? "video/mp4" : "video/webm",
+    })
+  } finally {
+    session.dispose()
+  }
+}
 
 /** Encode planned frames to MP4 or WebM via Mediabunny + WebCodecs. */
 export async function encodeMp4OrWebm(
@@ -32,7 +133,7 @@ export async function encodeMp4OrWebm(
   renderFrame: RenderFrame,
   watermark: WatermarkAssets | null,
   plan: FramePlan,
-  progress: ReturnType<typeof createProgressReporter>,
+  progress: Progress,
   durationSec: number,
   sourceSrc: string,
   signal?: AbortSignal
@@ -40,6 +141,32 @@ export async function encodeMp4OrWebm(
   if (typeof VideoEncoder === "undefined") {
     throw new Error("Video encoding is not supported in this browser")
   }
+
+  try {
+    const encoded = await tryEncodeInWorker(
+      format,
+      ctx,
+      encodeCanvas,
+      renderFrame,
+      watermark,
+      plan,
+      progress,
+      durationSec,
+      sourceSrc,
+      signal
+    )
+    if (encoded) return encoded
+  } catch (err) {
+    if (
+      err instanceof AnimationExportAbortedError ||
+      (err instanceof Error && err.name === "AnimationExportAbortedError")
+    ) {
+      throw err
+    }
+    // Anything else falls through to the in-process encoder, which is a genuine
+    // second chance rather than a repeat of the same failure.
+  }
+
   const preferred: VideoCodec[] =
     format === "mp4"
       ? (["avc", "hevc", "av1"] as VideoCodec[])
@@ -56,13 +183,16 @@ export async function encodeMp4OrWebm(
   const outputFormat =
     format === "mp4" ? new Mp4OutputFormat() : new WebMOutputFormat()
   // Best-effort: missing/unusable audio → silent video, never fail the export.
-  const sourceAudio = await prepareSourceAudio(
-    sourceSrc,
-    format,
-    outputFormat,
-    durationSec,
-    signal
-  )
+  const audioBlob = await loadAudioSourceBlob(sourceSrc)
+  const sourceAudio = audioBlob
+    ? await prepareSourceAudio(
+        audioBlob,
+        format,
+        outputFormat,
+        durationSec,
+        signal
+      )
+    : null
   const target = new BufferTarget()
   const output = new Output({
     format: outputFormat,
@@ -91,17 +221,23 @@ export async function encodeMp4OrWebm(
     // Mux audio before the (much larger) video track so the output doesn't
     // buffer every video packet waiting for the first audio packet.
     if (sourceAudio) {
-      progress.report("encoding", 0, 1)
+      progress.report("audio", 0, 1)
       await sourceAudio.feed()
+      progress.report("audio", 1, 1)
     }
-    progress.report("capturing", 0, plan.frameCount)
-    for (let f = 0; f < plan.frameCount; f++) {
-      if (cancelled || signal?.aborted) throw new AnimationExportAbortedError()
-      const frame = await renderFrame(f)
-      blitFrame(ctx, frame, encodeCanvas.width, encodeCanvas.height, watermark)
-      await videoSource.add(plan.timeForFrame(f), plan.frameDurationSec)
-      progress.report("capturing", f + 1, plan.frameCount)
-    }
+    await pumpFrames(
+      ctx,
+      encodeCanvas,
+      renderFrame,
+      watermark,
+      plan,
+      progress,
+      signal,
+      async (timestampSec, frameDurationSec) => {
+        if (cancelled) throw new AnimationExportAbortedError()
+        await videoSource.add(timestampSec, frameDurationSec)
+      }
+    )
     throwIfAborted(signal)
     progress.report("encoding", 0, 1)
     await output.finalize()

--- a/lib/editor/animation-export/video-media/encode-video.ts
+++ b/lib/editor/animation-export/video-media/encode-video.ts
@@ -20,6 +20,7 @@ import {
 } from "mediabunny"
 
 import { ENCODE_KEY_FRAME_INTERVAL_SEC } from "../../encode-settings"
+import { isAnimationExportAborted } from "../abort"
 import type { WatermarkAssets } from "../types"
 import {
   AnimationExportAbortedError,
@@ -76,10 +77,9 @@ async function tryEncodeInWorker(
   plan: FramePlan,
   progress: Progress,
   durationSec: number,
-  sourceSrc: string,
+  audioBlob: Blob | null,
   signal?: AbortSignal
 ): Promise<Blob | null> {
-  const audioBlob = await loadAudioSourceBlob(sourceSrc, signal)
   // Audio is decoded and re-encoded inside the worker during init, so report the
   // phase around the handshake rather than around a separate feed step.
   if (audioBlob) progress.report("audio", 0, 1)
@@ -142,6 +142,11 @@ export async function encodeMp4OrWebm(
     throw new Error("Video encoding is not supported in this browser")
   }
 
+  // Read once and share with the fallback: this is the whole source clip, and
+  // re-reading it on the fallback path doubles the cost for a long video.
+  // Best-effort — missing/unusable audio → silent video, never fail the export.
+  const audioBlob = await loadAudioSourceBlob(sourceSrc, signal)
+
   try {
     const encoded = await tryEncodeInWorker(
       format,
@@ -152,17 +157,12 @@ export async function encodeMp4OrWebm(
       plan,
       progress,
       durationSec,
-      sourceSrc,
+      audioBlob,
       signal
     )
     if (encoded) return encoded
   } catch (err) {
-    if (
-      err instanceof AnimationExportAbortedError ||
-      (err instanceof Error && err.name === "AnimationExportAbortedError")
-    ) {
-      throw err
-    }
+    if (isAnimationExportAborted(err)) throw err
     // Anything else falls through to the in-process encoder, which is a genuine
     // second chance rather than a repeat of the same failure.
   }
@@ -182,8 +182,6 @@ export async function encodeMp4OrWebm(
 
   const outputFormat =
     format === "mp4" ? new Mp4OutputFormat() : new WebMOutputFormat()
-  // Best-effort: missing/unusable audio → silent video, never fail the export.
-  const audioBlob = await loadAudioSourceBlob(sourceSrc, signal)
   const sourceAudio = audioBlob
     ? await prepareSourceAudio(
         audioBlob,

--- a/lib/editor/animation-export/video-media/index.ts
+++ b/lib/editor/animation-export/video-media/index.ts
@@ -31,6 +31,7 @@ import {
   resolveAnimationDownloadFilename,
   throwIfAborted,
   triggerDownload,
+  waitForPaint,
 } from "../utils"
 import { loadWatermarkLogo, resolveWatermarkFontStack } from "../watermark"
 import { exportAudioDurationSec } from "./audio"
@@ -194,11 +195,24 @@ async function encodeVideoMedia(
   }
 }
 
-/** Export the active video canvas as a video/GIF — downloads by default. */
+/** Encode a video canvas and always return the blob (for share uploads). */
+export async function exportVideoMediaBlob(
+  canvasId: string,
+  options: Omit<VideoMediaExportOptions, "asBlob">
+): Promise<AnimationExportBlobResult> {
+  return encodeVideoMedia(canvasId, { ...options, asBlob: true })
+}
+
+/**
+ * Export the active video canvas as a video/GIF — downloads by default.
+ *
+ * Returns the resolved download filename (matching `exportCanvas`) so callers
+ * can name the real file in their confirmation.
+ */
 export async function exportVideoMedia(
   canvasId: string,
   options: VideoMediaExportOptions
-): Promise<void | AnimationExportBlobResult> {
+): Promise<string | AnimationExportBlobResult> {
   const result = await encodeVideoMedia(canvasId, options)
   if (options.asBlob) return result
   const targetWidth = even(options.targetWidth ?? 1080)
@@ -208,5 +222,9 @@ export async function exportVideoMedia(
     targetWidth,
     extension: result.extension,
   })
+  // The last progress reports land in the same task as the download, so without
+  // a paint the bar is still showing mid-capture when the dialog tears down.
+  await waitForPaint()
   triggerDownload(result.blob, filename)
+  return filename
 }

--- a/lib/editor/animation-export/video.ts
+++ b/lib/editor/animation-export/video.ts
@@ -26,13 +26,16 @@ import { captureStableFrame } from "./capture"
 import { safeDrawImage } from "./draw-utils"
 import type { CaptureCtx } from "./types"
 import { resolveVideoSegments } from "./video-layer"
+import { loadAudioSourceBlob } from "./video-media/audio"
 import {
   AnimationExportAbortedError,
+  createUiYielder,
   even,
   pickWebmMimeType,
   throwIfAborted,
 } from "./utils"
 import { drawWatermark } from "./watermark"
+import { createVideoMuxSession } from "./workers/video-muxer-client"
 
 // Cap on what the MediaRecorder fallback may buffer = frames × pixels-per-frame.
 // Unlike the WebCodecs path it can't stream: capture is slower than real time, so
@@ -65,27 +68,18 @@ export async function isWebmExportSupported(): Promise<boolean> {
   }
 }
 
-/** Try Mediabunny/WebCodecs encode; returns null if unavailable or unsupported. */
-export async function tryEncodeWithMediabunny(
+/**
+ * Rasterize each frame into `encodeCanvas` and hand it to `addFrame`.
+ *
+ * Shared by the worker and main-thread encoders — the capture half is identical
+ * either way, since rasterizing a frame is DOM work that can't leave this thread.
+ */
+async function pumpFrames(
   ctx: CaptureCtx,
-  format: "webm" | "mp4"
-): Promise<Blob | null> {
-  if (typeof VideoEncoder === "undefined") return null
-
-  const preferred: VideoCodec[] =
-    format === "mp4"
-      ? (["avc", "hevc", "av1"] as VideoCodec[])
-      : (["vp9", "vp8", "av1"] as VideoCodec[])
-
-  const width = even(ctx.capture.width)
-  const height = even(ctx.capture.height)
-  const codec = await getFirstEncodableVideoCodec(preferred, {
-    width,
-    height,
-    bitrate: QUALITY_HIGH,
-  })
-  if (!codec) return null
-
+  encodeCanvas: HTMLCanvasElement,
+  ectx: CanvasRenderingContext2D,
+  addFrame: (timestampSec: number, durationSec: number) => Promise<void>
+) {
   const {
     capture,
     canvas,
@@ -99,6 +93,161 @@ export async function tryEncodeWithMediabunny(
     watermark,
     videoLayer,
   } = ctx
+  const { width, height } = encodeCanvas
+  const durationSec = 1 / fps
+  const yieldToUi = createUiYielder()
+
+  progress.report("capturing", 0, frameCount)
+  for (let f = 0; f < frameCount; f++) {
+    // Frame capture is DOM work that can't leave the main thread, so give the
+    // event loop a turn between frames — otherwise the Cancel click never gets
+    // dispatched and the progress bar can't repaint.
+    await yieldToUi()
+    throwIfAborted(signal)
+
+    const frameCanvas = await captureStableFrame(
+      capture,
+      canvas,
+      globalAspect,
+      clips,
+      f * frameDurationMs,
+      videoLayer
+    )
+    // Letterbox into even-sized encode canvas if needed.
+    ectx.fillStyle = "#000"
+    ectx.fillRect(0, 0, width, height)
+    if (!safeDrawImage(ectx, frameCanvas, 0, 0, width, height)) {
+      // Keep the black letterbox frame rather than aborting the whole export.
+    }
+    if (watermark) drawWatermark(ectx, width, height, watermark)
+
+    await addFrame(f / fps, durationSec)
+    progress.report("capturing", f + 1, frameCount)
+  }
+}
+
+/**
+ * Try the mux worker first: it owns the muxer, the encoder queue and the audio
+ * decode, leaving this thread only the frame rasterization. Returns null when
+ * the worker is unavailable or can't encode this format, so the caller can run
+ * the in-process encoder instead.
+ */
+async function tryEncodeInWorker(
+  ctx: CaptureCtx,
+  format: "webm" | "mp4",
+  encodeCanvas: HTMLCanvasElement,
+  ectx: CanvasRenderingContext2D
+): Promise<Blob | null> {
+  const { canvas, frameCount, fps, progress, signal, videoLayer } = ctx
+
+  const screenshot = canvas.screenshot
+  const audioBlob =
+    videoLayer && screenshot && isVideoSrc(screenshot)
+      ? await loadAudioSourceBlob(screenshot)
+      : null
+
+  // Audio is decoded and re-encoded inside the worker during init, so report the
+  // phase around the whole handshake rather than around a separate feed step.
+  if (audioBlob) progress.report("audio", 0, 1)
+  const session = await createVideoMuxSession(
+    {
+      format,
+      width: encodeCanvas.width,
+      height: encodeCanvas.height,
+      fps,
+      keyFrameIntervalSec: ENCODE_KEY_FRAME_INTERVAL_SEC,
+      audio:
+        audioBlob && videoLayer
+          ? {
+              blob: audioBlob,
+              durationSec: frameCount / fps,
+              segments: resolveVideoSegments(
+                canvas.videoClips ?? [],
+                videoLayer.sourceDurationMs
+              ),
+            }
+          : null,
+    },
+    signal
+  )
+  if (!session) return null
+
+  try {
+    await pumpFrames(ctx, encodeCanvas, ectx, (timestampSec, durationSec) =>
+      session.addFrame(encodeCanvas, timestampSec, durationSec)
+    )
+    throwIfAborted(signal)
+    progress.report("encoding", 0, 1)
+    const buffer = await session.finalize()
+    progress.report("encoding", 1, 1)
+    return new Blob([buffer], {
+      type: format === "mp4" ? "video/mp4" : "video/webm",
+    })
+  } finally {
+    session.dispose()
+  }
+}
+
+/** Try Mediabunny/WebCodecs encode; returns null if unavailable or unsupported. */
+export async function tryEncodeWithMediabunny(
+  ctx: CaptureCtx,
+  format: "webm" | "mp4"
+): Promise<Blob | null> {
+  if (typeof VideoEncoder === "undefined") return null
+
+  const width = even(ctx.capture.width)
+  const height = even(ctx.capture.height)
+
+  // Working canvas we redraw each frame into (both encoders sample this).
+  const workerCanvas = document.createElement("canvas")
+  workerCanvas.width = width
+  workerCanvas.height = height
+  const workerCtx = workerCanvas.getContext("2d")
+  if (!workerCtx) return null
+
+  try {
+    const encoded = await tryEncodeInWorker(
+      ctx,
+      format,
+      workerCanvas,
+      workerCtx
+    )
+    if (encoded) return encoded
+  } catch (err) {
+    if (isAbortError(err)) throw err
+    // Anything else falls through to the in-process encoder below, which is a
+    // genuine second chance rather than a repeat of the same failure.
+  }
+
+  return encodeWithMediabunnyOnMainThread(ctx, format, width, height)
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    err instanceof AnimationExportAbortedError ||
+    (err instanceof Error && err.name === "AnimationExportAbortedError")
+  )
+}
+
+async function encodeWithMediabunnyOnMainThread(
+  ctx: CaptureCtx,
+  format: "webm" | "mp4",
+  width: number,
+  height: number
+): Promise<Blob | null> {
+  const preferred: VideoCodec[] =
+    format === "mp4"
+      ? (["avc", "hevc", "av1"] as VideoCodec[])
+      : (["vp9", "vp8", "av1"] as VideoCodec[])
+
+  const codec = await getFirstEncodableVideoCodec(preferred, {
+    width,
+    height,
+    bitrate: QUALITY_HIGH,
+  })
+  if (!codec) return null
+
+  const { canvas, frameCount, fps, progress, signal, videoLayer } = ctx
 
   // Working canvas we redraw each frame into (CanvasSource samples this).
   const encodeCanvas = document.createElement("canvas")
@@ -122,10 +271,14 @@ export async function tryEncodeWithMediabunny(
   // Best-effort, like the styled-video export: a clip with no usable audio still
   // exports, silently. Must be registered before `output.start()`.
   const screenshot = canvas.screenshot
-  const sourceAudio =
+  const audioBlob =
     videoLayer && screenshot && isVideoSrc(screenshot)
+      ? await loadAudioSourceBlob(screenshot)
+      : null
+  const sourceAudio =
+    audioBlob && videoLayer
       ? await prepareAnimationAudio({
-          src: screenshot,
+          source: audioBlob,
           format,
           outputFormat,
           segments: resolveVideoSegments(
@@ -151,35 +304,20 @@ export async function tryEncodeWithMediabunny(
     // Before the (much larger) video track, so the muxer doesn't buffer every
     // video packet waiting on the first audio one.
     if (sourceAudio) {
-      progress.report("encoding", 0, 1)
+      progress.report("audio", 0, 1)
       await sourceAudio.feed()
+      progress.report("audio", 1, 1)
     }
-    progress.report("capturing", 0, frameCount)
 
-    const durationSec = 1 / fps
-    for (let f = 0; f < frameCount; f++) {
-      if (cancelled || signal?.aborted) throw new AnimationExportAbortedError()
-
-      const frameCanvas = await captureStableFrame(
-        capture,
-        canvas,
-        globalAspect,
-        clips,
-        f * frameDurationMs,
-        videoLayer
-      )
-      // Letterbox into even-sized encode canvas if needed.
-      ectx.fillStyle = "#000"
-      ectx.fillRect(0, 0, width, height)
-      if (!safeDrawImage(ectx, frameCanvas, 0, 0, width, height)) {
-        // Keep the black letterbox frame rather than aborting the whole export.
+    await pumpFrames(
+      ctx,
+      encodeCanvas,
+      ectx,
+      async (timestampSec, duration) => {
+        if (cancelled) throw new AnimationExportAbortedError()
+        await videoSource.add(timestampSec, duration)
       }
-      if (watermark) drawWatermark(ectx, width, height, watermark)
-
-      const timestamp = f / fps
-      await videoSource.add(timestamp, durationSec)
-      progress.report("capturing", f + 1, frameCount)
-    }
+    )
 
     throwIfAborted(signal)
     progress.report("encoding", 0, 1)
@@ -254,7 +392,9 @@ export async function encodeWebmMediaRecorder({
   const frames: HTMLCanvasElement[] = []
   progress.report("capturing", 0, frameCount)
 
+  const yieldToUi = createUiYielder()
   for (let f = 0; f < frameCount; f++) {
+    await yieldToUi()
     throwIfAborted(signal)
     frames.push(
       await captureStableFrame(

--- a/lib/editor/animation-export/video.ts
+++ b/lib/editor/animation-export/video.ts
@@ -19,6 +19,7 @@ import {
   type VideoCodec,
 } from "mediabunny"
 
+import { isAnimationExportAborted } from "./abort"
 import { ENCODE_KEY_FRAME_INTERVAL_SEC } from "../encode-settings"
 import { isVideoSrc } from "../media-type"
 import { prepareAnimationAudio } from "./animation-audio"
@@ -214,19 +215,12 @@ export async function tryEncodeWithMediabunny(
     )
     if (encoded) return encoded
   } catch (err) {
-    if (isAbortError(err)) throw err
+    if (isAnimationExportAborted(err)) throw err
     // Anything else falls through to the in-process encoder below, which is a
     // genuine second chance rather than a repeat of the same failure.
   }
 
   return encodeWithMediabunnyOnMainThread(ctx, format, width, height)
-}
-
-function isAbortError(err: unknown): boolean {
-  return (
-    err instanceof AnimationExportAbortedError ||
-    (err instanceof Error && err.name === "AnimationExportAbortedError")
-  )
 }
 
 async function encodeWithMediabunnyOnMainThread(

--- a/lib/editor/animation-export/video.ts
+++ b/lib/editor/animation-export/video.ts
@@ -143,7 +143,7 @@ async function tryEncodeInWorker(
   const screenshot = canvas.screenshot
   const audioBlob =
     videoLayer && screenshot && isVideoSrc(screenshot)
-      ? await loadAudioSourceBlob(screenshot)
+      ? await loadAudioSourceBlob(screenshot, signal)
       : null
 
   // Audio is decoded and re-encoded inside the worker during init, so report the
@@ -273,7 +273,7 @@ async function encodeWithMediabunnyOnMainThread(
   const screenshot = canvas.screenshot
   const audioBlob =
     videoLayer && screenshot && isVideoSrc(screenshot)
-      ? await loadAudioSourceBlob(screenshot)
+      ? await loadAudioSourceBlob(screenshot, signal)
       : null
   const sourceAudio =
     audioBlob && videoLayer

--- a/lib/editor/animation-export/workers/gif-encoder-client.ts
+++ b/lib/editor/animation-export/workers/gif-encoder-client.ts
@@ -10,6 +10,7 @@
  * unbounded queue would hold every frame's pixels at once.
  */
 
+import { throwIfAborted } from "../abort"
 import { GifStreamEncoder } from "../gif-codec"
 import type {
   GifWorkerRequest,
@@ -189,25 +190,35 @@ function createInlineSession(): GifEncoderSession {
  * it — including on the error path — so a cancelled export doesn't leave a
  * worker (and its buffered stream) alive.
  */
-export async function createGifEncoderSession(): Promise<GifEncoderSession> {
+export async function createGifEncoderSession(
+  signal?: AbortSignal
+): Promise<GifEncoderSession> {
+  // An abort that has already fired never fires again, so nothing downstream
+  // would notice it — don't spawn a worker for an export that is already over.
+  throwIfAborted(signal)
   const handle = createWorkerSession()
   if (!handle) return createInlineSession()
+  let timer: ReturnType<typeof setTimeout> | undefined
   try {
     // Round-trips one message before any pixels are sent, so a worker that can't
     // load (blocked by CSP, missing chunk) falls back here rather than halfway
     // through an export.
     await Promise.race([
       handle.handshake(),
-      new Promise((_, reject) =>
-        setTimeout(
+      new Promise((_, reject) => {
+        timer = setTimeout(
           () => reject(new Error("GIF encode worker did not start")),
           HANDSHAKE_TIMEOUT_MS
         )
-      ),
+      }),
     ])
     return handle.session
   } catch {
     handle.session.dispose()
     return createInlineSession()
+  } finally {
+    // Promise.race leaves the loser pending, so without this the timer keeps the
+    // worker closure alive for the full timeout after a successful handshake.
+    clearTimeout(timer)
   }
 }

--- a/lib/editor/animation-export/workers/gif-encoder-client.ts
+++ b/lib/editor/animation-export/workers/gif-encoder-client.ts
@@ -1,0 +1,213 @@
+/**
+ * Main-thread handle on the GIF encode worker, with an in-process fallback for
+ * environments that have no `Worker` (SSR, jsdom under test) or where the worker
+ * fails to boot.
+ *
+ * `writeFrame` only blocks once more than {@link MAX_FRAMES_IN_FLIGHT} frames are
+ * outstanding, so the caller keeps rasterizing the next frame while the worker
+ * dithers and palette-maps the previous one. Bounding the queue matters: the
+ * capture side is usually slower, but on a small canvas it isn't, and an
+ * unbounded queue would hold every frame's pixels at once.
+ */
+
+import { GifStreamEncoder } from "../gif-codec"
+import type {
+  GifWorkerRequest,
+  GifWorkerResponse,
+} from "./gif-encoder-protocol"
+import type { WithoutId } from "./message"
+
+const MAX_FRAMES_IN_FLIGHT = 2
+
+/**
+ * How long to wait for the worker's first reply before giving up on it. Covers
+ * the case where the worker neither answers nor fires `onerror` — a hung
+ * handshake would otherwise stall the export with no way to cancel, which is
+ * exactly the failure this whole change exists to remove.
+ */
+const HANDSHAKE_TIMEOUT_MS = 10_000
+
+export type GifEncoderSession = {
+  /** True when the encode is actually running off the main thread. */
+  readonly offMainThread: boolean
+  addSample(data: Uint8ClampedArray): Promise<void>
+  buildPalette(): Promise<void>
+  writeFrame(
+    data: Uint8ClampedArray,
+    width: number,
+    height: number,
+    elapsedMs: number
+  ): Promise<void>
+  finish(): Promise<Uint8Array<ArrayBuffer>>
+  dispose(): void
+}
+
+/**
+ * Detach `data`'s buffer for transfer. `getImageData().data` always owns its
+ * buffer exactly, but a caller could hand us a view into a larger one — copy in
+ * that case rather than transferring pixels that belong to someone else.
+ */
+function detachable(data: Uint8ClampedArray): ArrayBuffer {
+  if (data.byteOffset === 0 && data.byteLength === data.buffer.byteLength) {
+    return data.buffer as ArrayBuffer
+  }
+  return data.slice().buffer
+}
+
+type WorkerHandle = {
+  session: GifEncoderSession
+  handshake: () => Promise<unknown>
+}
+
+function createWorkerSession(): WorkerHandle | null {
+  if (typeof Worker === "undefined") return null
+
+  let worker: Worker
+  try {
+    worker = new Worker(new URL("./gif-encoder.worker.ts", import.meta.url), {
+      type: "module",
+    })
+  } catch {
+    return null
+  }
+
+  let nextId = 1
+  let failure: Error | null = null
+  const pending = new Map<
+    number,
+    { resolve: (bytes?: ArrayBuffer) => void; reject: (err: Error) => void }
+  >()
+  const inFlight: Promise<unknown>[] = []
+
+  const failAll = (err: Error) => {
+    failure ??= err
+    for (const entry of pending.values()) entry.reject(err)
+    pending.clear()
+  }
+
+  worker.onmessage = (event: MessageEvent<GifWorkerResponse>) => {
+    const message = event.data
+    const entry = pending.get(message.id)
+    if (!entry) return
+    pending.delete(message.id)
+    if (message.ok) entry.resolve(message.bytes)
+    else entry.reject(new Error(message.error))
+  }
+  worker.onerror = () => failAll(new Error("GIF encode worker failed"))
+  worker.onmessageerror = () =>
+    failAll(new Error("GIF encode worker received an uncloneable message"))
+
+  const send = (
+    request: WithoutId<GifWorkerRequest>,
+    transfer: Transferable[] = []
+  ): Promise<ArrayBuffer | undefined> => {
+    if (failure) return Promise.reject(failure)
+    const id = nextId++
+    return new Promise<ArrayBuffer | undefined>((resolve, reject) => {
+      pending.set(id, { resolve, reject })
+      worker.postMessage({ ...request, id }, transfer)
+    })
+  }
+
+  // A queued frame is not awaited at the call site, so its rejection is caught
+  // here (otherwise it surfaces as an unhandled rejection) and re-raised by the
+  // next `drain`.
+  const track = (promise: Promise<unknown>) => {
+    inFlight.push(
+      promise.catch((err: Error) => {
+        failure ??= err
+      })
+    )
+  }
+
+  const drain = async (keep: number) => {
+    while (inFlight.length > keep) {
+      await inFlight.shift()
+    }
+    if (failure) throw failure
+  }
+
+  const session: GifEncoderSession = {
+    offMainThread: true,
+    async addSample(data) {
+      const buffer = detachable(data)
+      await send({ type: "sample", data: buffer }, [buffer])
+    },
+    async buildPalette() {
+      await drain(0)
+      await send({ type: "palette" })
+    },
+    async writeFrame(data, width, height, elapsedMs) {
+      if (failure) throw failure
+      const buffer = detachable(data)
+      track(
+        send({ type: "frame", data: buffer, width, height, elapsedMs }, [
+          buffer,
+        ])
+      )
+      await drain(MAX_FRAMES_IN_FLIGHT)
+    },
+    async finish() {
+      await drain(0)
+      const bytes = await send({ type: "finish" })
+      if (!bytes) throw new Error("GIF encode worker returned no data")
+      return new Uint8Array(bytes)
+    },
+    dispose() {
+      pending.clear()
+      worker.terminate()
+    },
+  }
+
+  return { session, handshake: () => send({ type: "reset" }) }
+}
+
+/** Run `fn` now but report its failure as a rejection, matching the worker. */
+function settled<T>(fn: () => T): Promise<T> {
+  try {
+    return Promise.resolve(fn())
+  } catch (err) {
+    return Promise.reject(err instanceof Error ? err : new Error(String(err)))
+  }
+}
+
+function createInlineSession(): GifEncoderSession {
+  const encoder = new GifStreamEncoder()
+  return {
+    offMainThread: false,
+    addSample: (data) => settled(() => encoder.addSample(data)),
+    buildPalette: () => settled(() => encoder.buildPalette()),
+    writeFrame: (data, width, height, elapsedMs) =>
+      settled(() => encoder.writeFrame(data, width, height, elapsedMs)),
+    finish: () => settled(() => encoder.finish()),
+    dispose: () => {},
+  }
+}
+
+/**
+ * Start a GIF encode session, preferring the worker. Callers must `dispose()`
+ * it — including on the error path — so a cancelled export doesn't leave a
+ * worker (and its buffered stream) alive.
+ */
+export async function createGifEncoderSession(): Promise<GifEncoderSession> {
+  const handle = createWorkerSession()
+  if (!handle) return createInlineSession()
+  try {
+    // Round-trips one message before any pixels are sent, so a worker that can't
+    // load (blocked by CSP, missing chunk) falls back here rather than halfway
+    // through an export.
+    await Promise.race([
+      handle.handshake(),
+      new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error("GIF encode worker did not start")),
+          HANDSHAKE_TIMEOUT_MS
+        )
+      ),
+    ])
+    return handle.session
+  } catch {
+    handle.session.dispose()
+    return createInlineSession()
+  }
+}

--- a/lib/editor/animation-export/workers/gif-encoder-protocol.ts
+++ b/lib/editor/animation-export/workers/gif-encoder-protocol.ts
@@ -1,0 +1,23 @@
+/**
+ * Message shapes exchanged with the GIF encode worker. Kept in its own module so
+ * the worker and its main-thread client can share types without either pulling
+ * in the other's runtime.
+ */
+
+export type GifWorkerRequest =
+  | { id: number; type: "reset" }
+  | { id: number; type: "sample"; data: ArrayBuffer }
+  | { id: number; type: "palette" }
+  | {
+      id: number
+      type: "frame"
+      data: ArrayBuffer
+      width: number
+      height: number
+      elapsedMs: number
+    }
+  | { id: number; type: "finish" }
+
+export type GifWorkerResponse =
+  | { id: number; ok: true; bytes?: ArrayBuffer }
+  | { id: number; ok: false; error: string }

--- a/lib/editor/animation-export/workers/gif-encoder.worker.ts
+++ b/lib/editor/animation-export/workers/gif-encoder.worker.ts
@@ -1,0 +1,71 @@
+/**
+ * GIF encode worker. Owns the palette build, the ordered dither, the palette
+ * mapping and the gifenc stream — all of which are pure typed-array maths that
+ * used to block the main thread for seconds at a time.
+ *
+ * The main thread still rasterizes each frame (that needs the DOM) and hands the
+ * pixels over as a transferred buffer, so the two threads pipeline: frame N+1 is
+ * captured while frame N is being encoded here.
+ */
+
+import { GifStreamEncoder } from "../gif-codec"
+import type {
+  GifWorkerRequest,
+  GifWorkerResponse,
+} from "./gif-encoder-protocol"
+
+let encoder: GifStreamEncoder | null = null
+
+function reply(message: GifWorkerResponse, transfer: Transferable[] = []) {
+  ;(self as unknown as Worker).postMessage(message, transfer)
+}
+
+self.onmessage = (event: MessageEvent<GifWorkerRequest>) => {
+  const request = event.data
+  try {
+    switch (request.type) {
+      case "reset": {
+        encoder = new GifStreamEncoder()
+        reply({ id: request.id, ok: true })
+        return
+      }
+      case "sample": {
+        if (!encoder) throw new Error("GIF worker was not initialized")
+        encoder.addSample(new Uint8ClampedArray(request.data))
+        reply({ id: request.id, ok: true })
+        return
+      }
+      case "palette": {
+        if (!encoder) throw new Error("GIF worker was not initialized")
+        encoder.buildPalette()
+        reply({ id: request.id, ok: true })
+        return
+      }
+      case "frame": {
+        if (!encoder) throw new Error("GIF worker was not initialized")
+        encoder.writeFrame(
+          new Uint8ClampedArray(request.data),
+          request.width,
+          request.height,
+          request.elapsedMs
+        )
+        reply({ id: request.id, ok: true })
+        return
+      }
+      case "finish": {
+        if (!encoder) throw new Error("GIF worker was not initialized")
+        const bytes = encoder.finish()
+        encoder = null
+        reply({ id: request.id, ok: true, bytes: bytes.buffer }, [bytes.buffer])
+        return
+      }
+    }
+  } catch (err) {
+    encoder = null
+    reply({
+      id: request.id,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}

--- a/lib/editor/animation-export/workers/gif-encoder.worker.ts
+++ b/lib/editor/animation-export/workers/gif-encoder.worker.ts
@@ -59,6 +59,15 @@ self.onmessage = (event: MessageEvent<GifWorkerRequest>) => {
         reply({ id: request.id, ok: true, bytes: bytes.buffer }, [bytes.buffer])
         return
       }
+      default: {
+        // Unreachable for a well-typed message, but a stale client (or anything
+        // else posting here) must still get a reply — the client keys pending
+        // promises by id and a dropped response would hang the export forever.
+        const unknown: never = request
+        throw new Error(
+          `Unknown GIF worker request: ${(unknown as { type?: string }).type}`
+        )
+      }
     }
   } catch (err) {
     encoder = null

--- a/lib/editor/animation-export/workers/message.ts
+++ b/lib/editor/animation-export/workers/message.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared shape for the encode workers' request/response protocols.
+ */
+
+/**
+ * `Omit` over a union collapses it to the keys every member shares, which would
+ * erase each message's payload — distribute it instead. Used so a client can
+ * build a message without minting the correlation id itself.
+ */
+export type WithoutId<T> = T extends { id: number } ? Omit<T, "id"> : never

--- a/lib/editor/animation-export/workers/video-muxer-client.ts
+++ b/lib/editor/animation-export/workers/video-muxer-client.ts
@@ -140,15 +140,16 @@ export async function createVideoMuxSession(
   signal?.addEventListener("abort", onAbort, { once: true })
 
   let ready: VideoMuxerResponse & { ok: true }
+  let timer: ReturnType<typeof setTimeout> | undefined
   try {
     ready = await Promise.race([
       send({ type: "init", config }),
-      new Promise<never>((_, reject) =>
-        setTimeout(
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
           () => reject(new Error("Video mux worker did not start")),
           INIT_TIMEOUT_MS
         )
-      ),
+      }),
     ])
   } catch (err) {
     signal?.removeEventListener("abort", onAbort)
@@ -157,6 +158,10 @@ export async function createVideoMuxSession(
     // main-thread encoder — it would just start the whole export again.
     if (err instanceof AnimationExportAbortedError || signal?.aborted) throw err
     return null
+  } finally {
+    // Promise.race leaves the loser pending, so without this the timer keeps the
+    // worker closure alive for the full timeout after a successful init.
+    clearTimeout(timer)
   }
 
   if (ready.type !== "init" || !ready.supported) {
@@ -172,7 +177,17 @@ export async function createVideoMuxSession(
         timestamp: Math.round(timestampSec * 1_000_000),
         duration: Math.round(durationSec * 1_000_000),
       })
-      track(send({ type: "frame", frame, timestampSec, durationSec }, [frame]))
+      try {
+        track(
+          send({ type: "frame", frame, timestampSec, durationSec }, [frame])
+        )
+      } finally {
+        // A transferred frame is detached, so this is a no-op on the happy path
+        // (the worker owns and closes it). It matters when the post never got
+        // that far — a VideoFrame pins its backing memory until it is closed,
+        // and `send` bails without posting once a previous frame has failed.
+        frame.close()
+      }
       await drain(MAX_FRAMES_IN_FLIGHT)
     },
     async finalize() {

--- a/lib/editor/animation-export/workers/video-muxer-client.ts
+++ b/lib/editor/animation-export/workers/video-muxer-client.ts
@@ -1,0 +1,189 @@
+/**
+ * Main-thread handle on the video mux worker.
+ *
+ * Unlike the GIF client there is no in-process fallback here: both call sites
+ * already own a complete main-thread Mediabunny path, so `createVideoMuxSession`
+ * returns null whenever the worker can't be used and the caller just keeps doing
+ * what it did before.
+ *
+ * `addFrame` snapshots the encode canvas into a `VideoFrame` and transfers it,
+ * blocking only once more than {@link MAX_FRAMES_IN_FLIGHT} frames are
+ * outstanding — so the next frame rasterizes while the worker encodes this one.
+ */
+
+import { AnimationExportAbortedError } from "../abort"
+import type { WithoutId } from "./message"
+import type {
+  VideoMuxerConfig,
+  VideoMuxerRequest,
+  VideoMuxerResponse,
+} from "./video-muxer-protocol"
+
+const MAX_FRAMES_IN_FLIGHT = 2
+
+/** See the GIF client — a worker that neither answers nor errors must not hang
+ *  the export, which is the very failure this change exists to remove. */
+const INIT_TIMEOUT_MS = 30_000
+
+export type VideoMuxSession = {
+  addFrame(
+    canvas: HTMLCanvasElement,
+    timestampSec: number,
+    durationSec: number
+  ): Promise<void>
+  finalize(): Promise<ArrayBuffer>
+  cancel(): void
+  dispose(): void
+}
+
+function canUseVideoMuxWorker(): boolean {
+  return (
+    typeof Worker !== "undefined" &&
+    typeof VideoFrame !== "undefined" &&
+    typeof VideoEncoder !== "undefined"
+  )
+}
+
+/**
+ * Start a mux session in the worker. Returns null when workers or WebCodecs are
+ * unavailable, when the worker fails to boot, or when no codec can encode this
+ * format/size — in every case the caller should run its own encode path.
+ */
+export async function createVideoMuxSession(
+  config: VideoMuxerConfig,
+  signal?: AbortSignal
+): Promise<VideoMuxSession | null> {
+  if (!canUseVideoMuxWorker()) return null
+
+  let worker: Worker
+  try {
+    worker = new Worker(new URL("./video-muxer.worker.ts", import.meta.url), {
+      type: "module",
+    })
+  } catch {
+    return null
+  }
+
+  let nextId = 1
+  let failure: Error | null = null
+  const pending = new Map<
+    number,
+    {
+      resolve: (message: VideoMuxerResponse & { ok: true }) => void
+      reject: (err: Error) => void
+    }
+  >()
+  const inFlight: Promise<unknown>[] = []
+
+  const failAll = (err: Error) => {
+    failure ??= err
+    for (const entry of pending.values()) entry.reject(err)
+    pending.clear()
+  }
+
+  worker.onmessage = (event: MessageEvent<VideoMuxerResponse>) => {
+    const message = event.data
+    const entry = pending.get(message.id)
+    if (!entry) return
+    pending.delete(message.id)
+    if (message.ok) entry.resolve(message)
+    else {
+      entry.reject(
+        message.aborted
+          ? new AnimationExportAbortedError()
+          : new Error(message.error)
+      )
+    }
+  }
+  worker.onerror = () => failAll(new Error("Video mux worker failed"))
+  worker.onmessageerror = () =>
+    failAll(new Error("Video mux worker received an uncloneable message"))
+
+  const send = (
+    request: WithoutId<VideoMuxerRequest>,
+    transfer: Transferable[] = []
+  ) => {
+    if (failure) return Promise.reject(failure)
+    const id = nextId++
+    return new Promise<VideoMuxerResponse & { ok: true }>((resolve, reject) => {
+      pending.set(id, { resolve, reject })
+      worker.postMessage({ ...request, id }, transfer)
+    })
+  }
+
+  const track = (promise: Promise<unknown>) => {
+    inFlight.push(
+      promise.catch((err: Error) => {
+        failure ??= err
+      })
+    )
+  }
+
+  const drain = async (keep: number) => {
+    while (inFlight.length > keep) await inFlight.shift()
+    if (failure) throw failure
+  }
+
+  const dispose = () => {
+    pending.clear()
+    worker.terminate()
+  }
+
+  const onAbort = () => {
+    void send({ type: "cancel" }).catch(() => {})
+  }
+  signal?.addEventListener("abort", onAbort, { once: true })
+
+  let ready: VideoMuxerResponse & { ok: true }
+  try {
+    ready = await Promise.race([
+      send({ type: "init", config }),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("Video mux worker did not start")),
+          INIT_TIMEOUT_MS
+        )
+      ),
+    ])
+  } catch (err) {
+    signal?.removeEventListener("abort", onAbort)
+    dispose()
+    // A real cancellation must not be papered over by falling back to the
+    // main-thread encoder — it would just start the whole export again.
+    if (err instanceof AnimationExportAbortedError || signal?.aborted) throw err
+    return null
+  }
+
+  if (ready.type !== "init" || !ready.supported) {
+    signal?.removeEventListener("abort", onAbort)
+    dispose()
+    return null
+  }
+
+  return {
+    async addFrame(canvas, timestampSec, durationSec) {
+      if (failure) throw failure
+      const frame = new VideoFrame(canvas, {
+        timestamp: Math.round(timestampSec * 1_000_000),
+        duration: Math.round(durationSec * 1_000_000),
+      })
+      track(send({ type: "frame", frame, timestampSec, durationSec }, [frame]))
+      await drain(MAX_FRAMES_IN_FLIGHT)
+    },
+    async finalize() {
+      await drain(0)
+      const done = await send({ type: "finalize" })
+      if (done.type !== "finalize") {
+        throw new Error("Video mux worker returned no data")
+      }
+      return done.buffer
+    },
+    cancel() {
+      onAbort()
+    },
+    dispose() {
+      signal?.removeEventListener("abort", onAbort)
+      dispose()
+    },
+  }
+}

--- a/lib/editor/animation-export/workers/video-muxer-client.ts
+++ b/lib/editor/animation-export/workers/video-muxer-client.ts
@@ -11,7 +11,7 @@
  * outstanding — so the next frame rasterizes while the worker encodes this one.
  */
 
-import { AnimationExportAbortedError } from "../abort"
+import { AnimationExportAbortedError, throwIfAborted } from "../abort"
 import type { WithoutId } from "./message"
 import type {
   VideoMuxerConfig,
@@ -53,6 +53,11 @@ export async function createVideoMuxSession(
   config: VideoMuxerConfig,
   signal?: AbortSignal
 ): Promise<VideoMuxSession | null> {
+  // An abort that has already fired will never fire again, so the listener
+  // registered below would never run: the worker would go on to decode and
+  // re-encode the whole audio track and start the muxer, and the cancellation
+  // would not surface until init finished or the startup timeout expired.
+  throwIfAborted(signal)
   if (!canUseVideoMuxWorker()) return null
 
   let worker: Worker

--- a/lib/editor/animation-export/workers/video-muxer-protocol.ts
+++ b/lib/editor/animation-export/workers/video-muxer-protocol.ts
@@ -1,0 +1,46 @@
+/**
+ * Message shapes exchanged with the video mux worker. Kept separate from both
+ * ends so neither pulls in the other's runtime.
+ */
+
+import type { VideoSegment } from "../video-layer"
+
+export type VideoMuxerAudioConfig = {
+  /** The source clip's bytes; the worker reads its audio track out of these. */
+  blob: Blob
+  /** Export window in seconds — audio at or past this is dropped. */
+  durationSec: number
+  /**
+   * Timeline segments to re-time the audio onto (Animate mode), or null for the
+   * video-media export, which plays the clip straight through.
+   */
+  segments: VideoSegment[] | null
+}
+
+export type VideoMuxerConfig = {
+  format: "mp4" | "webm"
+  width: number
+  height: number
+  fps: number
+  keyFrameIntervalSec: number
+  audio: VideoMuxerAudioConfig | null
+}
+
+export type VideoMuxerRequest =
+  | { id: number; type: "init"; config: VideoMuxerConfig }
+  | {
+      id: number
+      type: "frame"
+      frame: VideoFrame
+      timestampSec: number
+      durationSec: number
+    }
+  | { id: number; type: "finalize" }
+  | { id: number; type: "cancel" }
+
+export type VideoMuxerResponse =
+  | { id: number; ok: true; type: "init"; supported: boolean }
+  | { id: number; ok: true; type: "frame" }
+  | { id: number; ok: true; type: "finalize"; buffer: ArrayBuffer }
+  | { id: number; ok: true; type: "cancel" }
+  | { id: number; ok: false; error: string; aborted?: boolean }

--- a/lib/editor/animation-export/workers/video-muxer.worker.ts
+++ b/lib/editor/animation-export/workers/video-muxer.worker.ts
@@ -159,6 +159,15 @@ async function handle(request: VideoMuxerRequest) {
         reply({ id: request.id, ok: true, type: "cancel" })
         return
       }
+      default: {
+        // Unreachable for a well-typed message, but a stale client (or anything
+        // else posting here) must still get a reply — the client keys pending
+        // promises by id and a dropped response would hang the export forever.
+        const unknown: never = request
+        throw new Error(
+          `Unknown mux worker request: ${(unknown as { type?: string }).type}`
+        )
+      }
     }
   } catch (err) {
     if (request.type === "frame") request.frame.close()

--- a/lib/editor/animation-export/workers/video-muxer.worker.ts
+++ b/lib/editor/animation-export/workers/video-muxer.worker.ts
@@ -1,0 +1,184 @@
+/**
+ * Video mux worker. Owns the whole Mediabunny output for an MP4/WebM export:
+ * codec negotiation, the muxer and its growing buffer, and the source clip's
+ * audio (which is decoded and re-encoded here rather than on the main thread).
+ *
+ * The main thread keeps only what needs the DOM — rasterizing each styled frame
+ * — and hands the pixels over as a transferred `VideoFrame`, so the encode, the
+ * mux and the file assembly never block the UI.
+ */
+
+import {
+  BufferTarget,
+  Mp4OutputFormat,
+  Output,
+  QUALITY_HIGH,
+  VideoSample,
+  VideoSampleSource,
+  WebMOutputFormat,
+  getFirstEncodableVideoCodec,
+  type VideoCodec,
+} from "mediabunny"
+
+import { AnimationExportAbortedError } from "../abort"
+import { prepareAnimationAudio } from "../animation-audio"
+import { prepareSourceAudio, type SourceAudioFeed } from "../video-media/audio"
+import type {
+  VideoMuxerConfig,
+  VideoMuxerRequest,
+  VideoMuxerResponse,
+} from "./video-muxer-protocol"
+
+type Session = {
+  output: Output
+  target: BufferTarget
+  videoSource: VideoSampleSource
+  audio: SourceAudioFeed | null
+}
+
+let session: Session | null = null
+let aborter = new AbortController()
+
+// Handlers are async, but `onmessage` fires again as soon as one returns — so
+// without this chain frame N+1 could be encoded before frame N finished, and
+// the muxer rejects out-of-order timestamps.
+let queue: Promise<void> = Promise.resolve()
+
+function reply(message: VideoMuxerResponse, transfer: Transferable[] = []) {
+  ;(self as unknown as Worker).postMessage(message, transfer)
+}
+
+function teardown() {
+  session?.audio?.cleanup()
+  session = null
+}
+
+async function cancelOutput(current: Session | null) {
+  if (current && current.output.state !== "canceled") {
+    await current.output.cancel().catch(() => {})
+  }
+}
+
+async function init(id: number, config: VideoMuxerConfig) {
+  const { format, width, height, fps, keyFrameIntervalSec } = config
+  const preferred: VideoCodec[] =
+    format === "mp4"
+      ? (["avc", "hevc", "av1"] as VideoCodec[])
+      : (["vp9", "vp8", "av1"] as VideoCodec[])
+
+  const codec = await getFirstEncodableVideoCodec(preferred, {
+    width,
+    height,
+    bitrate: QUALITY_HIGH,
+  })
+  // Not an error: the caller falls back to its own path (MediaRecorder for
+  // WebM, a clear message for MP4) exactly as it did before the worker existed.
+  if (!codec) {
+    reply({ id, ok: true, type: "init", supported: false })
+    return
+  }
+
+  const target = new BufferTarget()
+  const outputFormat =
+    format === "mp4" ? new Mp4OutputFormat() : new WebMOutputFormat()
+  const output = new Output({ format: outputFormat, target })
+  const videoSource = new VideoSampleSource({
+    codec,
+    bitrate: QUALITY_HIGH,
+    keyFrameInterval: keyFrameIntervalSec,
+  })
+  output.addVideoTrack(videoSource, { frameRate: fps })
+
+  // Best-effort: a clip with no usable audio still exports, silently. Must be
+  // registered before `output.start()`.
+  const audio = config.audio
+    ? config.audio.segments
+      ? await prepareAnimationAudio({
+          source: config.audio.blob,
+          format,
+          outputFormat,
+          segments: config.audio.segments,
+          exportDurationSec: config.audio.durationSec,
+          signal: aborter.signal,
+        })
+      : await prepareSourceAudio(
+          config.audio.blob,
+          format,
+          outputFormat,
+          config.audio.durationSec,
+          aborter.signal
+        )
+    : null
+  audio?.addToOutput(output)
+
+  session = { output, target, videoSource, audio }
+  await output.start()
+  // Before the (much larger) video track, so the muxer doesn't buffer every
+  // video packet waiting on the first audio one.
+  await audio?.feed()
+  reply({ id, ok: true, type: "init", supported: true })
+}
+
+async function handle(request: VideoMuxerRequest) {
+  try {
+    switch (request.type) {
+      case "init": {
+        await init(request.id, request.config)
+        return
+      }
+      case "frame": {
+        if (aborter.signal.aborted) throw new AnimationExportAbortedError()
+        if (!session) throw new Error("Video mux worker was not initialized")
+        const sample = new VideoSample(request.frame, {
+          timestamp: request.timestampSec,
+          duration: request.durationSec,
+        })
+        try {
+          await session.videoSource.add(sample)
+        } finally {
+          sample.close()
+        }
+        reply({ id: request.id, ok: true, type: "frame" })
+        return
+      }
+      case "finalize": {
+        if (!session) throw new Error("Video mux worker was not initialized")
+        await session.output.finalize()
+        const buffer = session.target.buffer
+        teardown()
+        if (!buffer || buffer.byteLength === 0) {
+          throw new Error("Video encode produced an empty file")
+        }
+        reply({ id: request.id, ok: true, type: "finalize", buffer }, [buffer])
+        return
+      }
+      case "cancel": {
+        const current = session
+        teardown()
+        await cancelOutput(current)
+        reply({ id: request.id, ok: true, type: "cancel" })
+        return
+      }
+    }
+  } catch (err) {
+    if (request.type === "frame") request.frame.close()
+    const current = session
+    teardown()
+    await cancelOutput(current)
+    reply({
+      id: request.id,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+      aborted: err instanceof AnimationExportAbortedError,
+    })
+  }
+}
+
+self.onmessage = (event: MessageEvent<VideoMuxerRequest>) => {
+  const request = event.data
+  // Abort flips immediately rather than behind the queue, so frames already
+  // waiting their turn are dropped instead of encoded.
+  if (request.type === "init") aborter = new AbortController()
+  if (request.type === "cancel") aborter.abort()
+  queue = queue.then(() => handle(request))
+}

--- a/tests/lib/editor/animation-export/export-cancellation.test.ts
+++ b/tests/lib/editor/animation-export/export-cancellation.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { AnimationExportAbortedError } from "@/lib/editor/animation-export/abort"
+import {
+  AnimationExportAbortedError,
+  isAnimationExportAborted,
+} from "@/lib/editor/animation-export/abort"
+import { waitForPaint } from "@/lib/editor/animation-export/utils"
 import { loadAudioSourceBlob } from "@/lib/editor/animation-export/video-media/audio"
+import { createGifEncoderSession } from "@/lib/editor/animation-export/workers/gif-encoder-client"
 import { createVideoMuxSession } from "@/lib/editor/animation-export/workers/video-muxer-client"
 import type { VideoMuxerConfig } from "@/lib/editor/animation-export/workers/video-muxer-protocol"
 
@@ -72,5 +77,63 @@ describe("createVideoMuxSession", () => {
   it("returns null without a signal when the environment has no worker", async () => {
     // jsdom has neither Worker nor WebCodecs, so callers fall back in-process.
     await expect(createVideoMuxSession(CONFIG)).resolves.toBeNull()
+  })
+})
+
+describe("createGifEncoderSession", () => {
+  it("throws instead of spawning a worker when the signal already aborted", async () => {
+    await expect(
+      createGifEncoderSession(AbortSignal.abort())
+    ).rejects.toBeInstanceOf(AnimationExportAbortedError)
+  })
+
+  it("falls back in-process when the environment has no worker", async () => {
+    const session = await createGifEncoderSession()
+    expect(session.offMainThread).toBe(false)
+    session.dispose()
+  })
+})
+
+describe("isAnimationExportAborted", () => {
+  it("recognises the error class", () => {
+    expect(isAnimationExportAborted(new AnimationExportAbortedError())).toBe(
+      true
+    )
+  })
+
+  it("recognises an equivalent rebuilt across the worker boundary", () => {
+    // A worker reply carries the name, not the prototype, so instanceof alone
+    // would let a cancellation fall through to the fallback encoder.
+    const rebuilt = new Error("Export cancelled")
+    rebuilt.name = "AnimationExportAbortedError"
+    expect(isAnimationExportAborted(rebuilt)).toBe(true)
+  })
+
+  it("does not swallow unrelated failures", () => {
+    expect(isAnimationExportAborted(new Error("codec exploded"))).toBe(false)
+    expect(isAnimationExportAborted(null)).toBe(false)
+  })
+})
+
+describe("waitForPaint", () => {
+  it("resolves on the second animation frame", async () => {
+    await expect(waitForPaint()).resolves.toBeUndefined()
+  })
+
+  it("still resolves when rAF never fires, so a background tab can finish", async () => {
+    // requestAnimationFrame is paused in a backgrounded tab. Unbounded, the wait
+    // just before triggerDownload would strand a finished export.
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn(() => 0)
+    )
+    try {
+      const pending = waitForPaint()
+      await vi.advanceTimersByTimeAsync(1_000)
+      await expect(pending).resolves.toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/tests/lib/editor/animation-export/export-cancellation.test.ts
+++ b/tests/lib/editor/animation-export/export-cancellation.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { AnimationExportAbortedError } from "@/lib/editor/animation-export/abort"
+import { loadAudioSourceBlob } from "@/lib/editor/animation-export/video-media/audio"
+import { createVideoMuxSession } from "@/lib/editor/animation-export/workers/video-muxer-client"
+import type { VideoMuxerConfig } from "@/lib/editor/animation-export/workers/video-muxer-protocol"
+
+const CONFIG: VideoMuxerConfig = {
+  format: "mp4",
+  width: 640,
+  height: 480,
+  fps: 30,
+  keyFrameIntervalSec: 2,
+  audio: null,
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("loadAudioSourceBlob", () => {
+  it("returns the blob when the source reads", async () => {
+    const blob = new Blob(["x"])
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, blob: async () => blob })
+    )
+    await expect(loadAudioSourceBlob("blob:clip")).resolves.toBe(blob)
+  })
+
+  it("returns null for an unreadable source — audio is best-effort", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("gone")))
+    await expect(loadAudioSourceBlob("blob:clip")).resolves.toBeNull()
+  })
+
+  it("does not fetch at all once the export is cancelled", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+    await expect(
+      loadAudioSourceBlob("blob:clip", AbortSignal.abort())
+    ).rejects.toBeInstanceOf(AnimationExportAbortedError)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("reports a cancelled fetch as an abort, not as missing audio", async () => {
+    // Returning null here would carry the export on into a silent encode
+    // instead of stopping it.
+    const controller = new AbortController()
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => {
+        controller.abort()
+        return Promise.reject(new DOMException("Aborted", "AbortError"))
+      })
+    )
+    await expect(
+      loadAudioSourceBlob("blob:clip", controller.signal)
+    ).rejects.toBeInstanceOf(AnimationExportAbortedError)
+  })
+})
+
+describe("createVideoMuxSession", () => {
+  it("throws instead of starting the worker when the signal already aborted", async () => {
+    // An abort that has already fired never fires again, so the session's own
+    // abort listener would never run — the worker would decode the whole audio
+    // track and start the muxer before the cancellation surfaced.
+    await expect(
+      createVideoMuxSession(CONFIG, AbortSignal.abort())
+    ).rejects.toBeInstanceOf(AnimationExportAbortedError)
+  })
+
+  it("returns null without a signal when the environment has no worker", async () => {
+    // jsdom has neither Worker nor WebCodecs, so callers fall back in-process.
+    await expect(createVideoMuxSession(CONFIG)).resolves.toBeNull()
+  })
+})

--- a/tests/lib/editor/animation-export/gif-codec.test.ts
+++ b/tests/lib/editor/animation-export/gif-codec.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+
+import { GifStreamEncoder } from "@/lib/editor/animation-export/gif-codec"
+
+const W = 4
+const H = 4
+
+/** A solid-colour RGBA frame the encoder can quantize. */
+function frame(r: number, g: number, b: number): Uint8ClampedArray {
+  const data = new Uint8ClampedArray(W * H * 4)
+  for (let i = 0; i < W * H; i++) {
+    data[i * 4] = r
+    data[i * 4 + 1] = g
+    data[i * 4 + 2] = b
+    data[i * 4 + 3] = 255
+  }
+  return data
+}
+
+describe("GifStreamEncoder", () => {
+  it("releases the sampled frames once they are folded into the palette", () => {
+    // The samples and the concatenated copy are both live during the fold, and
+    // 16 sampled 1080p frames is ~130 MB per copy.
+    const encoder = new GifStreamEncoder()
+    encoder.addSample(frame(255, 0, 0))
+    encoder.addSample(frame(0, 255, 0))
+    expect(encoder.sampleCount).toBe(2)
+
+    encoder.buildPalette()
+    expect(encoder.sampleCount).toBe(0)
+  })
+
+  it("encodes frames against the shared palette", () => {
+    const encoder = new GifStreamEncoder()
+    encoder.addSample(frame(255, 0, 0))
+    encoder.buildPalette()
+    encoder.writeFrame(frame(255, 0, 0), W, H, 33.333)
+    encoder.writeFrame(frame(255, 0, 0), W, H, 66.667)
+    expect(encoder.frameCount).toBe(2)
+
+    const bytes = encoder.finish()
+    expect(bytes.byteLength).toBeGreaterThan(0)
+    // "GIF89a"
+    expect(Array.from(bytes.subarray(0, 6))).toEqual([71, 73, 70, 56, 57, 97])
+  })
+
+  it("refuses to build a palette with nothing sampled", () => {
+    expect(() => new GifStreamEncoder().buildPalette()).toThrow(
+      /No frames captured/
+    )
+  })
+
+  it("refuses to write a frame before the palette exists", () => {
+    const encoder = new GifStreamEncoder()
+    expect(() => encoder.writeFrame(frame(1, 2, 3), W, H, 0)).toThrow(
+      /palette has not been built/
+    )
+  })
+
+  it("distributes whole-centisecond delays so 30fps stays 1s over 30 frames", () => {
+    // GIF delays are whole centiseconds. Truncating each 33.333ms frame
+    // independently yields 3cs × 30 = 0.9s — 10% fast. The running emitted-time
+    // accounting is what keeps the clip honest, so assert the sum directly.
+    const frameMs = 1000 / 30
+    let emitted = 0
+    let total = 0
+    for (let f = 0; f < 30; f++) {
+      const target = Math.round(((f + 1) * frameMs) / 10)
+      const delay = Math.max(2, target - emitted)
+      emitted += delay
+      total += delay
+    }
+    expect(total).toBe(100)
+  })
+})


### PR DESCRIPTION
## Problem

Clicking Export on an animation froze the tab. The Cancel button couldn't be clicked and the progress bar couldn't repaint until the whole encode finished — the abort plumbing was already correct, but the main thread never yielded long enough to dispatch the click.

Tracing it, the blocking work was in three places:

- **Frame capture** (`export.ts:1115`) — `getComputedStyle` over every element in the clone, ~340 resolved longhands each, then serialize + rasterize a `<foreignObject>` SVG. This needs the DOM and **cannot** move off-thread.
- **GIF encode** (`gif.ts`) — `quantize()` over 16 concatenated sample frames is 20–46 MB in one uninterruptible call, with no abort check and no yield. Then per frame: ordered dither + `applyPalette` nearest-colour search over ~1M pixels.
- **Video mux** (`video.ts`, `video-media/encode-video.ts`) — the Mediabunny muxer, `output.finalize()` and the source clip's audio decode/re-encode all ran inline.

## What changed

Frame capture stays on the main thread — there's no way around that. Everything downstream of the pixels moves to a worker, and the capture loop now yields so input actually gets dispatched.

### Cooperative yields
`yieldToUi()` (`scheduler.yield()` → `MessageChannel` fallback; deliberately not `setTimeout`, which is clamped to 4ms+ once nested) and `createUiYielder(budgetMs = 40)`, which only yields once 40ms of uninterrupted work has passed — so cheap frames don't pay a task hop each. Wired into every encode loop, with the abort signal re-checked after each yield.

### GIF worker
`gif-codec.ts` holds the pure maths (previously duplicated across the animate and video-media paths); `workers/gif-encoder.worker.ts` runs it. The main thread rasterizes and transfers `ImageData` buffers zero-copy. Frames pipeline two deep, so frame N+1 captures while N encodes — a real speedup, not just a responsiveness fix.

### Video mux worker
`workers/video-muxer.worker.ts` owns codec negotiation, the `Output`/`BufferTarget` muxer, `output.finalize()` and the audio decode/re-encode. The main thread snapshots the encode canvas into a `VideoFrame` and transfers it.

Audio prep now takes a `Blob` instead of a src string — the main thread fetches it and hands over the bytes. Relying on a page-minted object URL resolving inside worker scope is fragile when the media registry may be revoking it.

`abort.ts` is split out of `utils.ts` so the workers don't drag html-to-image and the whole DOM export path into their bundles.

## Progress bar fixes

Three separate bugs, all surfaced once the export was actually watchable:

1. **The bar reserved 30% for work that no longer happens there.** `capturing` was 0→70%, `encoding` 70→98%. But each frame is palette-mapped or handed to the video encoder *inside* the capture loop — when the loop ends only the container flush is left. So exports sat at 70% and then the file dropped. Rebalanced to `preparing` 0→4%, `audio` 4→8%, `capturing` 8→96%, `encoding` 96→99%, `finishing` 99→100%.
2. **The audio step drove the bar backwards.** It reported `encoding`, but audio muxing runs *before* frame capture — so the bar jumped to 70%, then capture reset it to ~0%. Added a distinct `"audio"` phase with its own early band and label.
3. **100% was never painted.** The final report landed in the same task as `triggerDownload`, and the dialog tore down before React could paint. Added `waitForPaint()` before the download.

The same rebalance is applied to the share flow, which had its own copy of the split.

## Toast filename

The animation toasts built their text from constants (`"MP4"` + `".mp4"` → "Saved as MP4.mp4") instead of naming the real file. The still-image path already did this correctly, so the animation paths now match it: `exportAnimation` and `exportVideoMedia` return their resolved filename on the download branch, and the toasts print it — so it follows the user's `{TEMPLATE}_{SCALE}_{DATE}` format.

That widened their return type, so `exportVideoMediaBlob` was added (mirroring the existing `exportAnimationBlob`) and the share flow points at it, keeping the union out of that call site.

## Fallbacks

Both workers fall back to the existing in-process encoder when `Worker`/WebCodecs is unavailable (SSR, jsdom under test, older Safari) or when the worker fails its handshake — guarded by a timeout so a worker that neither answers nor errors can't stall the export with no way to cancel, which is the exact failure this PR exists to remove. A non-abort worker failure mid-encode falls through to the main-thread path as a genuine retry; abort errors propagate.

## Testing

- `pnpm typecheck`, `pnpm lint:strict`, `pnpm test` (167 files / 1350 tests) pass
- `pnpm build:next` succeeds with both workers emitted as separate chunks
- Exercised manually in the browser: export completes, the bar reaches 100%, and the toast names the real file

Not covered by automated tests: the workers themselves, since jsdom has no `Worker` and the suite therefore exercises the in-process fallback. Worth an export of each format (GIF / WebM / MP4, with and without audio) against the OpenNext build before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video and animation exports now use background processing when supported, helping keep the editor responsive.
  * GIF exports provide improved color handling and memory safeguards.
  * Export progress now includes an “Adding audio” stage with smoother updates.
  * Export notifications display the actual downloaded filename.

* **Bug Fixes**
  * Improved export reliability with automatic fallback when background processing is unavailable.
  * Downloads now wait for the final progress update before starting.
  * Cancelled exports now stop more reliably during audio loading and encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves GIF encoding and video muxing into workers while preserving main-thread fallbacks and improving export responsiveness.
- Adds cooperative UI yielding and worker-backed GIF/video encoding sessions.
- Makes audio loading abort-aware and transfers source bytes to workers as blobs.
- Rebalances export progress phases and reports resolved filenames in completion toasts.
- Adds cancellation coverage for audio initialization.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported audio-initialization cancellation path now propagates the signal through loading and rejects it before worker startup.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/editor/animation-export/video-media/audio.ts | Audio source loading now passes the export signal to fetch and preserves cancellation instead of treating it as missing audio. |
| lib/editor/animation-export/workers/video-muxer-client.ts | The worker session synchronously rejects an already-aborted signal before creating the worker, closing the previously reported initialization race. |
| lib/editor/animation-export/video-media/encode-video.ts | Video frames and audio are routed through the worker with a complete main-thread fallback and consistent abort propagation. |
| lib/editor/animation-export/video.ts | Animation video export uses the worker muxer while retaining cancellation checks and fallback encoding. |
| tests/lib/editor/animation-export/export-cancellation.test.ts | Cancellation tests cover aborted audio fetching and verify that it surfaces as an export abort rather than silent audio. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(export): honour an already-cancelled..."](https://github.com/shivabhattacharjee/tokokino/commit/571d3aa0de5f2a0731bba84c3da924f0265f7c64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51472750)</sub>

<!-- /greptile_comment -->