### PR TITLE
feat: add export-ready glass stack frames

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -55,6 +55,10 @@ const releases: Release[] = [
         text: "The front glass rim stays even on every edge, full-page screenshots preview correctly in the frame picker, and each media slot uses its own frame geometry when cropping.",
       },
       {
+        title: "Smoother glass corners",
+        text: "Every glass corner now eases into its straight edges instead of snapping into a circular arc, so the rim reads as one continuous curve even in an 8K export.",
+      },
+      {
         title: "Export-ready on every browser",
         text: "Glass frames carry through to still and motion exports, with WebKit compositing and clipping fallbacks for Safari.",
       },

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -35,6 +35,32 @@ type Release = {
 
 const releases: Release[] = [
   {
+    id: "v2-2-0",
+    version: "2.2.0",
+    date: "August 13, 2026",
+    title: "Glass frames",
+    summary:
+      "Give screenshots and videos a polished glass treatment with a single card or layered stacks — designed to stay consistent from the live canvas through high-resolution export.",
+    changes: [
+      {
+        title: "Three new glass frames",
+        text: "Choose Glass Card for a clean single pane, Glass Cascade for layers beneath the canvas, or Glass Crown for layers rising behind it.",
+      },
+      {
+        title: "Dark and light glass",
+        text: "Each frame includes dark and light variants with translucent gradients, background blur, soft highlights, and depth-aware shadows.",
+      },
+      {
+        title: "Consistent media framing",
+        text: "The front glass rim stays even on every edge, full-page screenshots preview correctly in the frame picker, and each media slot uses its own frame geometry when cropping.",
+      },
+      {
+        title: "Export-ready on every browser",
+        text: "Glass frames carry through to still and motion exports, with WebKit compositing and clipping fallbacks for Safari.",
+      },
+    ],
+  },
+  {
     id: "v2-1-0",
     version: "2.1.0",
     date: "August 2, 2026",

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -11,6 +11,7 @@ import { TextElementView } from "@/components/editor/text-element"
 import { bulkToolbarScale } from "@/components/editor/toolbar/primitives"
 import { cn } from "@/lib/utils"
 import { isBrowserFrame, resolveBrowserFrameColor } from "@/lib/browser-frame"
+import { isGlassFrame, resolveGlassFrameColor } from "@/lib/glass-frame"
 import {
   MAIN_MEDIA_FX_PREVIEW_VAR,
   NEUTRAL_MEDIA_ADJUSTMENTS,
@@ -85,6 +86,10 @@ import {
   BrowserFrameEmptyState,
   ScreenshotBrowserFrame,
 } from "./screenshot-browser-frame"
+import {
+  GlassFrameEmptyState,
+  ScreenshotGlassFrame,
+} from "./screenshot-glass-frame"
 import { ScreenshotMockup } from "./screenshot-mockup"
 import { TweetCardView } from "./tweet-card"
 import { isVideoSrc } from "@/lib/editor/media-type"
@@ -424,8 +429,12 @@ function CanvasViewInner({
   const isPortraitOrSquareCanvas = ah >= aw
   const browserFrame = isBrowserFrame(frame.id)
   const browserFrameColor = resolveBrowserFrameColor(frame.color)
+  const glassFrame = isGlassFrame(frame.id)
+  const glassFrameColor = resolveGlassFrameColor(frame.color)
   const mockupDevice =
-    frame.id === "none" || browserFrame ? null : getDeviceMockup(frame.id)
+    frame.id === "none" || browserFrame || glassFrame
+      ? null
+      : getDeviceMockup(frame.id)
   const mockupOrientation = mockupDevice?.orientations.includes("portrait")
     ? "portrait"
     : "landscape"
@@ -671,7 +680,7 @@ function CanvasViewInner({
       ? -90
       : 0
   const mockupAsset =
-    frame.id === "none" || browserFrame
+    frame.id === "none" || browserFrame || glassFrame
       ? null
       : getDeviceMockupAsset(frame.id, frame.color, mockupOrientation)
   const mockupSpec = mockupAsset ? deviceMockupSpec(frame.id) : null
@@ -1098,6 +1107,51 @@ function CanvasViewInner({
                     onMediaElement={handleMediaElement}
                     mediaStyle={fullPageMediaStyle ?? videoMediaStyle}
                   />
+                ) : glassFrame ? (
+                  <ScreenshotGlassFrame
+                    screenshot={screenshot}
+                    frameId={frame.id}
+                    color={glassFrameColor}
+                    screenshotLayer={screenshotLayer}
+                    transform={transform}
+                    shadowFilter={computedShadowFilter}
+                    screenshotOffset={effectiveOffset}
+                    screenshotAnchor={screenshotAnchor}
+                    enhanceFilter={enhanceFilter}
+                    objectFit={effectiveObjectFit}
+                    isScreenshotSelected={isScreenshotSelected && isActive}
+                    isScreenshotDragging={isScreenshotDragging}
+                    hoverActionsDisabled={
+                      bulkCanvasDragging || isScreenshotDragging
+                    }
+                    activeTool={activeTool}
+                    stageRef={stageRef}
+                    imageRef={imageRef}
+                    onSelect={handleScreenshotClickSelect}
+                    onPointerDown={(e) => {
+                      if (document.activeElement instanceof HTMLElement) {
+                        document.activeElement.blur()
+                      }
+                      startMockupDrag(e)
+                    }}
+                    onPointerMove={moveMockup}
+                    onPointerUp={stopMockupDrag}
+                    onWheel={handleFullPageWheel}
+                    onImageLoad={handleImageLoad}
+                    onCropClick={openMainCropModal}
+                    onReplaceFile={readFile}
+                    onDelete={() => {
+                      setIsScreenshotSelected(false)
+                      setScreenshot(null)
+                    }}
+                    onCaptureWebsite={handleCaptureWebsite}
+                    onLoadTweet={handleLoadTweet}
+                    captureDefaultDevice={captureDefaultDevice}
+                    captureStateKey={mainCaptureStateKey}
+                    innerLightingStyle={innerLightingStyle}
+                    onMediaElement={handleMediaElement}
+                    mediaStyle={fullPageMediaStyle ?? videoMediaStyle}
+                  />
                 ) : mockupAsset && mockupSpec ? (
                   <ScreenshotMockup
                     screenshot={screenshot}
@@ -1232,6 +1286,41 @@ function CanvasViewInner({
                   activeTool={activeTool}
                   addressValue={frameAddress}
                   onAddressChange={setFrameAddress}
+                  onCapture={handleCaptureWebsite}
+                  onDemo={handleDemoScreenshot}
+                  defaultCaptureDevice={captureDefaultDevice}
+                  captureStateKey={mainCaptureStateKey}
+                  compact={
+                    isPortraitOrSquareCanvas ||
+                    tilt.rx !== 0 ||
+                    tilt.ry !== 0 ||
+                    tilt.rz !== 0 ||
+                    scale !== 100 ||
+                    screenshotSlots.length > 0
+                  }
+                  onPointerDown={(e) => {
+                    if (document.activeElement instanceof HTMLElement) {
+                      document.activeElement.blur()
+                    }
+                    startMockupDrag(e)
+                  }}
+                  onPointerMove={moveMockup}
+                  onPointerUp={stopMockupDrag}
+                  innerLightingStyle={innerLightingStyle}
+                />
+              ) : glassFrame ? (
+                <GlassFrameEmptyState
+                  frameId={frame.id}
+                  color={glassFrameColor}
+                  isDragOver={isDragOver}
+                  onBrowse={() => fileInputRef.current?.click()}
+                  transform={transform}
+                  shadowFilter={computedShadowFilter}
+                  enhanceFilter={enhanceFilter}
+                  screenshotOffset={effectiveOffset}
+                  screenshotAnchor={screenshotAnchor}
+                  isScreenshotDragging={isScreenshotDragging}
+                  activeTool={activeTool}
                   onCapture={handleCaptureWebsite}
                   onDemo={handleDemoScreenshot}
                   defaultCaptureDevice={captureDefaultDevice}

--- a/components/editor/canvas/helpers.ts
+++ b/components/editor/canvas/helpers.ts
@@ -6,6 +6,7 @@ import {
   isBrowserFrame,
   SAFARI_BROWSER_FRAME_ID,
 } from "@/lib/browser-frame"
+import { isGlassFrame } from "@/lib/glass-frame"
 import { hexToRgb } from "@/lib/editor/color-utils"
 import { shadowDropFilterPreviewCss } from "@/lib/editor/css-utils"
 import {
@@ -217,6 +218,7 @@ export function clamp(n: number, min: number, max: number) {
 
 export function frameSelectionRadius(frameId: string, fallback: number) {
   if (frameId === "none") return fallback
+  if (isGlassFrame(frameId)) return 12
   if (frameId === CHROME_BROWSER_FRAME_ID) return 8
   if (frameId === SAFARI_BROWSER_FRAME_ID) return 14
   if (frameId === ARC_BROWSER_FRAME_ID) return 18

--- a/components/editor/canvas/screenshot-edit-menu.tsx
+++ b/components/editor/canvas/screenshot-edit-menu.tsx
@@ -32,6 +32,11 @@ import {
   resolveBrowserFrameColor,
 } from "@/lib/browser-frame"
 import type { DeviceFrame, FrameOrientation } from "@/lib/editor/store"
+import {
+  GLASS_FRAMES,
+  getGlassFrame,
+  resolveGlassFrameColor,
+} from "@/lib/glass-frame"
 import { DEVICE_MOCKUPS, getDeviceMockup } from "@/lib/mockups"
 import { cn } from "@/lib/utils"
 
@@ -208,9 +213,14 @@ export function ScreenshotFrameSettings({
 }) {
   const currentDevice = getDeviceMockup(frame.id)
   const currentBrowserFrame = getBrowserFrame(frame.id)
+  const currentGlassFrame = getGlassFrame(frame.id)
   const deviceOptions = React.useMemo(
     () => [
       { id: "none", name: "None" },
+      ...GLASS_FRAMES.map((glassFrame) => ({
+        id: glassFrame.id,
+        name: glassFrame.name,
+      })),
       ...BROWSER_FRAMES.map((browserFrame) => ({
         id: browserFrame.id,
         name: browserFrame.name,
@@ -230,9 +240,12 @@ export function ScreenshotFrameSettings({
     ? [...currentDevice.colors]
     : currentBrowserFrame
       ? [...currentBrowserFrame.colors]
-      : []
+      : currentGlassFrame
+        ? [...currentGlassFrame.colors]
+        : []
   const availableOrientations = currentDevice?.orientations ?? []
   const isCurrentBrowserFrame = Boolean(currentBrowserFrame)
+  const isCurrentGlassFrame = Boolean(currentGlassFrame)
   const frameOrientationSupported = currentDevice
     ? frame.orientation === "vertical"
       ? availableOrientations.includes("portrait")
@@ -240,16 +253,19 @@ export function ScreenshotFrameSettings({
     : true
   const effectiveColor = currentBrowserFrame
     ? resolveBrowserFrameColor(frame.color)
-    : currentDevice && availableColors.includes(frame.color)
-      ? frame.color
-      : (availableColors[0] ?? frame.color)
-  const effectiveOrientation = isCurrentBrowserFrame
-    ? "horizontal"
-    : currentDevice && frameOrientationSupported
-      ? frame.orientation
-      : availableOrientations[0] === "landscape"
-        ? "horizontal"
-        : "vertical"
+    : currentGlassFrame
+      ? resolveGlassFrameColor(frame.color)
+      : currentDevice && availableColors.includes(frame.color)
+        ? frame.color
+        : (availableColors[0] ?? frame.color)
+  const effectiveOrientation =
+    isCurrentBrowserFrame || isCurrentGlassFrame
+      ? "horizontal"
+      : currentDevice && frameOrientationSupported
+        ? frame.orientation
+        : availableOrientations[0] === "landscape"
+          ? "horizontal"
+          : "vertical"
 
   const updateDevice = (id: string) => {
     if (id === "none") {
@@ -265,6 +281,15 @@ export function ScreenshotFrameSettings({
         )
           ? resolveBrowserFrameColor(frame.color)
           : nextBrowserFrame.colors[0],
+        orientation: "horizontal",
+      })
+      return
+    }
+    const nextGlassFrame = getGlassFrame(id)
+    if (nextGlassFrame) {
+      onFrameChange({
+        id,
+        color: resolveGlassFrameColor(frame.color),
         orientation: "horizontal",
       })
       return
@@ -309,7 +334,7 @@ export function ScreenshotFrameSettings({
         </Select>
       </div>
 
-      {currentDevice || currentBrowserFrame ? (
+      {currentDevice || currentBrowserFrame || currentGlassFrame ? (
         <>
           <div className="space-y-1.5">
             <span className="px-1 text-[10px] font-medium tracking-[0.12em] text-muted-foreground uppercase">

--- a/components/editor/canvas/screenshot-frame-content.tsx
+++ b/components/editor/canvas/screenshot-frame-content.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 
 import { isBrowserFrame, resolveBrowserFrameColor } from "@/lib/browser-frame"
+import { isGlassFrame, resolveGlassFrameColor } from "@/lib/glass-frame"
 import type {
   DeviceFrame,
   EditorTool,
@@ -20,6 +21,10 @@ import {
   BrowserFrameEmptyState,
   ScreenshotBrowserFrame,
 } from "./screenshot-browser-frame"
+import {
+  GlassFrameEmptyState,
+  ScreenshotGlassFrame,
+} from "./screenshot-glass-frame"
 import { ScreenshotMockup } from "./screenshot-mockup"
 import type { CaptureDevice, CaptureSettings } from "./upload-card"
 
@@ -147,8 +152,12 @@ export function ScreenshotFrameContent({
 }: ScreenshotFrameContentProps) {
   const browserFrame = isBrowserFrame(frame.id)
   const browserFrameColor = resolveBrowserFrameColor(frame.color)
+  const glassFrame = isGlassFrame(frame.id)
+  const glassFrameColor = resolveGlassFrameColor(frame.color)
   const mockupDevice =
-    frame.id === "none" || browserFrame ? null : getDeviceMockup(frame.id)
+    frame.id === "none" || browserFrame || glassFrame
+      ? null
+      : getDeviceMockup(frame.id)
   const mockupOrientation = mockupDevice?.orientations.includes("portrait")
     ? "portrait"
     : "landscape"
@@ -157,7 +166,7 @@ export function ScreenshotFrameContent({
       ? -90
       : 0
   const mockupAsset =
-    frame.id === "none" || browserFrame
+    frame.id === "none" || browserFrame || glassFrame
       ? null
       : getDeviceMockupAsset(frame.id, frame.color, mockupOrientation)
   const mockupSpec = mockupAsset ? deviceMockupSpec(frame.id) : null
@@ -184,6 +193,44 @@ export function ScreenshotFrameContent({
           imageRef={imageRef}
           addressValue={addressValue}
           onAddressChange={onAddressChange}
+          onSelect={onSelect}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onImageLoad={handleImageLoad}
+          onCropClick={onCrop}
+          onReplaceFile={onReplaceFile}
+          onDelete={onDelete}
+          onCaptureWebsite={onCapture}
+          captureDefaultDevice={captureDefaultDevice}
+          captureStateKey={captureStateKey}
+          showHoverActions={false}
+          readMainPreviewVars={readMainPreviewVars}
+          innerLightingStyle={innerLightingStyle}
+          onMediaElement={onMediaElement}
+          mediaStyle={mediaStyle}
+        />
+      )
+    }
+
+    if (glassFrame) {
+      return (
+        <ScreenshotGlassFrame
+          screenshot={src}
+          frameId={frame.id}
+          color={glassFrameColor}
+          screenshotLayer={CONTENT_LAYER}
+          transform={contentTransform}
+          shadowFilter={shadowFilter}
+          screenshotOffset={screenshotOffset}
+          screenshotAnchor={screenshotAnchor}
+          enhanceFilter={imageFilter}
+          objectFit={objectFit}
+          isScreenshotSelected={false}
+          isScreenshotDragging={isDragging}
+          activeTool={activeTool}
+          stageRef={stageRef}
+          imageRef={imageRef}
           onSelect={onSelect}
           onPointerDown={onPointerDown}
           onPointerMove={onPointerMove}
@@ -317,6 +364,35 @@ export function ScreenshotFrameContent({
         activeTool={activeTool}
         addressValue={addressValue}
         onAddressChange={onAddressChange}
+        onCapture={onCapture}
+        onDemo={onDemo}
+        defaultCaptureDevice={captureDefaultDevice}
+        captureStateKey={captureStateKey}
+        allowVideo={allowVideo}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        compact={emptyCompact}
+        readMainPreviewVars={readMainPreviewVars}
+        innerLightingStyle={innerLightingStyle}
+      />
+    )
+  }
+
+  if (glassFrame) {
+    return (
+      <GlassFrameEmptyState
+        frameId={frame.id}
+        color={glassFrameColor}
+        isDragOver={isDragOver}
+        onBrowse={onBrowse}
+        transform={contentTransform}
+        shadowFilter={shadowFilter}
+        enhanceFilter={imageFilter}
+        screenshotOffset={screenshotOffset}
+        screenshotAnchor={screenshotAnchor}
+        isScreenshotDragging={isDragging}
+        activeTool={activeTool}
         onCapture={onCapture}
         onDemo={onDemo}
         defaultCaptureDevice={captureDefaultDevice}

--- a/components/editor/canvas/screenshot-glass-frame.tsx
+++ b/components/editor/canvas/screenshot-glass-frame.tsx
@@ -218,6 +218,7 @@ export function ScreenshotGlassFrame({
           }}
         >
           <div
+            data-export-hidden="true"
             className={cn(
               "pointer-events-none absolute top-1/2 left-1/2 z-40 -translate-x-1/2 -translate-y-1/2 transition-opacity duration-200",
               editOpen || isScreenshotSelected

--- a/components/editor/canvas/screenshot-glass-frame.tsx
+++ b/components/editor/canvas/screenshot-glass-frame.tsx
@@ -1,0 +1,385 @@
+"use client"
+
+import * as React from "react"
+
+import { EmptyStateBackdrop } from "@/components/editor/canvas/empty-state-backdrop"
+import { ScreenshotEditMenu } from "@/components/editor/canvas/screenshot-edit-menu"
+import {
+  UploadCard,
+  type CaptureDevice,
+  type CaptureSettings,
+} from "@/components/editor/canvas/upload-card"
+import { GlassFrame } from "@/components/ui/glass-frame"
+import { useAnimationPlayerOptional } from "@/hooks/use-animation-player"
+import { isVideoSrc } from "@/lib/editor/media-type"
+import type { EditorTool, ScreenshotLayer } from "@/lib/editor/store"
+import type { TweetCardSettings } from "@/lib/editor/tweet-settings"
+import { getGlassFrame, type GlassFrameColor } from "@/lib/glass-frame"
+import { cn } from "@/lib/utils"
+
+import {
+  frameFitStyle,
+  framePositionedStyle,
+  framePositionTransform,
+} from "./helpers"
+import { InnerLightingOverlay } from "./inner-lighting-overlay"
+
+type SelectEvent = { stopPropagation: () => void }
+type ImageFit = "contain" | "cover" | "fill"
+
+type ScreenshotGlassFrameProps = {
+  screenshot: string
+  frameId: string
+  color: GlassFrameColor
+  screenshotLayer: ScreenshotLayer
+  transform: string
+  shadowFilter: string | undefined
+  screenshotOffset: { x: number; y: number }
+  screenshotAnchor: { x: number; y: number }
+  enhanceFilter: string | undefined
+  objectFit?: ImageFit
+  isScreenshotSelected: boolean
+  isScreenshotDragging: boolean
+  hoverActionsDisabled?: boolean
+  activeTool: EditorTool
+  stageRef: React.RefObject<HTMLDivElement | null>
+  imageRef: React.RefObject<HTMLImageElement | null>
+  onSelect: (event: SelectEvent) => void
+  onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void
+  onPointerMove: (event: React.PointerEvent<HTMLDivElement>) => void
+  onPointerUp: (event: React.PointerEvent<HTMLDivElement>) => void
+  onWheel?: React.WheelEventHandler<HTMLDivElement>
+  onImageLoad: (event: React.SyntheticEvent<HTMLImageElement>) => void
+  onCropClick: () => void
+  onReplaceFile: (file: File) => void
+  onDelete: () => void
+  onCaptureWebsite?: (
+    url: string,
+    settings: CaptureSettings
+  ) => void | Promise<void>
+  onLoadTweet?: (url: string, settings?: TweetCardSettings) => Promise<void>
+  captureDefaultDevice?: CaptureDevice
+  captureStateKey?: string
+  showHoverActions?: boolean
+  readMainPreviewVars?: boolean
+  innerLightingStyle?: React.CSSProperties | null
+  onMediaElement?: (element: HTMLVideoElement | null) => void
+  mediaStyle?: React.CSSProperties
+}
+
+type GlassFrameEmptyStateProps = {
+  frameId: string
+  color: GlassFrameColor
+  isDragOver: boolean
+  onBrowse: () => void
+  transform: string
+  shadowFilter?: string
+  enhanceFilter?: string
+  screenshotOffset: { x: number; y: number }
+  screenshotAnchor: { x: number; y: number }
+  isScreenshotDragging: boolean
+  activeTool: EditorTool
+  onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void
+  onPointerMove: (event: React.PointerEvent<HTMLDivElement>) => void
+  onPointerUp: (event: React.PointerEvent<HTMLDivElement>) => void
+  compact?: boolean
+  onCapture?: (url: string, settings: CaptureSettings) => void | Promise<void>
+  onDemo?: (src: string) => void | Promise<void>
+  defaultCaptureDevice?: CaptureDevice
+  captureStateKey?: string
+  readMainPreviewVars?: boolean
+  innerLightingStyle?: React.CSSProperties | null
+  allowVideo?: boolean
+}
+
+export function ScreenshotGlassFrame({
+  screenshot,
+  frameId,
+  color,
+  screenshotLayer,
+  transform,
+  shadowFilter,
+  screenshotOffset,
+  screenshotAnchor,
+  enhanceFilter,
+  objectFit = "cover",
+  isScreenshotSelected,
+  isScreenshotDragging,
+  hoverActionsDisabled,
+  activeTool,
+  stageRef,
+  imageRef,
+  onSelect,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onWheel,
+  onImageLoad,
+  onCropClick,
+  onReplaceFile,
+  onDelete,
+  onCaptureWebsite,
+  onLoadTweet,
+  captureDefaultDevice,
+  captureStateKey,
+  showHoverActions = true,
+  readMainPreviewVars = true,
+  innerLightingStyle,
+  onMediaElement,
+  mediaStyle,
+}: ScreenshotGlassFrameProps) {
+  const [editOpen, setEditOpen] = React.useState(false)
+  const animationPlayer = useAnimationPlayerOptional()
+  const isAnimationPlaying = animationPlayer?.isPlaying ?? false
+  const frame = getGlassFrame(frameId)
+  if (!frame) return null
+
+  const fitStyle = frameFitStyle(frame.aspectRatio)
+  const positionedStyle = framePositionedStyle({
+    aspectRatio: frame.aspectRatio,
+    anchor: screenshotAnchor,
+    offset: screenshotOffset,
+    transform,
+    shadowFilter,
+    enhanceFilter,
+    layer: screenshotLayer,
+    readPreviewVars: readMainPreviewVars,
+  })
+  const isVideo = isVideoSrc(screenshot)
+
+  return (
+    <div
+      data-box-hover-target
+      className="group/glass-frame pointer-events-none relative h-full w-full"
+      style={{ containerType: "size" }}
+    >
+      <div
+        data-editor-shadow-filter-target
+        data-editor-shadow-filter-base={shadowFilter || ""}
+        data-editor-enhance-filter={enhanceFilter || ""}
+        className={cn(
+          "pointer-events-auto absolute top-0 left-0 max-h-full max-w-full select-none",
+          screenshotLayer.hidden && "pointer-events-none",
+          isScreenshotDragging || activeTool === "position"
+            ? "cursor-grabbing transition-none"
+            : "transition-[transform,opacity,filter,box-shadow] duration-300 ease-out",
+          activeTool === "pointer" && "cursor-grab"
+        )}
+        style={positionedStyle}
+        onClick={onSelect}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter" && event.key !== " ") return
+          event.preventDefault()
+          onSelect(event)
+        }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        onWheel={onWheel}
+        role="button"
+        tabIndex={activeTool === "pointer" && !screenshotLayer.hidden ? 0 : -1}
+        aria-label="Select glass screenshot"
+      >
+        <GlassFrame
+          frameId={frameId}
+          colorMode={color}
+          imageSrc={isVideo ? undefined : screenshot}
+          videoSrc={isVideo ? screenshot : undefined}
+          screenRef={stageRef}
+          imageRef={imageRef}
+          onImageLoad={onImageLoad}
+          onMediaElement={onMediaElement}
+          mediaStyle={mediaStyle}
+          imageFit={objectFit}
+          shimmer
+          className="h-full w-full"
+          screenOverlay={<InnerLightingOverlay style={innerLightingStyle} />}
+        />
+      </div>
+
+      {showHoverActions &&
+      activeTool === "pointer" &&
+      !isAnimationPlaying &&
+      !screenshotLayer.hidden ? (
+        <div
+          className="pointer-events-none absolute top-0 left-0 max-h-full max-w-full"
+          style={{
+            ...fitStyle,
+            left: "50%",
+            top: "50%",
+            transform: framePositionTransform({
+              anchor: screenshotAnchor,
+              offset: screenshotOffset,
+              transform,
+              readPreviewVars: readMainPreviewVars,
+            }),
+            transformOrigin: "center",
+          }}
+        >
+          <div
+            className={cn(
+              "pointer-events-none absolute top-1/2 left-1/2 z-40 -translate-x-1/2 -translate-y-1/2 transition-opacity duration-200",
+              editOpen || isScreenshotSelected
+                ? "opacity-100"
+                : "opacity-0 group-hover/glass-frame:opacity-100",
+              isScreenshotDragging && !editOpen && "!opacity-0",
+              hoverActionsDisabled && !editOpen && "!opacity-0"
+            )}
+          >
+            <ScreenshotEditMenu
+              open={editOpen}
+              onOpenChange={(open) => {
+                if (hoverActionsDisabled) {
+                  setEditOpen(false)
+                  return
+                }
+                setEditOpen(open)
+              }}
+              onCrop={onCropClick}
+              onReplaceFile={onReplaceFile}
+              onDelete={onDelete}
+              onCaptureWebsite={onCaptureWebsite}
+              onLoadTweet={onLoadTweet}
+              captureDefaultDevice={captureDefaultDevice}
+              captureStateKey={captureStateKey}
+            />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export function GlassFrameEmptyState({
+  frameId,
+  color,
+  isDragOver,
+  onBrowse,
+  transform,
+  shadowFilter,
+  enhanceFilter,
+  screenshotOffset,
+  screenshotAnchor,
+  isScreenshotDragging,
+  activeTool,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  compact = false,
+  onCapture,
+  onDemo,
+  defaultCaptureDevice,
+  captureStateKey,
+  readMainPreviewVars = true,
+  innerLightingStyle,
+  allowVideo = true,
+}: GlassFrameEmptyStateProps) {
+  const frame = getGlassFrame(frameId)
+  if (!frame) return null
+
+  const fitStyle = frameFitStyle(frame.aspectRatio)
+  const positionedStyle = framePositionedStyle({
+    aspectRatio: frame.aspectRatio,
+    anchor: screenshotAnchor,
+    offset: screenshotOffset,
+    transform,
+    shadowFilter,
+    enhanceFilter,
+    readPreviewVars: readMainPreviewVars,
+  })
+
+  const uploadCard = (
+    <EmptyStateBackdrop
+      data-drag-over={isDragOver}
+      className={cn(
+        "flex size-full items-center justify-center transition-all",
+        compact && "pointer-events-none",
+        "data-[drag-over=true]:ring-2 data-[drag-over=true]:ring-primary/40"
+      )}
+    >
+      {compact ? null : (
+        <UploadCard
+          isDragOver={isDragOver}
+          onBrowse={onBrowse}
+          onCapture={onCapture}
+          onDemo={onDemo}
+          defaultDevice={defaultCaptureDevice}
+          captureStateKey={captureStateKey}
+          allowVideo={allowVideo}
+          showHint
+          className="w-full max-w-[400px]"
+        />
+      )}
+    </EmptyStateBackdrop>
+  )
+
+  return (
+    <div
+      className="pointer-events-none relative h-full w-full"
+      style={{ containerType: "size" }}
+    >
+      <div
+        data-editor-shadow-filter-target
+        data-editor-shadow-filter-base={shadowFilter || ""}
+        data-editor-enhance-filter={enhanceFilter || ""}
+        className={cn(
+          "pointer-events-auto absolute top-0 left-0 max-h-full max-w-full select-none",
+          isScreenshotDragging || activeTool === "position"
+            ? "cursor-grabbing transition-none"
+            : "transition-[transform,opacity,filter,box-shadow] duration-300 ease-out",
+          activeTool === "pointer" && !isScreenshotDragging && "cursor-grab"
+        )}
+        style={positionedStyle}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+      >
+        <GlassFrame
+          frameId={frameId}
+          colorMode={color}
+          className="h-full w-full"
+          screenOverlay={
+            <>
+              {uploadCard}
+              <InnerLightingOverlay style={innerLightingStyle} />
+            </>
+          }
+        />
+      </div>
+
+      {compact ? (
+        <div
+          className="pointer-events-none absolute top-0 left-0 max-h-full max-w-full"
+          style={{
+            ...fitStyle,
+            left: "50%",
+            top: "50%",
+            transform: framePositionTransform({
+              anchor: screenshotAnchor,
+              offset: screenshotOffset,
+              transform: "",
+              readPreviewVars: readMainPreviewVars,
+            }),
+            transformOrigin: "center",
+          }}
+        >
+          <div className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center">
+            <UploadCard
+              compact
+              isDragOver={isDragOver}
+              onBrowse={onBrowse}
+              onCapture={onCapture}
+              onDemo={onDemo}
+              defaultDevice={defaultCaptureDevice}
+              captureStateKey={captureStateKey}
+              allowVideo={allowVideo}
+              showHint
+            />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/components/editor/effects-sidebar.tsx
+++ b/components/editor/effects-sidebar.tsx
@@ -58,6 +58,7 @@ export function EffectsSidebar({
   const bulkEditMode = useEditorStore((s) => s.bulkEditMode)
   const frame = useActiveCanvasField((c) => c.frame)
   const objectFit = useActiveCanvasField((c) => c.objectFit)
+  const fullPageCapture = useActiveCanvasField((c) => c.fullPageCapture)
   const tweet = useActiveCanvasField((c) => c.tweet)
   const setAspect = useEditorStore((s) => s.setAspect)
   const setCanvasAspect = useEditorStore((s) => s.setCanvasAspect)
@@ -173,6 +174,11 @@ export function EffectsSidebar({
             value={displayFrame}
             align={popoverAlign}
             previewImage={selectedSlot ? selectedSlot.src : undefined}
+            previewFullPageCapture={
+              selectedSlot
+                ? (selectedSlot.fullPageCapture ?? null)
+                : fullPageCapture
+            }
             imageFit={selectedSlot?.objectFit ?? objectFit ?? "cover"}
             disabled={Boolean(tweet)}
             disabledLabel="Disabled for social posts"

--- a/components/editor/frame-popover.tsx
+++ b/components/editor/frame-popover.tsx
@@ -252,8 +252,9 @@ export function findFrameOptionName(id: string) {
   return ALL_OPTIONS.find((o) => o.id === id)?.name ?? "None"
 }
 
-const BROWSER_TILE_PREVIEW_WIDTH = 112
-const BROWSER_TILE_PREVIEW_VIRTUAL_WIDTH = 240
+const FRAME_TILE_PREVIEW_WIDTH = 112
+const FRAME_TILE_PREVIEW_VIRTUAL_WIDTH = 240
+const FRAME_TILE_PREVIEW_IMAGE_URL = BROWSER_FRAME_PREVIEW_IMAGE_URL
 
 const FRAME_SEARCH_ALIASES: Record<string, string[]> = {
   iphone_17: ["apple"],
@@ -1153,7 +1154,7 @@ const BrowserTilePreview = React.memo(function BrowserTilePreview({
   mediaStyle?: React.CSSProperties
 }) {
   const frame = getBrowserFrame(frameId)
-  const scale = BROWSER_TILE_PREVIEW_WIDTH / BROWSER_TILE_PREVIEW_VIRTUAL_WIDTH
+  const scale = FRAME_TILE_PREVIEW_WIDTH / FRAME_TILE_PREVIEW_VIRTUAL_WIDTH
   const isVideo = isVideoSrc(screenshot)
   // Video blob URLs can't be used as <img> src — pass them as videoSrc. When
   // there's no canvas media, fall back to the static browser preview image.
@@ -1164,14 +1165,14 @@ const BrowserTilePreview = React.memo(function BrowserTilePreview({
     <div
       className="relative overflow-hidden drop-shadow-sm"
       style={{
-        width: BROWSER_TILE_PREVIEW_WIDTH,
+        width: FRAME_TILE_PREVIEW_WIDTH,
         aspectRatio: frame?.aspectRatio,
       }}
     >
       <div
         className="absolute top-0 left-0"
         style={{
-          width: BROWSER_TILE_PREVIEW_VIRTUAL_WIDTH,
+          width: FRAME_TILE_PREVIEW_VIRTUAL_WIDTH,
           transform: `scale(${scale})`,
           transformOrigin: "top left",
         }}
@@ -1230,25 +1231,25 @@ const GlassTilePreview = React.memo(function GlassTilePreview({
   mediaStyle?: React.CSSProperties
 }) {
   const frame = getGlassFrame(frameId)
-  const scale = BROWSER_TILE_PREVIEW_WIDTH / BROWSER_TILE_PREVIEW_VIRTUAL_WIDTH
+  const scale = FRAME_TILE_PREVIEW_WIDTH / FRAME_TILE_PREVIEW_VIRTUAL_WIDTH
   const isVideo = isVideoSrc(screenshot)
   const imageSrc = isVideo
     ? undefined
-    : (screenshot ?? BROWSER_FRAME_PREVIEW_IMAGE_URL)
+    : (screenshot ?? FRAME_TILE_PREVIEW_IMAGE_URL)
   const videoSrc = isVideo ? (screenshot ?? undefined) : undefined
 
   return (
     <div
       className="relative overflow-visible drop-shadow-sm"
       style={{
-        width: BROWSER_TILE_PREVIEW_WIDTH,
+        width: FRAME_TILE_PREVIEW_WIDTH,
         aspectRatio: frame?.aspectRatio,
       }}
     >
       <div
         className="absolute top-0 left-0"
         style={{
-          width: BROWSER_TILE_PREVIEW_VIRTUAL_WIDTH,
+          width: FRAME_TILE_PREVIEW_VIRTUAL_WIDTH,
           transform: `scale(${scale})`,
           transformOrigin: "top left",
         }}

--- a/components/editor/frame-popover.tsx
+++ b/components/editor/frame-popover.tsx
@@ -11,6 +11,7 @@ import {
   RiMacLine,
   RiSearchLine,
   RiSmartphoneLine,
+  RiStackLine,
   RiTabletLine,
   RiWindow2Line,
 } from "@remixicon/react"
@@ -46,8 +47,14 @@ import {
 import type { DeviceFrame, FrameOrientation } from "@/lib/editor/store"
 import { useActiveCanvasField } from "@/lib/editor/store"
 import { isVideoSrc } from "@/lib/editor/media-type"
+import {
+  fullPageCaptureMediaStyle,
+  fullPageCaptureObjectFit,
+} from "@/lib/editor/full-page-capture"
+import type { FullPageCapture } from "@/lib/editor/state-types"
 import { VideoIdlePoster } from "@/components/editor/canvas/video-idle-poster"
 import { BoxEmptyState } from "@/components/editor/canvas/box-empty-state"
+import { GlassFrame } from "@/components/ui/glass-frame"
 
 const DEVICE_FRAME_EMPTY_VIRTUAL_WIDTH = 280
 import {
@@ -60,12 +67,19 @@ import { Chrome } from "@/components/ui/chrome"
 import { Safari } from "@/components/ui/safari"
 import {
   ARC_BROWSER_FRAME_ID,
+  BROWSER_FRAME_PREVIEW_IMAGE_URL,
   BROWSER_FRAMES,
   CHROME_BROWSER_FRAME_ID,
   getBrowserFrame,
   isBrowserFrame,
 } from "@/lib/browser-frame"
 import { cn } from "@/lib/utils"
+import {
+  GLASS_FRAMES,
+  getGlassFrame,
+  isGlassFrame,
+  resolveGlassFrameColor,
+} from "@/lib/glass-frame"
 
 const POP_EASE: [number, number, number, number] = [0.16, 1, 0.3, 1]
 
@@ -93,7 +107,14 @@ function useLazyVisible(rootMargin = "200px") {
   return { ref, visible }
 }
 
-type FrameKind = "browser" | "phone" | "tablet" | "watch" | "desktop" | "none"
+type FrameKind =
+  | "glass"
+  | "browser"
+  | "phone"
+  | "tablet"
+  | "watch"
+  | "desktop"
+  | "none"
 type ImageFit = "contain" | "cover" | "fill"
 
 type FrameOption = {
@@ -141,6 +162,18 @@ const BROWSER_OPTIONS: FrameOption[] = BROWSER_FRAMES.map((frame) => ({
   isDevice: false,
 }))
 
+const GLASS_OPTIONS: FrameOption[] = GLASS_FRAMES.map((frame) => ({
+  id: frame.id,
+  name: frame.name,
+  w: frame.screen.width,
+  h: frame.screen.height,
+  kind: "glass",
+  colors: [...frame.colors],
+  previewSrc: null,
+  rotatePreview: false,
+  isDevice: false,
+}))
+
 const LANDSCAPE_THUMBNAIL_DEVICE_IDS = new Set([
   "ipad_air",
   "ipad_pro_11_m4",
@@ -152,6 +185,12 @@ const DEVICE_OPTIONS = DEVICE_MOCKUPS.map(deviceToOption).filter(
 )
 
 const SECTIONS: FrameSection[] = [
+  {
+    id: "glass",
+    label: "Glass",
+    icon: RiStackLine,
+    options: GLASS_OPTIONS,
+  },
   {
     id: "browser",
     label: "Browser",
@@ -241,6 +280,7 @@ export function FramePopover({
   value,
   onChange,
   previewImage,
+  previewFullPageCapture,
   imageFit = "cover",
   align = "start",
   disabled = false,
@@ -250,6 +290,7 @@ export function FramePopover({
   value: DeviceFrame
   onChange: (frame: DeviceFrame) => void
   previewImage?: string | null
+  previewFullPageCapture?: FullPageCapture | null
   imageFit?: ImageFit
   align?: "start" | "end"
   disabled?: boolean
@@ -259,14 +300,22 @@ export function FramePopover({
   const [open, setOpen] = React.useState(false)
   const [query, setQuery] = React.useState("")
   const screenshot = useActiveCanvasField((c) => c.screenshot)
+  const fullPageCapture = useActiveCanvasField((c) => c.fullPageCapture)
   const previewScreenshot =
     previewImage === undefined ? screenshot : previewImage
+  const previewCapture =
+    previewFullPageCapture === undefined
+      ? fullPageCapture
+      : previewFullPageCapture
+  const previewImageFit = fullPageCaptureObjectFit(previewCapture, imageFit)
+  const previewMediaStyle = fullPageCaptureMediaStyle(previewCapture)
 
   const current = ALL_OPTIONS.find((o) => o.id === value.id) ?? ALL_OPTIONS[0]
   const currentDevice = getDeviceMockup(current.id)
-  const effectiveOrientation = isBrowserFrame(current.id)
-    ? "horizontal"
-    : value.orientation
+  const effectiveOrientation =
+    isBrowserFrame(current.id) || isGlassFrame(current.id)
+      ? "horizontal"
+      : value.orientation
   const CurrentIcon =
     SECTIONS.find((s) => s.options.some((o) => o.id === current.id))?.icon ??
     RiSmartphoneLine
@@ -308,7 +357,10 @@ export function FramePopover({
       onChange({
         id: option.id,
         color: resolveFrameColor(option, device, value.color),
-        orientation: isBrowserFrame(option.id) ? "horizontal" : "vertical",
+        orientation:
+          isBrowserFrame(option.id) || isGlassFrame(option.id)
+            ? "horizontal"
+            : "vertical",
       })
     },
     [onChange, value.color]
@@ -435,7 +487,8 @@ export function FramePopover({
                     selectedColor={currentColor}
                     active={value.id === option.id}
                     screenshot={previewScreenshot}
-                    imageFit={imageFit}
+                    imageFit={previewImageFit}
+                    mediaStyle={previewMediaStyle}
                     compact={isCompactFrameSection(section.id)}
                     onSelect={selectFrame}
                   />
@@ -550,23 +603,33 @@ export function MobileFramePicker({
   value,
   onChange,
   previewImage,
+  previewFullPageCapture,
   imageFit = "cover",
 }: {
   value: DeviceFrame
   onChange: (frame: DeviceFrame) => void
   previewImage?: string | null
+  previewFullPageCapture?: FullPageCapture | null
   imageFit?: ImageFit
 }) {
   const [query, setQuery] = React.useState("")
   const screenshot = useActiveCanvasField((c) => c.screenshot)
+  const fullPageCapture = useActiveCanvasField((c) => c.fullPageCapture)
   const previewScreenshot =
     previewImage === undefined ? screenshot : previewImage
+  const previewCapture =
+    previewFullPageCapture === undefined
+      ? fullPageCapture
+      : previewFullPageCapture
+  const previewImageFit = fullPageCaptureObjectFit(previewCapture, imageFit)
+  const previewMediaStyle = fullPageCaptureMediaStyle(previewCapture)
 
   const current = ALL_OPTIONS.find((o) => o.id === value.id) ?? ALL_OPTIONS[0]
   const currentDevice = getDeviceMockup(current.id)
-  const effectiveOrientation = isBrowserFrame(current.id)
-    ? "horizontal"
-    : value.orientation
+  const effectiveOrientation =
+    isBrowserFrame(current.id) || isGlassFrame(current.id)
+      ? "horizontal"
+      : value.orientation
   const currentColor = resolveFrameColor(current, currentDevice, value.color)
   const [activeSectionId, setActiveSectionId] = React.useState(ALL_CATEGORY_ID)
 
@@ -605,7 +668,10 @@ export function MobileFramePicker({
       onChange({
         id: option.id,
         color: resolveFrameColor(option, device, value.color),
-        orientation: isBrowserFrame(option.id) ? "horizontal" : "vertical",
+        orientation:
+          isBrowserFrame(option.id) || isGlassFrame(option.id)
+            ? "horizontal"
+            : "vertical",
       })
     },
     [onChange, value.color]
@@ -659,7 +725,8 @@ export function MobileFramePicker({
                   selectedColor={currentColor}
                   active={value.id === option.id}
                   screenshot={previewScreenshot}
-                  imageFit={imageFit}
+                  imageFit={previewImageFit}
+                  mediaStyle={previewMediaStyle}
                   compact={isCompactFrameSection(section.id)}
                   onSelect={selectFrame}
                 />
@@ -840,6 +907,7 @@ const DeviceTile = React.memo(function DeviceTile({
   active,
   screenshot,
   imageFit,
+  mediaStyle,
   compact = false,
   onSelect,
 }: {
@@ -848,6 +916,7 @@ const DeviceTile = React.memo(function DeviceTile({
   active: boolean
   screenshot: string | null
   imageFit: ImageFit
+  mediaStyle?: React.CSSProperties
   compact?: boolean
   onSelect: (option: FrameOption) => void
 }) {
@@ -885,12 +954,21 @@ const DeviceTile = React.memo(function DeviceTile({
       >
         {!visible ? (
           <div className="h-full w-full rounded-md bg-secondary/30" />
+        ) : option.kind === "glass" ? (
+          <GlassTilePreview
+            frameId={option.id}
+            color={tileColor}
+            screenshot={screenshot}
+            imageFit={imageFit}
+            mediaStyle={mediaStyle}
+          />
         ) : option.kind === "browser" ? (
           <BrowserTilePreview
             frameId={option.id}
             color={tileColor}
             screenshot={screenshot}
             imageFit={imageFit}
+            mediaStyle={mediaStyle}
           />
         ) : preview && spec ? (
           <DeviceTilePreview
@@ -899,6 +977,7 @@ const DeviceTile = React.memo(function DeviceTile({
             rotatePreview={rotatePreview}
             screenshot={screenshot}
             imageFit={imageFit}
+            mediaStyle={mediaStyle}
           />
         ) : preview ? (
           <ShimmerImage
@@ -948,12 +1027,14 @@ const DeviceTilePreview = React.memo(function DeviceTilePreview({
   rotatePreview,
   screenshot,
   imageFit,
+  mediaStyle,
 }: {
   spec: ReturnType<typeof deviceMockupSpec>
   preview: string
   rotatePreview: boolean
   screenshot: string | null
   imageFit: ImageFit
+  mediaStyle?: React.CSSProperties
 }) {
   const screenRef = React.useRef<HTMLDivElement | null>(null)
   const [stageWidth, setStageWidth] = React.useState<number | undefined>(
@@ -1004,6 +1085,7 @@ const DeviceTilePreview = React.memo(function DeviceTilePreview({
                     "relative z-10 h-full w-full object-center",
                     imageFitClassName(imageFit)
                   )}
+                  style={mediaStyle}
                 />
                 <VideoIdlePoster src={screenshot} interactive={false} />
               </div>
@@ -1031,6 +1113,7 @@ const DeviceTilePreview = React.memo(function DeviceTilePreview({
                     "relative z-10 h-full w-full object-center",
                     imageFitClassName(imageFit)
                   )}
+                  style={mediaStyle}
                   loading="lazy"
                 />
               </>
@@ -1061,11 +1144,13 @@ const BrowserTilePreview = React.memo(function BrowserTilePreview({
   color,
   screenshot,
   imageFit,
+  mediaStyle,
 }: {
   frameId: string
   color: string
   screenshot: string | null
   imageFit: ImageFit
+  mediaStyle?: React.CSSProperties
 }) {
   const frame = getBrowserFrame(frameId)
   const scale = BROWSER_TILE_PREVIEW_WIDTH / BROWSER_TILE_PREVIEW_VIRTUAL_WIDTH
@@ -1096,6 +1181,7 @@ const BrowserTilePreview = React.memo(function BrowserTilePreview({
             imageSrc={imageSrc}
             videoSrc={videoSrc}
             imageFit={imageFit}
+            mediaStyle={mediaStyle}
             colorMode={color === "dark" ? "dark" : "light"}
             frameBorderRadius="5px"
             screenBorderRadius="4px"
@@ -1106,6 +1192,7 @@ const BrowserTilePreview = React.memo(function BrowserTilePreview({
             imageSrc={imageSrc}
             videoSrc={videoSrc}
             imageFit={imageFit}
+            mediaStyle={mediaStyle}
             colorMode={color === "dark" ? "dark" : "light"}
             url={screenshot && !isVideo ? frame?.defaultUrl : frame?.previewUrl}
             frameBorderRadius="5px"
@@ -1117,12 +1204,64 @@ const BrowserTilePreview = React.memo(function BrowserTilePreview({
             imageSrc={imageSrc}
             videoSrc={videoSrc}
             imageFit={imageFit}
+            mediaStyle={mediaStyle}
             colorMode={color === "dark" ? "dark" : "light"}
             url={screenshot && !isVideo ? frame?.defaultUrl : frame?.previewUrl}
             screenBorderRadius="0 0 4px 4px"
             className="block w-full"
           />
         )}
+      </div>
+    </div>
+  )
+})
+
+const GlassTilePreview = React.memo(function GlassTilePreview({
+  frameId,
+  color,
+  screenshot,
+  imageFit,
+  mediaStyle,
+}: {
+  frameId: string
+  color: string
+  screenshot: string | null
+  imageFit: ImageFit
+  mediaStyle?: React.CSSProperties
+}) {
+  const frame = getGlassFrame(frameId)
+  const scale = BROWSER_TILE_PREVIEW_WIDTH / BROWSER_TILE_PREVIEW_VIRTUAL_WIDTH
+  const isVideo = isVideoSrc(screenshot)
+  const imageSrc = isVideo
+    ? undefined
+    : (screenshot ?? BROWSER_FRAME_PREVIEW_IMAGE_URL)
+  const videoSrc = isVideo ? (screenshot ?? undefined) : undefined
+
+  return (
+    <div
+      className="relative overflow-visible drop-shadow-sm"
+      style={{
+        width: BROWSER_TILE_PREVIEW_WIDTH,
+        aspectRatio: frame?.aspectRatio,
+      }}
+    >
+      <div
+        className="absolute top-0 left-0"
+        style={{
+          width: BROWSER_TILE_PREVIEW_VIRTUAL_WIDTH,
+          transform: `scale(${scale})`,
+          transformOrigin: "top left",
+        }}
+      >
+        <GlassFrame
+          frameId={frameId}
+          colorMode={resolveGlassFrameColor(color)}
+          imageSrc={imageSrc}
+          videoSrc={videoSrc}
+          imageFit={imageFit}
+          mediaStyle={mediaStyle}
+          className="block w-full"
+        />
       </div>
     </div>
   )

--- a/components/editor/layers-popover.tsx
+++ b/components/editor/layers-popover.tsx
@@ -58,6 +58,7 @@ import {
 } from "@/lib/editor/store"
 import { getDeviceMockup } from "@/lib/mockups"
 import { BROWSER_FRAMES } from "@/lib/browser-frame"
+import { getGlassFrame } from "@/lib/glass-frame"
 import { cn } from "@/lib/utils"
 
 type EditableLayerType =
@@ -935,6 +936,7 @@ function FrameLockedLayer({
   onRemove: () => void
 }) {
   const browserFrame = BROWSER_FRAMES.find((f) => f.id === frame.id)
+  const glassFrame = getGlassFrame(frame.id)
   const deviceMockup = getDeviceMockup(frame.id)
 
   let name = "Frame"
@@ -943,6 +945,9 @@ function FrameLockedLayer({
   if (browserFrame) {
     name = browserFrame.name
     meta = "Browser frame · locked"
+  } else if (glassFrame) {
+    name = glassFrame.name
+    meta = "Glass frame · locked"
   } else if (deviceMockup) {
     name = deviceMockup.name
     meta = "Device frame · locked"
@@ -951,9 +956,11 @@ function FrameLockedLayer({
   // Get available colors for this frame
   const availableColors: string[] = browserFrame
     ? [...browserFrame.colors]
-    : deviceMockup
-      ? deviceMockup.colors
-      : []
+    : glassFrame
+      ? [...glassFrame.colors]
+      : deviceMockup
+        ? deviceMockup.colors
+        : []
 
   return (
     <div className="mt-1 rounded-md border border-border/60 bg-secondary/20 px-1.5 py-1.5">

--- a/components/editor/mobile-controls/index.tsx
+++ b/components/editor/mobile-controls/index.tsx
@@ -86,6 +86,7 @@ export function MobileControls({
   const activeCanvasId = useEditorStore((s) => s.present.activeCanvasId)
   const frame = useActiveCanvasField((c) => c.frame)
   const objectFit = useActiveCanvasField((c) => c.objectFit)
+  const fullPageCapture = useActiveCanvasField((c) => c.fullPageCapture)
   const screenshot = useActiveCanvasField((c) => c.screenshot)
   const tweet = useActiveCanvasField((c) => c.tweet)
   const screenshotSlots = useActiveCanvasField((c) => c.screenshotSlots)
@@ -755,6 +756,11 @@ export function MobileControls({
                 value={frame}
                 onChange={handleFrameChange}
                 previewImage={selectedSlot ? selectedSlot.src : undefined}
+                previewFullPageCapture={
+                  selectedSlot
+                    ? (selectedSlot.fullPageCapture ?? null)
+                    : fullPageCapture
+                }
                 imageFit={selectedSlot?.objectFit ?? objectFit ?? "cover"}
               />
             ) : null}

--- a/components/editor/screenshot-slot-element.tsx
+++ b/components/editor/screenshot-slot-element.tsx
@@ -41,7 +41,11 @@ import { slotBoxAspectRatio } from "@/lib/editor/screenshot-layout"
 import { resolveSlotScreenshotStyle } from "@/lib/editor/store/canvas-helpers"
 import { buildScreenshotImageStyle } from "@/lib/editor/screenshot-visual"
 import { slotMediaFxPreviewVar } from "@/lib/editor/css-utils"
-import { computeCropTarget, type CropTarget } from "@/lib/editor/crop-utils"
+import {
+  computeCropTarget,
+  resolveSlotCropFrame,
+  type CropTarget,
+} from "@/lib/editor/crop-utils"
 import { clipAffectsSlot, clipOwns } from "@/lib/editor/animation-playback"
 import {
   type AssetBlendMode,
@@ -648,7 +652,7 @@ export function ScreenshotSlotView({
 
   const requestCrop = React.useCallback(() => {
     const target = computeCropTarget({
-      frame: canvasFrame,
+      frame: resolveSlotCropFrame(slot.frame, canvasFrame),
       objectFit: slot.objectFit ?? "contain",
       stageElement: stageRef.current,
       imageElement: imageRef.current,
@@ -665,6 +669,7 @@ export function ScreenshotSlotView({
     imageRef,
     onCropRequest,
     slot.id,
+    slot.frame,
     slot.lastCropRegion,
     slot.objectFit,
     stageRef,

--- a/components/ui/glass-frame-styles.ts
+++ b/components/ui/glass-frame-styles.ts
@@ -20,11 +20,11 @@ export function glassScreenClipStyle(): CSSProperties {
  * curvature continuous through that join; browsers without it drop the
  * declaration and keep the circular arc.
  */
-export function glassCornerStyle(radiusCqw: number): CSSProperties {
+type GlassCornerStyle = CSSProperties & { cornerShape: string }
+
+export function glassCornerStyle(radiusCqw: number): GlassCornerStyle {
   return {
     borderRadius: `${radiusCqw}cqw`,
-    ...({
-      cornerShape: "var(--theme-corner-shape, superellipse(1.3))",
-    } as CSSProperties),
+    cornerShape: "var(--theme-corner-shape, superellipse(1.3))",
   }
 }

--- a/components/ui/glass-frame-styles.ts
+++ b/components/ui/glass-frame-styles.ts
@@ -12,3 +12,19 @@ export function glassScreenClipStyle(): CSSProperties {
     WebkitMaskImage: "-webkit-radial-gradient(white, black)",
   }
 }
+
+/**
+ * Corner geometry for every glass rect. A plain circular border-radius jumps
+ * from zero curvature to 1/r the instant the straight edge ends, which reads as
+ * a kink once the panel is exported at 4K and zoomed. `corner-shape` keeps the
+ * curvature continuous through that join; browsers without it drop the
+ * declaration and keep the circular arc.
+ */
+export function glassCornerStyle(radiusCqw: number): CSSProperties {
+  return {
+    borderRadius: `${radiusCqw}cqw`,
+    ...({
+      cornerShape: "var(--theme-corner-shape, superellipse(1.3))",
+    } as CSSProperties),
+  }
+}

--- a/components/ui/glass-frame-styles.ts
+++ b/components/ui/glass-frame-styles.ts
@@ -1,0 +1,14 @@
+import type { CSSProperties } from "react"
+
+export function glassBackdropStyle(value: string): CSSProperties {
+  return {
+    backdropFilter: value,
+    WebkitBackdropFilter: value,
+  }
+}
+
+export function glassScreenClipStyle(): CSSProperties {
+  return {
+    WebkitMaskImage: "-webkit-radial-gradient(white, black)",
+  }
+}

--- a/components/ui/glass-frame.tsx
+++ b/components/ui/glass-frame.tsx
@@ -11,6 +11,7 @@ import { useVideoPreload } from "@/components/editor/canvas/use-video-preload"
 import { assignMediaRef } from "@/components/ui/browser-frame-media"
 import {
   glassBackdropStyle,
+  glassCornerStyle,
   glassScreenClipStyle,
 } from "@/components/ui/glass-frame-styles"
 import { ShimmerImage } from "@/components/ui/shimmer-image"
@@ -20,6 +21,7 @@ import {
   type GlassFrameColor,
   type GlassFrameSpec,
 } from "@/lib/glass-frame"
+import { cn } from "@/lib/utils"
 
 type ImageFit = "contain" | "cover" | "fill"
 
@@ -97,7 +99,10 @@ export function GlassFrame({
 
   return (
     <div
-      className={`relative inline-block w-full overflow-visible align-middle leading-none ${className ?? ""}`}
+      className={cn(
+        "relative inline-block w-full overflow-visible align-middle leading-none",
+        className
+      )}
       style={{
         aspectRatio: frame.aspectRatio,
         containerType: "inline-size",
@@ -243,7 +248,7 @@ function rectStyle(
     top: `${(rect.y / height) * 100}%`,
     width: `${(rect.width / width) * 100}%`,
     height: `${(rect.height / height) * 100}%`,
-    borderRadius: `${(rect.radius / width) * 100}cqw`,
+    ...glassCornerStyle((rect.radius / width) * 100),
   }
 }
 

--- a/components/ui/glass-frame.tsx
+++ b/components/ui/glass-frame.tsx
@@ -1,0 +1,254 @@
+import {
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+  type Ref,
+  type SyntheticEvent,
+} from "react"
+
+import { VideoIdlePoster } from "@/components/editor/canvas/video-idle-poster"
+import { useVideoPreload } from "@/components/editor/canvas/use-video-preload"
+import { assignMediaRef } from "@/components/ui/browser-frame-media"
+import {
+  glassBackdropStyle,
+  glassScreenClipStyle,
+} from "@/components/ui/glass-frame-styles"
+import { ShimmerImage } from "@/components/ui/shimmer-image"
+import {
+  getGlassFrame,
+  resolveGlassFrameColor,
+  type GlassFrameColor,
+  type GlassFrameSpec,
+} from "@/lib/glass-frame"
+
+type ImageFit = "contain" | "cover" | "fill"
+
+export interface GlassFrameProps extends HTMLAttributes<HTMLDivElement> {
+  frameId: string
+  colorMode?: GlassFrameColor
+  imageSrc?: string
+  videoSrc?: string
+  children?: ReactNode
+  screenOverlay?: ReactNode
+  screenRef?: Ref<HTMLDivElement>
+  imageRef?: Ref<HTMLImageElement>
+  onImageLoad?: (event: SyntheticEvent<HTMLImageElement>) => void
+  onMediaElement?: (element: HTMLVideoElement | null) => void
+  mediaStyle?: CSSProperties
+  imageFit?: ImageFit
+  shimmer?: boolean
+}
+
+type GlassPalette = {
+  panelHighlight: string
+  panelShadow: string
+  layer: string
+  layerBorder: string
+  layerShadow: string
+  screenBackground: string
+}
+
+const DARK_GLASS: GlassPalette = {
+  panelHighlight: "rgba(255,255,255,0.32)",
+  panelShadow: "0 36px 80px rgba(2,6,14,0.42), 0 12px 28px rgba(2,6,14,0.28)",
+  layer:
+    "linear-gradient(145deg, rgba(255,255,255,0.13), rgba(18,25,38,0.52) 42%, rgba(4,8,15,0.78))",
+  layerBorder: "rgba(255,255,255,0.17)",
+  layerShadow: "0 24px 60px rgba(2,6,14,0.30)",
+  screenBackground: "#0a0c11",
+}
+
+const LIGHT_GLASS: GlassPalette = {
+  panelHighlight: "rgba(255,255,255,0.96)",
+  panelShadow:
+    "0 36px 80px rgba(25,35,55,0.20), 0 12px 28px rgba(25,35,55,0.13)",
+  layer:
+    "linear-gradient(145deg, rgba(255,255,255,0.74), rgba(228,235,245,0.48) 48%, rgba(196,208,225,0.54))",
+  layerBorder: "rgba(255,255,255,0.72)",
+  layerShadow: "0 24px 60px rgba(25,35,55,0.16)",
+  screenBackground: "#e8edf4",
+}
+
+export function GlassFrame({
+  frameId,
+  colorMode,
+  imageSrc,
+  videoSrc,
+  children,
+  screenOverlay,
+  screenRef,
+  imageRef,
+  onImageLoad,
+  onMediaElement,
+  mediaStyle,
+  imageFit = "cover",
+  shimmer = true,
+  className,
+  style,
+  ...props
+}: GlassFrameProps) {
+  const videoPreload = useVideoPreload()
+  const frame = getGlassFrame(frameId)
+  if (!frame) return null
+
+  const resolvedColor = resolveGlassFrameColor(colorMode ?? "dark")
+  const palette = resolvedColor === "light" ? LIGHT_GLASS : DARK_GLASS
+  const hasMedia = Boolean(videoSrc || imageSrc)
+
+  return (
+    <div
+      className={`relative inline-block w-full overflow-visible align-middle leading-none ${className ?? ""}`}
+      style={{
+        aspectRatio: frame.aspectRatio,
+        containerType: "inline-size",
+        isolation: "isolate",
+        transform: "translateZ(0)",
+        ...style,
+      }}
+      {...props}
+    >
+      {frame.layers.map((layer, index) => (
+        <div
+          key={`${frame.id}-layer-${index}`}
+          aria-hidden
+          data-glass-frame-layer="rear"
+          className="pointer-events-none absolute"
+          style={{
+            ...rectStyle(frame, layer),
+            zIndex: frame.layers.length - index,
+            background: palette.layer,
+            border: `1px solid ${palette.layerBorder}`,
+            boxShadow: palette.layerShadow,
+            ...glassBackdropStyle("blur(18px) saturate(135%)"),
+            transform: `translateZ(0) rotate(${layer.rotation ?? 0}deg)`,
+            transformOrigin: "center",
+          }}
+        />
+      ))}
+
+      <div
+        data-glass-frame-shell=""
+        data-glass-frame-layer="front"
+        className="absolute"
+        style={{
+          ...rectStyle(frame, frame.front),
+          zIndex: 10,
+          overflow: "hidden",
+          isolation: "isolate",
+          background: palette.layer,
+          boxShadow: palette.panelShadow,
+          ...glassBackdropStyle("blur(18px) saturate(135%)"),
+          transform: "translateZ(0)",
+        }}
+      >
+        <div
+          ref={screenRef}
+          data-glass-frame-screen=""
+          className="absolute overflow-hidden"
+          style={{
+            ...rectStyle(frame, frame.screen),
+            zIndex: 20,
+            isolation: "isolate",
+            backgroundColor: palette.screenBackground,
+            transform: "translateZ(0)",
+            ...glassScreenClipStyle(),
+          }}
+        >
+          {videoSrc ? (
+            <div className="relative size-full bg-black">
+              <video
+                ref={(node) => {
+                  assignMediaRef(
+                    imageRef,
+                    node as unknown as HTMLImageElement | null
+                  )
+                  onMediaElement?.(node)
+                }}
+                src={videoSrc}
+                muted
+                loop
+                playsInline
+                preload={videoPreload}
+                draggable={false}
+                className={`block size-full ${imageFitClassName(imageFit)}`}
+                style={mediaStyle}
+                onLoadedMetadata={(event) =>
+                  onImageLoad?.(
+                    event as unknown as SyntheticEvent<HTMLImageElement>
+                  )
+                }
+              />
+              <VideoIdlePoster src={videoSrc} />
+            </div>
+          ) : imageSrc ? (
+            <ShimmerImage
+              ref={imageRef}
+              shimmer={shimmer}
+              src={imageSrc}
+              alt=""
+              draggable={false}
+              onLoad={onImageLoad}
+              className={`block size-full ${imageFitClassName(imageFit)}`}
+              style={mediaStyle}
+            />
+          ) : (
+            children
+          )}
+
+          {screenOverlay}
+        </div>
+
+        <div
+          aria-hidden
+          data-export-frame-chrome=""
+          data-glass-frame-layer="chrome"
+          className="pointer-events-none absolute"
+          style={{
+            ...rectStyle(frame, frame.front),
+            zIndex: 30,
+            borderRadius: "inherit",
+            boxShadow: `inset 0 0 0 0.1cqw ${palette.panelHighlight}`,
+            background:
+              "linear-gradient(135deg, rgba(255,255,255,0.13), transparent 24%, transparent 72%, rgba(255,255,255,0.04))",
+            transform: "translateZ(0)",
+          }}
+        />
+
+        {!hasMedia && !children && !screenOverlay ? (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute opacity-60"
+            style={{
+              ...rectStyle(frame, frame.screen),
+              zIndex: 21,
+              backgroundImage:
+                "linear-gradient(rgba(255,255,255,0.055) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.055) 1px, transparent 1px)",
+              backgroundSize: "5cqw 5cqw",
+            }}
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function rectStyle(
+  frame: GlassFrameSpec,
+  rect: GlassFrameSpec["front"]
+): CSSProperties {
+  const { width, height } = frame.size
+  return {
+    boxSizing: "border-box",
+    left: `${(rect.x / width) * 100}%`,
+    top: `${(rect.y / height) * 100}%`,
+    width: `${(rect.width / width) * 100}%`,
+    height: `${(rect.height / height) * 100}%`,
+    borderRadius: `${(rect.radius / width) * 100}cqw`,
+  }
+}
+
+function imageFitClassName(imageFit: ImageFit) {
+  if (imageFit === "contain") return "object-contain object-center"
+  if (imageFit === "fill") return "object-fill"
+  return "object-cover object-center"
+}

--- a/lib/editor/crop-utils.ts
+++ b/lib/editor/crop-utils.ts
@@ -171,11 +171,14 @@ export type CropTarget = {
   initialRegion: CropRegion | null
 }
 
+/** Canvas media node. Frames stash `<video>` in the same ref as `<img>`. */
+type CropMediaElement = HTMLImageElement | HTMLVideoElement
+
 type CropTargetOptions = {
   frame: DeviceFrame
   objectFit?: "contain" | "cover" | "fill"
   stageElement?: HTMLElement | null
-  imageElement?: HTMLImageElement | null
+  imageElement?: CropMediaElement | null
   fallbackAspect?: number | null
 }
 
@@ -304,8 +307,7 @@ export function computeCropTarget({
 
   if (!aspect) return { aspect: null, initialRegion: null }
 
-  const naturalW = imageElement?.naturalWidth ?? 0
-  const naturalH = imageElement?.naturalHeight ?? 0
+  const { w: naturalW, h: naturalH } = mediaNaturalSize(imageElement)
   const coverPosition = cropCoverPositionForFrame(frame)
   const coverRegion =
     objectFit === "cover"
@@ -335,6 +337,14 @@ export function cropRegionMatchesAspect(
   const cropH = (region.height / 100) * naturalH
   if (!cropW || !cropH) return false
   return Math.abs(cropW / cropH - targetAspect) < 0.01
+}
+
+function mediaNaturalSize(element: CropMediaElement | null | undefined) {
+  if (!element) return { w: 0, h: 0 }
+  if (element instanceof HTMLVideoElement) {
+    return { w: element.videoWidth, h: element.videoHeight }
+  }
+  return { w: element.naturalWidth, h: element.naturalHeight }
 }
 
 function elementAspect(element: HTMLElement | null | undefined) {

--- a/lib/editor/crop-utils.ts
+++ b/lib/editor/crop-utils.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react"
 
 import { getBrowserFrame, isBrowserFrame } from "@/lib/browser-frame"
+import { glassFrameScreenAspect } from "@/lib/glass-frame"
 import { DEVICE_MOCKUP_SPECS, getDeviceMockup } from "@/lib/mockups"
 
 import type { CropRegion, DeviceFrame } from "./state-types"
@@ -264,6 +265,9 @@ export function cropAspectForFrameScreen(frame: DeviceFrame): number | null {
     return browserFrame.size.w / browserFrame.size.h
   }
 
+  const glassAspect = glassFrameScreenAspect(frame.id)
+  if (glassAspect) return glassAspect
+
   const spec = DEVICE_MOCKUP_SPECS[frame.id]
   if (!spec) return null
 
@@ -277,6 +281,13 @@ export function cropAspectForFrameScreen(frame: DeviceFrame): number | null {
     screenAspect < 1
 
   return rotatesPortraitAsset ? 1 / screenAspect : screenAspect
+}
+
+export function resolveSlotCropFrame(
+  slotFrame: DeviceFrame | undefined,
+  canvasFrame: DeviceFrame
+): DeviceFrame {
+  return slotFrame ?? canvasFrame
 }
 
 export function computeCropTarget({

--- a/lib/editor/frame-aspect-compatibility.ts
+++ b/lib/editor/frame-aspect-compatibility.ts
@@ -1,4 +1,5 @@
 import { getBrowserFrame, isBrowserFrame } from "@/lib/browser-frame"
+import { getGlassFrame } from "@/lib/glass-frame"
 import { DEVICE_MOCKUP_SPECS, getDeviceMockup } from "@/lib/mockups"
 import type { AspectState, DeviceFrame } from "./state-types"
 
@@ -68,6 +69,14 @@ function getFrameRatioInfo(frame: DeviceFrame) {
     return ratio && browserFrame
       ? { name: `${browserFrame.name} browser`, ratio }
       : null
+  }
+
+  const glassFrame = getGlassFrame(frame.id)
+  if (glassFrame) {
+    return {
+      name: glassFrame.name,
+      ratio: glassFrame.size.width / glassFrame.size.height,
+    }
   }
 
   const mockup = getDeviceMockup(frame.id)

--- a/lib/editor/screenshot-layout.ts
+++ b/lib/editor/screenshot-layout.ts
@@ -1,4 +1,5 @@
 import { isBrowserFrame } from "@/lib/browser-frame"
+import { getGlassFrame } from "@/lib/glass-frame"
 import { DEVICE_MOCKUP_SPECS } from "@/lib/mockups"
 
 import type { DeviceFrame } from "@/lib/editor/state-types"
@@ -15,6 +16,8 @@ const NONE_PORTRAIT_ASPECT = 10 / 14
 export function frameNaturalAspect(frame: DeviceFrame): number | null {
   if (frame.id === "none") return null
   if (isBrowserFrame(frame.id)) return BROWSER_FRAME_ASPECT
+  const glassFrame = getGlassFrame(frame.id)
+  if (glassFrame) return glassFrame.size.width / glassFrame.size.height
   const spec = DEVICE_MOCKUP_SPECS[frame.id]
   if (!spec) return null
   const [w, h] = spec.aspectRatio.split("/").map((part) => Number(part.trim()))

--- a/lib/glass-frame.ts
+++ b/lib/glass-frame.ts
@@ -1,0 +1,157 @@
+export const GLASS_CARD_FRAME_ID = "glass-card"
+export const GLASS_STACK_FRAME_ID = "glass-stack"
+export const GLASS_STACK_2_FRAME_ID = "glass-stack-2"
+
+export const GLASS_FRAME_COLORS = ["dark", "light"] as const
+
+export type GlassFrameColor = (typeof GLASS_FRAME_COLORS)[number]
+
+type GlassFrameRect = {
+  x: number
+  y: number
+  width: number
+  height: number
+  radius: number
+  rotation?: number
+}
+
+export type GlassFrameSpec = {
+  id: string
+  name: string
+  size: { width: number; height: number }
+  aspectRatio: string
+  screen: GlassFrameRect
+  front: GlassFrameRect
+  layers: GlassFrameRect[]
+  colors: readonly GlassFrameColor[]
+}
+
+const GLASS_FRAME_SIZE = { width: 1200, height: 750 } as const
+const SCREEN_INSET_X = 9
+const SCREEN_INSET_Y = SCREEN_INSET_X
+const SCREEN_WIDTH = GLASS_FRAME_SIZE.width - SCREEN_INSET_X * 2
+const SCREEN_HEIGHT = GLASS_FRAME_SIZE.height - SCREEN_INSET_Y * 2
+const FRONT_WIDTH = 1200
+const FRONT_HEIGHT = 750
+
+export const GLASS_FRAMES = [
+  {
+    id: GLASS_CARD_FRAME_ID,
+    name: "Glass Card",
+    size: GLASS_FRAME_SIZE,
+    aspectRatio: "1200 / 750",
+    front: {
+      x: 0,
+      y: 0,
+      width: FRONT_WIDTH,
+      height: FRONT_HEIGHT,
+      radius: 20,
+    },
+    screen: {
+      x: SCREEN_INSET_X,
+      y: SCREEN_INSET_Y,
+      width: SCREEN_WIDTH,
+      height: SCREEN_HEIGHT,
+      radius: 11,
+    },
+    layers: [],
+    colors: GLASS_FRAME_COLORS,
+  },
+  {
+    id: GLASS_STACK_FRAME_ID,
+    name: "Glass Cascade",
+    size: GLASS_FRAME_SIZE,
+    aspectRatio: "1200 / 750",
+    front: {
+      x: 0,
+      y: 0,
+      width: FRONT_WIDTH,
+      height: FRONT_HEIGHT,
+      radius: 20,
+    },
+    screen: {
+      x: SCREEN_INSET_X,
+      y: SCREEN_INSET_Y,
+      width: SCREEN_WIDTH,
+      height: SCREEN_HEIGHT,
+      radius: 11,
+    },
+    layers: [
+      {
+        x: 28,
+        y: 24,
+        width: 1144,
+        height: 750,
+        radius: 18,
+        rotation: -0.45,
+      },
+      {
+        x: 48,
+        y: 48,
+        width: 1104,
+        height: 750,
+        radius: 16,
+        rotation: 0.6,
+      },
+    ],
+    colors: GLASS_FRAME_COLORS,
+  },
+  {
+    id: GLASS_STACK_2_FRAME_ID,
+    name: "Glass Crown",
+    size: GLASS_FRAME_SIZE,
+    aspectRatio: "1200 / 750",
+    front: {
+      x: 0,
+      y: 0,
+      width: FRONT_WIDTH,
+      height: FRONT_HEIGHT,
+      radius: 20,
+    },
+    screen: {
+      x: SCREEN_INSET_X,
+      y: SCREEN_INSET_Y,
+      width: SCREEN_WIDTH,
+      height: SCREEN_HEIGHT,
+      radius: 11,
+    },
+    layers: [
+      {
+        x: 28,
+        y: -14,
+        width: 1144,
+        height: 730,
+        radius: 18,
+        rotation: 0.45,
+      },
+      {
+        x: 48,
+        y: -44,
+        width: 1104,
+        height: 700,
+        radius: 16,
+        rotation: -0.6,
+      },
+    ],
+    colors: GLASS_FRAME_COLORS,
+  },
+] as const satisfies readonly GlassFrameSpec[]
+
+export type GlassFrameId = (typeof GLASS_FRAMES)[number]["id"]
+
+export function getGlassFrame(id: string): GlassFrameSpec | null {
+  return GLASS_FRAMES.find((frame) => frame.id === id) ?? null
+}
+
+export function isGlassFrame(id: string): id is GlassFrameId {
+  return getGlassFrame(id) !== null
+}
+
+export function resolveGlassFrameColor(color: string): GlassFrameColor {
+  return color === "light" ? "light" : "dark"
+}
+
+export function glassFrameScreenAspect(frameId: string): number | null {
+  const frame = getGlassFrame(frameId)
+  return frame ? frame.screen.width / frame.screen.height : null
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokokino",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "private": false,
   "author": {

--- a/tests/components/editor/frame-popover.test.tsx
+++ b/tests/components/editor/frame-popover.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
@@ -8,6 +8,7 @@ vi.mock("@/lib/editor/store", () => ({
     selector({
       screenshot: "data:video/mp4;base64,AAAA",
       objectFit: "cover",
+      fullPageCapture: null,
     }),
 }))
 
@@ -59,6 +60,12 @@ describe("findFrameOptionName", () => {
   it("returns a name for a known frame id", () => {
     expect(typeof findFrameOptionName("none")).toBe("string")
   })
+
+  it("exposes each glass treatment to frame consumers", () => {
+    expect(findFrameOptionName("glass-card")).toBe("Glass Card")
+    expect(findFrameOptionName("glass-stack")).toBe("Glass Cascade")
+    expect(findFrameOptionName("glass-stack-2")).toBe("Glass Crown")
+  })
 })
 
 describe("MobileFramePicker", () => {
@@ -86,5 +93,26 @@ describe("MobileFramePicker", () => {
     const videos = container.querySelectorAll("video")
     expect(videos.length).toBeGreaterThan(0)
     expect(videos[0]?.getAttribute("src")).toBe("data:video/mp4;base64,AAAA")
+  })
+
+  it("shows a full-page capture at its canvas crop in frame tiles", async () => {
+    const { container } = render(
+      <MobileFramePicker
+        value={frame}
+        onChange={() => {}}
+        previewImage="full-page.png"
+        previewFullPageCapture={{ scrollPosition: 38 }}
+        imageFit="contain"
+      />
+    )
+
+    await waitFor(() => {
+      const preview = Array.from(container.querySelectorAll("img")).find(
+        (image) => image.getAttribute("src") === "full-page.png"
+      )
+      expect(preview).toBeTruthy()
+      expect(preview).toHaveClass("object-cover")
+      expect(preview).toHaveStyle({ objectPosition: "50% 38%" })
+    })
   })
 })

--- a/tests/components/editor/glass-frame.test.tsx
+++ b/tests/components/editor/glass-frame.test.tsx
@@ -8,6 +8,7 @@ vi.mock("@/lib/editor/store", () => ({
 import { GlassFrame } from "@/components/ui/glass-frame"
 import {
   glassBackdropStyle,
+  glassCornerStyle,
   glassScreenClipStyle,
 } from "@/components/ui/glass-frame-styles"
 
@@ -120,5 +121,40 @@ describe("GlassFrame", () => {
     expect(glassScreenClipStyle()).toEqual({
       WebkitMaskImage: "-webkit-radial-gradient(white, black)",
     })
+  })
+
+  it("gives every glass rect a continuous-curvature corner", () => {
+    expect(glassCornerStyle(1.6667)).toEqual({
+      borderRadius: "1.6667cqw",
+      cornerShape: "var(--theme-corner-shape, superellipse(1.3))",
+    })
+  })
+
+  it("keeps the screen corner concentric with the shell corner", () => {
+    const { container } = render(
+      <GlassFrame frameId="glass-card" colorMode="dark" imageSrc="shot.png" />
+    )
+
+    const shell = container.querySelector(
+      "[data-glass-frame-shell]"
+    ) as HTMLElement
+    const screen = container.querySelector(
+      "[data-glass-frame-screen]"
+    ) as HTMLElement
+
+    const shellRadius = parseFloat(shell.style.borderRadius)
+    const screenRadius = parseFloat(screen.style.borderRadius)
+    const inset = parseFloat(screen.style.left)
+
+    expect(shellRadius - screenRadius).toBeCloseTo(inset, 5)
+  })
+
+  it("merges className so later Tailwind utilities win", () => {
+    const { container } = render(
+      <GlassFrame frameId="glass-card" className="block w-full" />
+    )
+    const root = container.firstElementChild as HTMLElement
+    expect(root.className.split(" ")).toContain("block")
+    expect(root.className.split(" ")).not.toContain("inline-block")
   })
 })

--- a/tests/components/editor/glass-frame.test.tsx
+++ b/tests/components/editor/glass-frame.test.tsx
@@ -1,0 +1,124 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/editor/store", () => ({
+  useCanvasPreviewMode: () => false,
+}))
+
+import { GlassFrame } from "@/components/ui/glass-frame"
+import {
+  glassBackdropStyle,
+  glassScreenClipStyle,
+} from "@/components/ui/glass-frame-styles"
+
+describe("GlassFrame", () => {
+  it("renders image media inside the glass screen", () => {
+    const { container } = render(
+      <GlassFrame frameId="glass-card" colorMode="dark" imageSrc="shot.png" />
+    )
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe("shot.png")
+    expect(container.querySelector("[data-glass-frame-screen]")).toBeTruthy()
+  })
+
+  it("renders video media and keeps export chrome above it", () => {
+    const { container } = render(
+      <GlassFrame
+        frameId="glass-card"
+        colorMode="light"
+        videoSrc="data:video/mp4;base64,AAAA"
+      />
+    )
+
+    const video = container.querySelector("video")
+    expect(video?.getAttribute("src")).toBe("data:video/mp4;base64,AAAA")
+    expect(video?.getAttribute("preload")).toBe("metadata")
+    expect(container.querySelector("[data-export-frame-chrome]")).toBeTruthy()
+  })
+
+  it("renders two real DOM rear layers for each stack treatment", () => {
+    for (const frameId of ["glass-stack", "glass-stack-2"]) {
+      const { container, unmount } = render(
+        <GlassFrame frameId={frameId} colorMode="dark" imageSrc="shot.png" />
+      )
+
+      expect(
+        container.querySelectorAll('[data-glass-frame-layer="rear"]')
+      ).toHaveLength(2)
+      unmount()
+    }
+  })
+
+  it("uses the rear-card glass treatment for the front media rim", () => {
+    const { container } = render(
+      <GlassFrame frameId="glass-stack" colorMode="dark" imageSrc="shot.png" />
+    )
+
+    const rear = container.querySelector(
+      '[data-glass-frame-layer="rear"]'
+    ) as HTMLElement
+    const shell = container.querySelector(
+      "[data-glass-frame-shell]"
+    ) as HTMLElement
+    const screen = container.querySelector(
+      "[data-glass-frame-screen]"
+    ) as HTMLElement
+    const chrome = container.querySelector(
+      '[data-glass-frame-layer="chrome"]'
+    ) as HTMLElement
+
+    expect(shell.style.background).toBe(rear.style.background)
+    expect(shell.style.backdropFilter).toBe(rear.style.backdropFilter)
+    expect(parseFloat(screen.style.left)).toBeGreaterThan(0)
+    expect(parseFloat(screen.style.top)).toBeGreaterThan(0)
+    expect(parseFloat(screen.style.width)).toBeLessThan(100)
+    expect(parseFloat(screen.style.height)).toBeLessThan(100)
+    expect(chrome.style.borderWidth).toBe("")
+    expect(chrome.style.boxShadow).not.toContain("rgba(24,30,40,0.92)")
+    expect(chrome.style.boxShadow.match(/inset/g)).toHaveLength(1)
+  })
+
+  it("clips the screen and rim through one shared rounded shell", () => {
+    const { container } = render(
+      <GlassFrame frameId="glass-card" colorMode="dark" imageSrc="shot.png" />
+    )
+
+    const shell = container.querySelector(
+      "[data-glass-frame-shell]"
+    ) as HTMLElement
+    const screen = container.querySelector(
+      "[data-glass-frame-screen]"
+    ) as HTMLElement
+    const chrome = container.querySelector(
+      '[data-glass-frame-layer="chrome"]'
+    ) as HTMLElement
+
+    expect(shell).toBeTruthy()
+    expect(shell.contains(screen)).toBe(true)
+    expect(shell.contains(chrome)).toBe(true)
+    expect(shell.style.overflow).toBe("hidden")
+    expect(screen.style.borderRadius).not.toBe("inherit")
+    expect(chrome.style.borderRadius).toBe("inherit")
+  })
+
+  it("includes WebKit compositing and clipping fallbacks on glass layers", () => {
+    const { container } = render(
+      <GlassFrame frameId="glass-stack" colorMode="dark" imageSrc="shot.png" />
+    )
+
+    const root = container.firstElementChild as HTMLElement
+    const rear = container.querySelector(
+      '[data-glass-frame-layer="rear"]'
+    ) as HTMLElement
+    expect(root.style.isolation).toBe("isolate")
+    expect(root.style.transform).toBe("translateZ(0)")
+    expect(rear.style.backdropFilter).toBe("blur(18px) saturate(135%)")
+    expect(glassBackdropStyle("blur(18px) saturate(135%)")).toEqual({
+      backdropFilter: "blur(18px) saturate(135%)",
+      WebkitBackdropFilter: "blur(18px) saturate(135%)",
+    })
+    expect(glassScreenClipStyle()).toEqual({
+      WebkitMaskImage: "-webkit-radial-gradient(white, black)",
+    })
+  })
+})

--- a/tests/lib/editor/crop-utils.test.ts
+++ b/tests/lib/editor/crop-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   computeCoverCropRegion,
   computeCoverCropRegionForAspect,
+  computeCropTarget,
   CROP_ANIMATION_VARS,
   CROP_FIT_ORIGIN_VAR,
   CROP_FIT_SX_VAR,
@@ -21,6 +22,27 @@ import {
   supportsObjectViewBox,
   videoCropMediaStyle,
 } from "@/lib/editor/crop-utils"
+import type { DeviceFrame } from "@/lib/editor/state-types"
+
+const glassFrame: DeviceFrame = {
+  id: "glass-card",
+  color: "dark",
+  orientation: "horizontal",
+}
+
+function sizedImage(width: number, height: number) {
+  const img = document.createElement("img")
+  Object.defineProperty(img, "naturalWidth", { value: width })
+  Object.defineProperty(img, "naturalHeight", { value: height })
+  return img
+}
+
+function sizedVideo(width: number, height: number) {
+  const video = document.createElement("video")
+  Object.defineProperty(video, "videoWidth", { value: width })
+  Object.defineProperty(video, "videoHeight", { value: height })
+  return video
+}
 
 describe("crop utils", () => {
   it("computes side crops for wide images in narrow containers", () => {
@@ -167,5 +189,35 @@ describe("animated crop fit helpers", () => {
     ]) {
       expect(CROP_ANIMATION_VARS).toContain(name)
     }
+  })
+})
+
+describe("computeCropTarget", () => {
+  it("seeds cover-fit crop from a video's videoWidth, not naturalWidth", () => {
+    const video = sizedVideo(1920, 1080)
+    const fromVideo = computeCropTarget({
+      frame: glassFrame,
+      objectFit: "cover",
+      imageElement: video,
+    })
+    const fromImage = computeCropTarget({
+      frame: glassFrame,
+      objectFit: "cover",
+      imageElement: sizedImage(1920, 1080),
+    })
+
+    expect(fromVideo.initialRegion).not.toBeNull()
+    expect(fromVideo.initialRegion).toEqual(fromImage.initialRegion)
+  })
+
+  it("returns no initial region when a cover-fit video has no intrinsic size yet", () => {
+    const target = computeCropTarget({
+      frame: glassFrame,
+      objectFit: "cover",
+      imageElement: document.createElement("video"),
+    })
+
+    expect(target.aspect).not.toBeNull()
+    expect(target.initialRegion).toBeNull()
   })
 })

--- a/tests/lib/editor/slot-crop-frame.test.ts
+++ b/tests/lib/editor/slot-crop-frame.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  cropAspectForFrameScreen,
+  resolveSlotCropFrame,
+} from "@/lib/editor/crop-utils"
+import { glassFrameScreenAspect } from "@/lib/glass-frame"
+import type { DeviceFrame } from "@/lib/editor/state-types"
+
+const canvasFrame: DeviceFrame = {
+  id: "none",
+  color: "black",
+  orientation: "horizontal",
+}
+
+const glassFrame: DeviceFrame = {
+  id: "glass-card",
+  color: "dark",
+  orientation: "horizontal",
+}
+
+describe("resolveSlotCropFrame", () => {
+  it("uses a slot frame override for crop geometry", () => {
+    const frame = resolveSlotCropFrame(glassFrame, canvasFrame)
+
+    expect(frame).toBe(glassFrame)
+    expect(cropAspectForFrameScreen(frame)).toBeCloseTo(
+      glassFrameScreenAspect(glassFrame.id)!,
+      6
+    )
+  })
+
+  it("falls back to the canvas frame when the slot inherits it", () => {
+    expect(resolveSlotCropFrame(undefined, canvasFrame)).toBe(canvasFrame)
+  })
+})

--- a/tests/lib/glass-frame.test.ts
+++ b/tests/lib/glass-frame.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  GLASS_CARD_FRAME_ID,
+  GLASS_FRAMES,
+  GLASS_STACK_2_FRAME_ID,
+  GLASS_STACK_FRAME_ID,
+  getGlassFrame,
+  glassFrameScreenAspect,
+  resolveGlassFrameColor,
+} from "@/lib/glass-frame"
+import { cropAspectForFrameScreen } from "@/lib/editor/crop-utils"
+import { frameNaturalAspect } from "@/lib/editor/screenshot-layout"
+
+const frameValue = (id: string) => ({
+  id,
+  color: "dark",
+  orientation: "horizontal" as const,
+})
+
+describe("glass frame registry", () => {
+  it("registers the three selectable glass treatments", () => {
+    expect(GLASS_FRAMES.map(({ id, name }) => ({ id, name }))).toEqual([
+      { id: "glass-card", name: "Glass Card" },
+      { id: "glass-stack", name: "Glass Cascade" },
+      { id: "glass-stack-2", name: "Glass Crown" },
+    ])
+  })
+
+  it("normalizes saved colors to supported dark and light variants", () => {
+    expect(resolveGlassFrameColor("light")).toBe("light")
+    expect(resolveGlassFrameColor("dark")).toBe("dark")
+    expect(resolveGlassFrameColor("legacy-color")).toBe("dark")
+  })
+
+  it("returns null for unknown frame ids instead of treating them as glass", () => {
+    expect(getGlassFrame("glass-missing")).toBeNull()
+  })
+})
+
+describe("glass frame geometry", () => {
+  it("uses one equal-width rim on every side of the media opening", () => {
+    for (const frame of GLASS_FRAMES) {
+      const outerAspect = frame.size.width / frame.size.height
+      const frontWidthCoverage = frame.front.width / frame.size.width
+      const screenWidthCoverage = frame.screen.width / frame.size.width
+
+      expect(outerAspect, frame.id).toBeCloseTo(16 / 10, 6)
+      expect(frontWidthCoverage, frame.id).toBe(1)
+      expect(frame.screen.x, frame.id).toBeGreaterThan(0)
+      expect(frame.screen.y, frame.id).toBe(frame.screen.x)
+      expect(frame.screen.x * 2 + frame.screen.width, frame.id).toBe(
+        frame.size.width
+      )
+      expect(frame.screen.y * 2 + frame.screen.height, frame.id).toBe(
+        frame.size.height
+      )
+      expect(screenWidthCoverage, frame.id).toBeGreaterThanOrEqual(0.98)
+      expect(screenWidthCoverage, frame.id).toBeLessThan(1)
+      expect(frame.front.radius, frame.id).toBeLessThanOrEqual(20)
+      expect(frame.screen.radius, frame.id).toBe(
+        frame.front.radius - frame.screen.x
+      )
+    }
+  })
+
+  it("crops to the actual inner opening while layout uses the outer ratio", () => {
+    for (const frame of GLASS_FRAMES) {
+      const screenAspect = frame.screen.width / frame.screen.height
+
+      expect(glassFrameScreenAspect(frame.id)).toBeCloseTo(screenAspect, 6)
+      expect(cropAspectForFrameScreen(frameValue(frame.id))).toBeCloseTo(
+        screenAspect,
+        6
+      )
+      expect(frameNaturalAspect(frameValue(frame.id))).toBeCloseTo(16 / 10, 6)
+    }
+  })
+
+  it("places Stack behind the lower edge and Stack 2 behind the upper edge", () => {
+    const card = getGlassFrame(GLASS_CARD_FRAME_ID)
+    const stack = getGlassFrame(GLASS_STACK_FRAME_ID)
+    const stack2 = getGlassFrame(GLASS_STACK_2_FRAME_ID)
+
+    expect(card?.layers).toHaveLength(0)
+    expect(stack?.layers).toHaveLength(2)
+    expect(stack?.layers.every((layer) => layer.y > stack.front.y)).toBe(true)
+    const cascadeExposure = stack?.layers.map(
+      (layer) => layer.y + layer.height - stack.size.height
+    )
+    expect(cascadeExposure?.[0]).toBeGreaterThanOrEqual(20)
+    expect(cascadeExposure?.[1]).toBeGreaterThanOrEqual(40)
+    expect(stack2?.layers).toHaveLength(2)
+    expect(stack2?.layers.every((layer) => layer.y < stack2.front.y)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Adds three polished glass frame treatments for screenshots and videos: Glass Card, Glass Cascade, and Glass Crown. The frames support dark/light variants, single and multi-slot canvases, full-page preview thumbnails, crop-aware geometry, still/motion export, and Safari/WebKit fallbacks.

## Type of Change

- [ ] fix
- [ ] refactor
- [ ] delete
- [ ] optimised
- [x] docs
- [x] feature

## Related Issues

None.

## Changes Made

- Added a reusable CSS-native glass frame renderer and registry.
- Added Glass Card, Glass Cascade, and Glass Crown to desktop and mobile frame pickers.
- Supported dark/light glass, stacked rear panes, equal-width front rims, and WebKit compositing/clipping fallbacks.
- Integrated glass frames with the main canvas, extra screenshot slots, layers, edit menus, crop geometry, and export rendering.
- Fixed full-page frame-picker previews and slot-level crop overrides.
- Added focused registry, renderer, picker, and crop regression coverage.
- Added the 2.2.0 Glass frames changelog entry.

## Screenshots / Recordings (if UI)

Validated against the supplied canvas and frame-picker screenshots during implementation.

## Checklist

- [x] I ran `pnpm lint` (staged files via the commit hook)
- [x] I ran `pnpm typecheck`
- [x] I ran `pnpm test` (172 files, 1,382 tests)
- [x] I did not include secrets or sensitive data
- [x] I updated docs when behavior changed
- [x] I kept this PR focused and reasonably small

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added three glass frame styles with dark and light variants.
  - Added glass frame selection, previews, editable media, uploads, captures, and demo states.
  - Added support for image and video content, including full-page capture cropping.
  - Improved glass frame geometry, lighting, corner styling, and browser-compatible exports.
  - Updated the changelog for version 2.2.0, “Glass frames.”

- **Bug Fixes**
  - Corrected frame-specific crop sizing and video crop initialization.
  - Preserved accurate layout and aspect ratios across glass, browser, and device frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three reusable glass-frame treatments and integrates them across canvas rendering, frame selection, multi-slot editing, cropping, and export.
- Adds shared glass-frame specifications, rendering, styling, and dark/light variants.
- Extends desktop and mobile frame pickers with full-page-aware previews.
- Updates crop geometry to support slot-level frames and video intrinsic dimensions.
- Adds focused renderer, registry, picker, and crop regression tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/ui/glass-frame.tsx | Implements the reusable image/video glass renderer and now exposes video elements to crop calculations through the shared media ref. |
| components/editor/canvas/screenshot-glass-frame.tsx | Integrates glass rendering with canvas interaction, editing actions, empty states, media registration, and export-oriented overlays. |
| lib/editor/crop-utils.ts | Adds glass-screen crop geometry, slot-frame resolution, and intrinsic video-dimension handling that addresses the prior crop issue. |
| components/editor/frame-popover.tsx | Adds glass options and full-page-aware media previews to desktop and mobile frame pickers. |
| lib/glass-frame.ts | Defines the registry and geometry for Glass Card, Glass Cascade, and Glass Crown. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20shivabhattacharjee%2Ftokokino%20PR%20%2358%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=shivabhattacharjee%2Ftokokino&pr=58&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (2): Last reviewed commit: ["chore: update version to 2.2.0 and enhan..."](https://github.com/shivabhattacharjee/tokokino/commit/b83cebc442122c227911fc6fa0f2cddf24228894) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52907955)</sub>

<!-- /greptile_comment -->