### PR TITLE
feat(backdrop): ASCII textures for the canvas background

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -51,6 +51,10 @@ const releases: Release[] = [
         text: "A resolution slider takes the grid from 20 to 200 columns, ink can sample the background's own colours or use one of your choosing, and the ramp can be inverted so bright areas read sparse.",
       },
       {
+        title: "Animate the ASCII",
+        text: "ASCII is a keyframable effect in Animate mode: crossfade between character sets, resolutions and colours, dissolve it on or off, and it re-renders when a keyframe swaps the background beneath it.",
+      },
+      {
         title: "Sharp at 8K",
         text: "The characters are real text rather than a rasterized layer, so ASCII backdrops stay crisp in every still and motion export, at any resolution.",
       },

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -38,10 +38,22 @@ const releases: Release[] = [
     id: "v2-2-0",
     version: "2.2.0",
     date: "August 13, 2026",
-    title: "Glass frames",
+    title: "Glass frames & ASCII backdrops",
     summary:
-      "Give screenshots and videos a polished glass treatment with a single card or layered stacks — designed to stay consistent from the live canvas through high-resolution export.",
+      "Give screenshots and videos a polished glass treatment with a single card or layered stacks — designed to stay consistent from the live canvas through high-resolution export. Plus a new ASCII texture that redraws your background in characters.",
     changes: [
+      {
+        title: "ASCII backdrops",
+        text: "Turn any background — gradient, solid, or image — into ASCII art from the Texture control in Backdrop. Seven character sets, from a classic ramp to blocks, binary, dots, circles and stars.",
+      },
+      {
+        title: "Tune the ASCII look",
+        text: "A resolution slider takes the grid from 20 to 200 columns, ink can sample the background's own colours or use one of your choosing, and the ramp can be inverted so bright areas read sparse.",
+      },
+      {
+        title: "Sharp at 8K",
+        text: "The characters are real text rather than a rasterized layer, so ASCII backdrops stay crisp in every still and motion export, at any resolution.",
+      },
       {
         title: "Three new glass frames",
         text: "Choose Glass Card for a clean single pane, Glass Cascade for layers beneath the canvas, or Glass Crown for layers rising behind it.",

--- a/components/editor/animate/timeline-clip.tsx
+++ b/components/editor/animate/timeline-clip.tsx
@@ -111,6 +111,7 @@ const ICON_FOR: Record<ClipIconKey, typeof RiDragMove2Line> = {
   filter: RiSunLine,
   portrait: RiSunLine,
   pattern: RiSunLine,
+  ascii: RiSunLine,
   overlay: RiSunLine,
   // The media grade has its own Effects / Filters controls — share their icons.
   mediaEffects: RiEqualizerLine,

--- a/components/editor/canvas/ascii-backdrop.tsx
+++ b/components/editor/canvas/ascii-backdrop.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  ASCII_FONT_FAMILY,
+  ASCII_MAX_RESOLUTION,
+  ASCII_MIN_RESOLUTION,
+  asciiPlateColor,
+  asciiRowCount,
+  gridFromImageData,
+  monospaceAdvanceRatio,
+  sampleBackgroundPixels,
+  type AsciiGrid,
+} from "@/lib/editor/ascii-backdrop"
+import type { BackdropAscii, Background } from "@/lib/editor/state-types"
+import { clampNumber } from "@/lib/editor/value-schemas"
+
+type Segment = { text: string; color: string }
+
+/**
+ * Merge neighbouring cells that quantized to the same colour so a coloured grid
+ * renders as a few hundred spans instead of one per character.
+ */
+function rowSegments(grid: AsciiGrid, row: number): Segment[] {
+  const segments: Segment[] = []
+  const start = row * grid.cols
+  for (let i = 0; i < grid.cols; i++) {
+    const color = grid.colors[start + i]
+    const char = grid.chars[start + i]
+    const last = segments[segments.length - 1]
+    if (last && last.color === color) last.text += char
+    else segments.push({ text: char, color })
+  }
+  return segments
+}
+
+/**
+ * Renders the canvas background as ASCII characters.
+ *
+ * The glyphs are real DOM text rather than a `<canvas>` because export
+ * rasterizes the DOM at up to 8K — a canvas would be captured at its own
+ * (screen-sized) resolution and upscaled into mush, while text re-renders sharp
+ * at any pixel ratio.
+ */
+function AsciiBackdropImpl({
+  background,
+  ascii,
+  filter,
+}: {
+  background: Background
+  ascii: BackdropAscii
+  filter?: string
+}) {
+  const hostRef = React.useRef<HTMLDivElement>(null)
+  const [size, setSize] = React.useState({ width: 0, height: 0 })
+  const [pixels, setPixels] = React.useState<Uint8ClampedArray | null>(null)
+
+  React.useEffect(() => {
+    const node = hostRef.current
+    if (!node || typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver(([entry]) => {
+      const box = entry.contentRect
+      setSize((prev) =>
+        prev.width === box.width && prev.height === box.height
+          ? prev
+          : { width: box.width, height: box.height }
+      )
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  const cols = Math.round(
+    clampNumber(ascii.resolution, ASCII_MIN_RESOLUTION, ASCII_MAX_RESOLUTION) ??
+      ASCII_MIN_RESOLUTION
+  )
+  // Rows follow the canvas aspect only, so zooming the editor viewport rescales
+  // the glyphs without resampling the background.
+  const rows = asciiRowCount(cols, size.width, size.height)
+
+  React.useEffect(() => {
+    if (rows < 1) return
+    let cancelled = false
+    sampleBackgroundPixels(background, cols, rows)
+      .then((data) => {
+        if (!cancelled) setPixels(data)
+      })
+      .catch(() => {
+        if (!cancelled) setPixels(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [background, cols, rows])
+
+  const grid = React.useMemo(() => {
+    if (!pixels || rows < 1 || pixels.length < cols * rows * 4) return null
+    return gridFromImageData(pixels, cols, rows, {
+      charset: ascii.charset,
+      inverted: ascii.inverted,
+      colored: ascii.colored,
+    })
+  }, [ascii.charset, ascii.colored, ascii.inverted, cols, pixels, rows])
+
+  const plate = React.useMemo(() => {
+    if (!pixels || rows < 1 || pixels.length < cols * rows * 4) return undefined
+    return asciiPlateColor(pixels, cols * rows)
+  }, [cols, pixels, rows])
+
+  const cellWidth = size.width / cols
+  const cellHeight = rows > 0 ? size.height / rows : 0
+  // Size the font from the cell width so one glyph advance is exactly one cell;
+  // the line box then stretches to the cell height to fill the canvas.
+  const fontSize = cellWidth / monospaceAdvanceRatio()
+
+  return (
+    <div
+      ref={hostRef}
+      aria-hidden
+      className="pointer-events-none absolute inset-0 overflow-hidden"
+      style={{ background: plate, filter }}
+    >
+      {grid ? (
+        <div
+          style={{
+            fontFamily: ASCII_FONT_FAMILY,
+            fontSize: `${fontSize}px`,
+            lineHeight: `${cellHeight}px`,
+            whiteSpace: "pre",
+            fontVariantLigatures: "none",
+            color: ascii.colored ? undefined : ascii.color,
+          }}
+        >
+          {Array.from({ length: grid.rows }, (_, row) => (
+            <div key={row} style={{ height: `${cellHeight}px` }}>
+              {ascii.colored
+                ? rowSegments(grid, row).map((segment, i) => (
+                    <span key={i} style={{ color: segment.color }}>
+                      {segment.text}
+                    </span>
+                  ))
+                : grid.chars.slice(row * grid.cols, (row + 1) * grid.cols)}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export const AsciiBackdrop = React.memo(AsciiBackdropImpl)

--- a/components/editor/canvas/ascii-backdrop.tsx
+++ b/components/editor/canvas/ascii-backdrop.tsx
@@ -4,17 +4,14 @@ import * as React from "react"
 
 import {
   ASCII_FONT_FAMILY,
-  ASCII_MAX_RESOLUTION,
-  ASCII_MIN_RESOLUTION,
+  asciiGridSize,
   asciiPlateColor,
-  asciiRowCount,
   gridFromImageData,
   monospaceAdvanceRatio,
   sampleBackgroundPixels,
   type AsciiGrid,
 } from "@/lib/editor/ascii-backdrop"
 import type { BackdropAscii, Background } from "@/lib/editor/state-types"
-import { clampNumber } from "@/lib/editor/value-schemas"
 
 type Segment = { text: string; color: string }
 
@@ -78,13 +75,14 @@ function AsciiBackdropImpl({
     return () => observer.disconnect()
   }, [])
 
-  const cols = Math.round(
-    clampNumber(ascii.resolution, ASCII_MIN_RESOLUTION, ASCII_MAX_RESOLUTION) ??
-      ASCII_MIN_RESOLUTION
-  )
   // Rows follow the canvas aspect only, so zooming the editor viewport rescales
-  // the glyphs without resampling the background.
-  const rows = asciiRowCount(cols, size.width, size.height)
+  // the glyphs without resampling the background. The budget only bites on very
+  // tall canvases, where the row count would otherwise multiply out of hand.
+  const { cols, rows } = asciiGridSize(
+    ascii.resolution,
+    size.width,
+    size.height
+  )
 
   React.useEffect(() => {
     if (rows < 1) return

--- a/components/editor/canvas/ascii-backdrop.tsx
+++ b/components/editor/canvas/ascii-backdrop.tsx
@@ -47,10 +47,17 @@ function AsciiBackdropImpl({
   background,
   ascii,
   filter,
+  opacity,
 }: {
   background: Background
   ascii: BackdropAscii
   filter?: string
+  /**
+   * Animate mode: the layer's crossfade opacity, as a `var(…, <rest>)` string.
+   * Plain opacity on a plain element — no blend modes or backdrop-filter — so
+   * the transition composites identically on WebKit.
+   */
+  opacity?: string
 }) {
   const hostRef = React.useRef<HTMLDivElement>(null)
   const [size, setSize] = React.useState({ width: 0, height: 0 })
@@ -119,7 +126,11 @@ function AsciiBackdropImpl({
       ref={hostRef}
       aria-hidden
       className="pointer-events-none absolute inset-0 overflow-hidden"
-      style={{ background: plate, filter }}
+      style={{
+        background: plate,
+        filter,
+        opacity: opacity as React.CSSProperties["opacity"],
+      }}
     >
       {grid ? (
         <div

--- a/components/editor/canvas/canvas-backdrop.tsx
+++ b/components/editor/canvas/canvas-backdrop.tsx
@@ -231,21 +231,22 @@ function CanvasBackdropImpl({
         })
       : null
 
-  // Combine the backdrop-effects filter with a given asset filter preset into one
-  // CSS `filter`. The layer always reads `--bd-fx-preview`, even when the
-  // committed effects are neutral: slider drags and the animation player both
-  // drive that var, and a layer with no `filter` at all has nothing to drive.
-  // The neutral fallback is `brightness(1)` rather than `none` because `none`
-  // cannot sit next to a filter function when an asset filter is also applied.
-  const filterCssFor = React.useCallback(
-    (assetFilterId: AssetFilter): string => {
-      const fxPart = `var(--bd-fx-preview, ${effectsFilter ?? "brightness(1)"})`
-      const af = assetFilterCss(assetFilterId)
-      return af ? `${fxPart} ${af}` : fxPart
-    },
-    [effectsFilter]
+  // The backdrop colour grade, applied ONCE to the whole composed group (see
+  // the wrapper below) rather than per layer. It always reads `--bd-fx-preview`,
+  // even when the committed effects are neutral: slider drags and the animation
+  // player both drive that var, and an element with no `filter` at all has
+  // nothing to drive. The neutral fallback is `brightness(1)` rather than `none`
+  // because `none` cannot sit next to another filter function.
+  const gradeFilter = `var(--bd-fx-preview, ${effectsFilter ?? "brightness(1)"})`
+  // The per-layer half: each keyframe layer carries its own preset, which is
+  // how a filter animation chains. Undefined for "none" so a layer that needs
+  // no filter doesn't pay for a stacking context.
+  const presetFilter = React.useCallback(
+    (assetFilterId: AssetFilter): string | undefined =>
+      assetFilterCss(assetFilterId) || undefined,
+    []
   )
-  const filterValue = filterCssFor(backdrop.filter ?? "none")
+  const committedPresetFilter = presetFilter(backdrop.filter ?? "none")
 
   const ascii = React.useMemo(
     () => resolveBackdropAscii(backdrop.ascii),
@@ -278,6 +279,8 @@ function CanvasBackdropImpl({
     return {
       ascii: asciiStackBase.base,
       background: resolveEffectiveBackground(asciiStackBase.baseBackground),
+      filter: asciiStackBase.baseFilter,
+      restOpaque: asciiStackBase.baseRestOpaque,
     }
   }, [asciiStackBase, resolveEffectiveBackground])
 
@@ -372,168 +375,187 @@ function CanvasBackdropImpl({
         className="absolute inset-0"
         style={{ isolation: "isolate" }}
       >
-        {hasFilterStack ? (
-          // Animate mode with animated filter(s): the committed background is
-          // rendered once per FILTER keyframe (chronological, bottom → top) over
-          // a base (the filter before the first keyframe). AnimationLayer fades
-          // each layer in at its keyframe so multiple filter changes chain, each
-          // cross-fading over the one beneath — the mirror of the bg stack. At
-          // rest each layer falls back to its rest opacity so the selected
-          // keyframe's filter shows.
-          <>
-            <div
-              aria-hidden
-              className={cn(
-                "absolute inset-0",
-                effectiveBackground.type === "none" && "bg-transparency-checker"
-              )}
-              data-bg-source-url={
-                effectiveBackground.type === "image" &&
-                effectiveBackground.sourceUrl &&
-                effectiveBackground.sourceUrl !== effectiveBackground.value
-                  ? effectiveBackground.sourceUrl
-                  : undefined
-              }
-              style={{
-                ...backgroundCss(effectiveBackground),
-                filter: filterCssFor(filterStackBase),
-              }}
-            />
-            {filterLayers.map((layer) => {
-              const layerFilter = filterCssFor(layer.filter)
-              return (
+        {/*
+          The colour grade (and its `opacity()` leg) applies ONCE, here, to the
+          composed background-plus-ASCII result. Filtering both the background
+          and the ASCII layer that covers it compounded them — 50% opacity
+          rendered as ~75%. Per-keyframe filter PRESETS stay on the individual
+          layers, which is how a filter animation chains.
+        */}
+        <div
+          aria-hidden
+          data-backdrop-grade="true"
+          className="absolute inset-0"
+          style={{ filter: gradeFilter }}
+        >
+          {hasFilterStack ? (
+            // Animate mode with animated filter(s): the committed background is
+            // rendered once per FILTER keyframe (chronological, bottom → top) over
+            // a base (the filter before the first keyframe). AnimationLayer fades
+            // each layer in at its keyframe so multiple filter changes chain, each
+            // cross-fading over the one beneath — the mirror of the bg stack. At
+            // rest each layer falls back to its rest opacity so the selected
+            // keyframe's filter shows.
+            <>
+              <div
+                aria-hidden
+                className={cn(
+                  "absolute inset-0",
+                  effectiveBackground.type === "none" &&
+                    "bg-transparency-checker"
+                )}
+                data-bg-source-url={
+                  effectiveBackground.type === "image" &&
+                  effectiveBackground.sourceUrl &&
+                  effectiveBackground.sourceUrl !== effectiveBackground.value
+                    ? effectiveBackground.sourceUrl
+                    : undefined
+                }
+                style={{
+                  ...backgroundCss(effectiveBackground),
+                  filter: presetFilter(filterStackBase),
+                }}
+              />
+              {filterLayers.map((layer) => {
+                const layerFilter = presetFilter(layer.filter)
+                return (
+                  <div
+                    key={layer.id}
+                    aria-hidden
+                    className={cn(
+                      "absolute inset-0",
+                      effectiveBackground.type === "none" &&
+                        "bg-transparency-checker"
+                    )}
+                    data-bg-source-url={
+                      effectiveBackground.type === "image" &&
+                      effectiveBackground.sourceUrl &&
+                      effectiveBackground.sourceUrl !==
+                        effectiveBackground.value
+                        ? effectiveBackground.sourceUrl
+                        : undefined
+                    }
+                    style={{
+                      ...backgroundCss(effectiveBackground),
+                      filter: layerFilter,
+                      opacity: `var(${filterLayerOpacityVar(layer.id)}, ${
+                        layer.restOpaque ? 1 : 0
+                      })` as unknown as number,
+                    }}
+                  />
+                )
+              })}
+            </>
+          ) : hasBgStack ? (
+            // Animate mode with animated background(s): a stack of layers, one per
+            // background keyframe (chronological, bottom → top), over an optional
+            // base (the background before the first keyframe). AnimationLayer fades
+            // each layer in at its keyframe so multiple swaps chain, each
+            // cross-fading over the one beneath. At rest each layer falls back to
+            // its rest opacity so the selected keyframe's background shows.
+            <>
+              {effectiveBgBase ? (
+                <div
+                  aria-hidden
+                  className={cn(
+                    "absolute inset-0",
+                    effectiveBgBase.type === "none" && "bg-transparency-checker"
+                  )}
+                  data-bg-source-url={
+                    effectiveBgBase.type === "image" &&
+                    effectiveBgBase.sourceUrl &&
+                    effectiveBgBase.sourceUrl !== effectiveBgBase.value
+                      ? effectiveBgBase.sourceUrl
+                      : undefined
+                  }
+                  style={{
+                    ...backgroundCss(effectiveBgBase),
+                    filter: committedPresetFilter,
+                  }}
+                />
+              ) : null}
+              {effectiveBgLayers.map((layer) => (
                 <div
                   key={layer.id}
                   aria-hidden
                   className={cn(
                     "absolute inset-0",
-                    effectiveBackground.type === "none" &&
+                    layer.background.type === "none" &&
                       "bg-transparency-checker"
                   )}
                   data-bg-source-url={
-                    effectiveBackground.type === "image" &&
-                    effectiveBackground.sourceUrl &&
-                    effectiveBackground.sourceUrl !== effectiveBackground.value
-                      ? effectiveBackground.sourceUrl
+                    layer.background.type === "image" &&
+                    layer.background.sourceUrl &&
+                    layer.background.sourceUrl !== layer.background.value
+                      ? layer.background.sourceUrl
                       : undefined
                   }
                   style={{
-                    ...backgroundCss(effectiveBackground),
-                    filter: layerFilter,
-                    opacity: `var(${filterLayerOpacityVar(layer.id)}, ${
+                    ...backgroundCss(layer.background),
+                    filter: committedPresetFilter,
+                    opacity: `var(${backgroundLayerOpacityVar(layer.id)}, ${
                       layer.restOpaque ? 1 : 0
                     })` as unknown as number,
                   }}
                 />
-              )
-            })}
-          </>
-        ) : hasBgStack ? (
-          // Animate mode with animated background(s): a stack of layers, one per
-          // background keyframe (chronological, bottom → top), over an optional
-          // base (the background before the first keyframe). AnimationLayer fades
-          // each layer in at its keyframe so multiple swaps chain, each
-          // cross-fading over the one beneath. At rest each layer falls back to
-          // its rest opacity so the selected keyframe's background shows.
-          <>
-            {effectiveBgBase ? (
-              <div
-                aria-hidden
-                className={cn(
-                  "absolute inset-0",
-                  effectiveBgBase.type === "none" && "bg-transparency-checker"
-                )}
-                data-bg-source-url={
-                  effectiveBgBase.type === "image" &&
-                  effectiveBgBase.sourceUrl &&
-                  effectiveBgBase.sourceUrl !== effectiveBgBase.value
-                    ? effectiveBgBase.sourceUrl
-                    : undefined
-                }
-                style={{
-                  ...backgroundCss(effectiveBgBase),
-                  filter: filterValue,
-                }}
-              />
-            ) : null}
-            {effectiveBgLayers.map((layer) => (
-              <div
-                key={layer.id}
-                aria-hidden
-                className={cn(
-                  "absolute inset-0",
-                  layer.background.type === "none" && "bg-transparency-checker"
-                )}
-                data-bg-source-url={
-                  layer.background.type === "image" &&
-                  layer.background.sourceUrl &&
-                  layer.background.sourceUrl !== layer.background.value
-                    ? layer.background.sourceUrl
-                    : undefined
-                }
-                style={{
-                  ...backgroundCss(layer.background),
-                  filter: filterValue,
-                  opacity: `var(${backgroundLayerOpacityVar(layer.id)}, ${
-                    layer.restOpaque ? 1 : 0
-                  })` as unknown as number,
-                }}
-              />
-            ))}
-          </>
-        ) : (
-          <div
-            className={cn(
-              "absolute inset-0",
-              background.type === "none" && "bg-transparency-checker"
-            )}
-            data-bg-source-url={
-              background.type === "image" &&
-              background.sourceUrl &&
-              background.sourceUrl !== background.value
-                ? background.sourceUrl
-                : undefined
-            }
-            style={{
-              ...backgroundCss(effectiveBackground),
-              filter: filterValue,
-            }}
-          />
-        )}
+              ))}
+            </>
+          ) : (
+            <div
+              className={cn(
+                "absolute inset-0",
+                background.type === "none" && "bg-transparency-checker"
+              )}
+              data-bg-source-url={
+                background.type === "image" &&
+                background.sourceUrl &&
+                background.sourceUrl !== background.value
+                  ? background.sourceUrl
+                  : undefined
+              }
+              style={{
+                ...backgroundCss(effectiveBackground),
+                filter: committedPresetFilter,
+              }}
+            />
+          )}
 
-        {hasAsciiStack ? (
-          // Animate mode with animated ASCII: base layer + one per keyframe,
-          // crossfade-chained by the frame sampler. A keyframe that turns ASCII
-          // off renders nothing, so fading the layer beneath it back out is what
-          // reveals the untouched background.
-          <>
-            {effectiveAsciiBase ? (
-              <AsciiBackdrop
-                background={effectiveAsciiBase.background}
-                ascii={effectiveAsciiBase.ascii}
-                filter={filterValue}
-                opacity={`var(${ASCII_BASE_OPACITY_VAR}, 0)`}
-              />
-            ) : null}
-            {effectiveAsciiLayers.map((layer) => (
-              <AsciiBackdrop
-                key={layer.id}
-                background={layer.background}
-                ascii={layer.ascii}
-                filter={filterValue}
-                opacity={`var(${asciiLayerOpacityVar(layer.id)}, ${
-                  layer.restOpaque ? 1 : 0
-                })`}
-              />
-            ))}
-          </>
-        ) : asciiActive ? (
-          <AsciiBackdrop
-            background={effectiveBackground}
-            ascii={ascii}
-            filter={filterValue}
-          />
-        ) : null}
+          {hasAsciiStack ? (
+            // Animate mode with animated ASCII: base layer + one per keyframe,
+            // crossfade-chained by the frame sampler. A keyframe that turns ASCII
+            // off renders nothing, so fading the layer beneath it back out is what
+            // reveals the untouched background.
+            <>
+              {effectiveAsciiBase ? (
+                <AsciiBackdrop
+                  background={effectiveAsciiBase.background}
+                  ascii={effectiveAsciiBase.ascii}
+                  filter={presetFilter(effectiveAsciiBase.filter)}
+                  opacity={`var(${ASCII_BASE_OPACITY_VAR}, ${
+                    effectiveAsciiBase.restOpaque ? 1 : 0
+                  })`}
+                />
+              ) : null}
+              {effectiveAsciiLayers.map((layer) => (
+                <AsciiBackdrop
+                  key={layer.id}
+                  background={layer.background}
+                  ascii={layer.ascii}
+                  filter={presetFilter(layer.filter)}
+                  opacity={`var(${asciiLayerOpacityVar(layer.id)}, ${
+                    layer.restOpaque ? 1 : 0
+                  })`}
+                />
+              ))}
+            </>
+          ) : asciiActive ? (
+            <AsciiBackdrop
+              background={effectiveBackground}
+              ascii={ascii}
+              filter={committedPresetFilter}
+            />
+          ) : null}
+        </div>
 
         {hasPatternStack ? (
           // Animate mode with animated pattern: base group + one group per

--- a/components/editor/canvas/canvas-backdrop.tsx
+++ b/components/editor/canvas/canvas-backdrop.tsx
@@ -4,6 +4,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 import {
+  asciiLayerOpacityVar,
+  ASCII_BASE_OPACITY_VAR,
   backgroundLayerOpacityVar,
   filterLayerOpacityVar,
   patternLayerOpacityVar,
@@ -12,6 +14,7 @@ import {
   PORTRAIT_BASE_OPACITY_VAR,
   overlayLayerOpacityVar,
   OVERLAY_BASE_OPACITY_VAR,
+  type AnimateAsciiStack,
   type AnimateBgStack,
   type AnimateFilterStack,
   type AnimateOverlayStack,
@@ -34,6 +37,7 @@ import { remoteImagePreviewUrl } from "@/lib/editor/image-resize"
 import { isUnsplashImageUrl } from "@/lib/editor/unsplash"
 
 /** Stable empty layer list so the memo deps don't change every render. */
+const EMPTY_ASCII_LAYERS: AnimateAsciiStack["layers"] = []
 const EMPTY_BG_LAYERS: AnimateBgStack["layers"] = []
 const EMPTY_FILTER_LAYERS: AnimateFilterStack["layers"] = []
 const EMPTY_PORTRAIT_LAYERS: AnimatePortraitStack["layers"] = []
@@ -106,6 +110,13 @@ type CanvasBackdropProps = {
    */
   animatePatternStack?: AnimatePatternStack
   /**
+   * Animate mode only: one ASCII layer per ASCII keyframe (plus the pre-first
+   * base), crossfade-chained like the pattern stack. Layers whose keyframe has
+   * ASCII off render nothing, so the chain fades the layer beneath them out to
+   * reveal the untouched background. Empty → the committed ASCII renders.
+   */
+  animateAsciiStack?: AnimateAsciiStack
+  /**
    * Animate mode only: one texture-overlay layer per OVERLAY keyframe (plus the
    * pre-first base), crossfade-chained like the portrait/pattern stacks so the
    * additive textures transition instead of accumulating. Each layer renders in
@@ -135,6 +146,7 @@ function CanvasBackdropImpl({
   animateFilterStack,
   animatePortraitStack,
   animatePatternStack,
+  animateAsciiStack,
   animateOverlayStack,
   lightingAnimated = false,
 }: CanvasBackdropProps) {
@@ -240,6 +252,34 @@ function CanvasBackdropImpl({
     [backdrop.ascii]
   )
   const asciiActive = isAsciiBackdropActive(backdrop.ascii, background)
+  const asciiLayers = animateAsciiStack?.layers ?? EMPTY_ASCII_LAYERS
+  const hasAsciiStack = asciiLayers.length > 0
+  // Each ASCII layer samples ITS keyframe's background (downscaled the same way
+  // the rendered background is), so an animated background restyles the glyphs
+  // instead of leaving them on the committed one.
+  const effectiveAsciiLayers = React.useMemo(
+    () =>
+      asciiLayers
+        .filter((layer) => isAsciiBackdropActive(layer.ascii, layer.background))
+        .map((layer) => ({
+          ...layer,
+          background: resolveEffectiveBackground(layer.background),
+        })),
+    [asciiLayers, resolveEffectiveBackground]
+  )
+  const asciiStackBase = animateAsciiStack ?? null
+  const effectiveAsciiBase = React.useMemo(() => {
+    if (!asciiStackBase) return null
+    if (
+      !isAsciiBackdropActive(asciiStackBase.base, asciiStackBase.baseBackground)
+    ) {
+      return null
+    }
+    return {
+      ascii: asciiStackBase.base,
+      background: resolveEffectiveBackground(asciiStackBase.baseBackground),
+    }
+  }, [asciiStackBase, resolveEffectiveBackground])
 
   const filterStackBase = animateFilterStack?.base ?? "none"
   const filterLayers = animateFilterStack?.layers ?? EMPTY_FILTER_LAYERS
@@ -461,7 +501,33 @@ function CanvasBackdropImpl({
           />
         )}
 
-        {asciiActive ? (
+        {hasAsciiStack ? (
+          // Animate mode with animated ASCII: base layer + one per keyframe,
+          // crossfade-chained by the frame sampler. A keyframe that turns ASCII
+          // off renders nothing, so fading the layer beneath it back out is what
+          // reveals the untouched background.
+          <>
+            {effectiveAsciiBase ? (
+              <AsciiBackdrop
+                background={effectiveAsciiBase.background}
+                ascii={effectiveAsciiBase.ascii}
+                filter={filterValue}
+                opacity={`var(${ASCII_BASE_OPACITY_VAR}, 0)`}
+              />
+            ) : null}
+            {effectiveAsciiLayers.map((layer) => (
+              <AsciiBackdrop
+                key={layer.id}
+                background={layer.background}
+                ascii={layer.ascii}
+                filter={filterValue}
+                opacity={`var(${asciiLayerOpacityVar(layer.id)}, ${
+                  layer.restOpaque ? 1 : 0
+                })`}
+              />
+            ))}
+          </>
+        ) : asciiActive ? (
           <AsciiBackdrop
             background={effectiveBackground}
             ascii={ascii}

--- a/components/editor/canvas/canvas-backdrop.tsx
+++ b/components/editor/canvas/canvas-backdrop.tsx
@@ -41,6 +41,12 @@ const EMPTY_PATTERN_LAYERS: AnimatePatternStack["layers"] = []
 const EMPTY_OVERLAY_LAYERS: AnimateOverlayStack["layers"] = []
 
 import {
+  isAsciiBackdropActive,
+  resolveBackdropAscii,
+} from "@/lib/editor/ascii-backdrop"
+
+import { AsciiBackdrop } from "./ascii-backdrop"
+import {
   lightingOverlayCss,
   NOISE_DATA_URL,
   overlayLayerCss,
@@ -228,6 +234,12 @@ function CanvasBackdropImpl({
     [effectsFilter]
   )
   const filterValue = filterCssFor(backdrop.filter ?? "none")
+
+  const ascii = React.useMemo(
+    () => resolveBackdropAscii(backdrop.ascii),
+    [backdrop.ascii]
+  )
+  const asciiActive = isAsciiBackdropActive(backdrop.ascii, background)
 
   const filterStackBase = animateFilterStack?.base ?? "none"
   const filterLayers = animateFilterStack?.layers ?? EMPTY_FILTER_LAYERS
@@ -448,6 +460,14 @@ function CanvasBackdropImpl({
             }}
           />
         )}
+
+        {asciiActive ? (
+          <AsciiBackdrop
+            background={effectiveBackground}
+            ascii={ascii}
+            filter={filterValue}
+          />
+        ) : null}
 
         {hasPatternStack ? (
           // Animate mode with animated pattern: base group + one group per

--- a/components/editor/canvas/canvas-view.tsx
+++ b/components/editor/canvas/canvas-view.tsx
@@ -229,6 +229,7 @@ function CanvasViewInner({
     filterStack: animateFilterStack,
     portraitStack: animatePortraitStack,
     patternStack: animatePatternStack,
+    asciiStack: animateAsciiStack,
     overlayStack: animateOverlayStack,
   } = useAnimateStacks({
     isAnimateMode,
@@ -238,6 +239,7 @@ function CanvasViewInner({
     filter: backdrop.filter ?? "none",
     portrait,
     pattern: backdrop.pattern,
+    ascii: backdrop.ascii,
     overlay,
   })
   // Previews share the live canvas' background, which the real canvas already
@@ -941,6 +943,7 @@ function CanvasViewInner({
             animateFilterStack={animateFilterStack}
             animatePortraitStack={animatePortraitStack}
             animatePatternStack={animatePatternStack}
+            animateAsciiStack={animateAsciiStack}
             animateOverlayStack={animateOverlayStack}
             lightingAnimated={lightingAnimated && lightingSides.outer}
           />

--- a/components/editor/canvas/use-animate-stacks.ts
+++ b/components/editor/canvas/use-animate-stacks.ts
@@ -3,20 +3,24 @@
 import * as React from "react"
 
 import {
+  EMPTY_ASCII_STACK,
   EMPTY_BG_STACK,
   EMPTY_FILTER_STACK,
   EMPTY_OVERLAY_STACK,
   EMPTY_PATTERN_STACK,
   EMPTY_PORTRAIT_STACK,
+  resolveAnimateAsciiStack,
   resolveAnimateBgStack,
   resolveAnimateFilterStack,
   resolveAnimateOverlayStack,
   resolveAnimatePatternStack,
   resolveAnimatePortraitStack,
 } from "@/lib/editor/animation-playback"
+import { resolveBackdropAscii } from "@/lib/editor/ascii-backdrop"
 import type {
   AssetFilter,
   Background,
+  BackdropAscii,
   BackdropPattern,
   CanvasAnimation,
   Overlay,
@@ -40,6 +44,7 @@ export function useAnimateStacks({
   filter,
   portrait,
   pattern,
+  ascii,
   overlay,
 }: {
   isAnimateMode: boolean
@@ -49,6 +54,8 @@ export function useAnimateStacks({
   filter: AssetFilter
   portrait: Portrait
   pattern: BackdropPattern
+  /** Undefined on drafts saved before ASCII existed — resolved to defaults here. */
+  ascii: BackdropAscii | undefined
   overlay: Overlay
 }) {
   const clips = isAnimateMode ? (canvasAnimation?.clips ?? null) : null
@@ -81,6 +88,18 @@ export function useAnimateStacks({
         : EMPTY_PATTERN_STACK,
     [clips, pattern, selectedClipId]
   )
+  const asciiStack = React.useMemo(
+    () =>
+      clips
+        ? resolveAnimateAsciiStack(
+            clips,
+            resolveBackdropAscii(ascii),
+            background,
+            selectedClipId
+          )
+        : EMPTY_ASCII_STACK,
+    [clips, ascii, background, selectedClipId]
+  )
   const overlayStack = React.useMemo(
     () =>
       clips
@@ -89,5 +108,12 @@ export function useAnimateStacks({
     [clips, overlay, selectedClipId]
   )
 
-  return { bg, filterStack, portraitStack, patternStack, overlayStack }
+  return {
+    bg,
+    filterStack,
+    portraitStack,
+    patternStack,
+    asciiStack,
+    overlayStack,
+  }
 }

--- a/components/editor/canvas/use-animate-stacks.ts
+++ b/components/editor/canvas/use-animate-stacks.ts
@@ -93,12 +93,15 @@ export function useAnimateStacks({
       clips
         ? resolveAnimateAsciiStack(
             clips,
-            resolveBackdropAscii(ascii),
-            background,
+            {
+              ascii: resolveBackdropAscii(ascii),
+              background,
+              filter,
+            },
             selectedClipId
           )
         : EMPTY_ASCII_STACK,
-    [clips, ascii, background, selectedClipId]
+    [clips, ascii, background, filter, selectedClipId]
   )
   const overlayStack = React.useMemo(
     () =>

--- a/components/editor/inspector/backdrop-section-parts/color-swatches.tsx
+++ b/components/editor/inspector/backdrop-section-parts/color-swatches.tsx
@@ -34,6 +34,8 @@ export function ColorSwatches({
         {allowTransparent ? (
           <button
             onClick={() => onChange("transparent")}
+            aria-label={`${label}: transparent`}
+            aria-pressed={normalized === "transparent"}
             title="Transparent"
             className={cn(
               "bg-transparency-checker size-8 cursor-pointer rounded-full border border-border/60 transition-transform hover:scale-110",
@@ -45,6 +47,9 @@ export function ColorSwatches({
           <button
             key={c}
             onClick={() => onChange(c)}
+            aria-label={`${label}: ${c}`}
+            aria-pressed={normalized === c.trim().toLowerCase()}
+            title={c}
             className={cn(
               "size-8 cursor-pointer rounded-full border border-border/60 transition-transform hover:scale-110",
               normalized === c.trim().toLowerCase() && ACTIVE_COLOR_SWATCH_CLASS

--- a/components/editor/inspector/backdrop-section-parts/color-swatches.tsx
+++ b/components/editor/inspector/backdrop-section-parts/color-swatches.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { RiGradienterLine } from "@remixicon/react"
+
+import { ColorPickerPopover } from "@/components/editor/color-picker-popover"
+import { cn } from "@/lib/utils"
+
+import { ACTIVE_COLOR_SWATCH_CLASS } from "./constants"
+
+export function ColorSwatches({
+  presets,
+  value,
+  onChange,
+  label,
+  allowTransparent = false,
+}: {
+  presets: string[]
+  value: string
+  onChange: (color: string) => void
+  label: string
+  allowTransparent?: boolean
+}) {
+  const normalized = value.trim().toLowerCase()
+  const isPreset =
+    presets.some((c) => c.trim().toLowerCase() === normalized) ||
+    normalized === "transparent"
+
+  return (
+    <div>
+      <span className="mb-2 block text-[11px] text-muted-foreground">
+        {label}
+      </span>
+      <div className="flex flex-wrap items-center gap-2">
+        {allowTransparent ? (
+          <button
+            onClick={() => onChange("transparent")}
+            title="Transparent"
+            className={cn(
+              "bg-transparency-checker size-8 cursor-pointer rounded-full border border-border/60 transition-transform hover:scale-110",
+              normalized === "transparent" && ACTIVE_COLOR_SWATCH_CLASS
+            )}
+          />
+        ) : null}
+        {presets.map((c) => (
+          <button
+            key={c}
+            onClick={() => onChange(c)}
+            className={cn(
+              "size-8 cursor-pointer rounded-full border border-border/60 transition-transform hover:scale-110",
+              normalized === c.trim().toLowerCase() && ACTIVE_COLOR_SWATCH_CLASS
+            )}
+            style={{ background: c }}
+          />
+        ))}
+        <ColorPickerPopover value={value} onChange={onChange}>
+          <button
+            aria-label={`Custom ${label.toLowerCase()}`}
+            className={cn(
+              "relative size-8 cursor-pointer rounded-full border border-border/60 transition-transform hover:scale-110",
+              !isPreset && ACTIVE_COLOR_SWATCH_CLASS
+            )}
+            style={{
+              background: isPreset
+                ? "conic-gradient(from 180deg at 50% 50%, #f87171, #fbbf24, #34d399, #60a5fa, #a78bfa, #f472b6, #f87171)"
+                : value,
+            }}
+          >
+            <span className="absolute inset-0 flex items-center justify-center rounded-full bg-black/30 text-white">
+              <RiGradienterLine className="size-3.5" />
+            </span>
+          </button>
+        </ColorPickerPopover>
+      </div>
+    </div>
+  )
+}

--- a/components/editor/inspector/backdrop-section-parts/constants.ts
+++ b/components/editor/inspector/backdrop-section-parts/constants.ts
@@ -52,6 +52,14 @@ export const LIGHTING_OPACITY_VAR = "--bd-light-op"
 export const ACTIVE_COLOR_SWATCH_CLASS =
   "border-primary shadow-[0_0_0_2px_hsl(var(--background)),0_0_0_4px_hsl(var(--primary)/0.9)]"
 
+export const ASCII_COLOR_PRESETS = [
+  "#FFFFFF",
+  "#7CFFB2",
+  "#8AB4FF",
+  "#FFD59E",
+  "#FF9EC4",
+]
+
 export type BackdropControlId =
   | "overlay"
   | "lighting"

--- a/components/editor/inspector/backdrop-section-parts/pattern-control.tsx
+++ b/components/editor/inspector/backdrop-section-parts/pattern-control.tsx
@@ -1,18 +1,36 @@
 "use client"
 
-import { RiGradienterLine, RiGridLine } from "@remixicon/react"
+import * as React from "react"
+import { RiGridLine } from "@remixicon/react"
 
-import { ColorPickerPopover } from "@/components/editor/color-picker-popover"
-import type { BackdropPattern } from "@/lib/editor/state-types"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import {
+  ASCII_CHARSET_OPTIONS,
+  ASCII_CHARSETS,
+  ASCII_MAX_RESOLUTION,
+  ASCII_MIN_RESOLUTION,
+} from "@/lib/editor/ascii-backdrop"
+import type { BackdropAscii, BackdropPattern } from "@/lib/editor/state-types"
 import { BACKDROP_PATTERNS, patternCssFor } from "@/lib/editor/store"
 import { cn } from "@/lib/utils"
 
 import { EffectSlider } from "../effect-slider"
+import { ColorSwatches } from "./color-swatches"
 import { BackdropControlPopover } from "./control-popover"
-import {
-  ACTIVE_COLOR_SWATCH_CLASS,
-  type BackdropPickerLayout,
-} from "./constants"
+import { ASCII_COLOR_PRESETS, type BackdropPickerLayout } from "./constants"
+
+const TOGGLE_ITEM_CLASS =
+  "h-7 flex-1 cursor-pointer rounded-[4px] text-[10px] hover:bg-transparent hover:text-foreground data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:shadow-sm data-[state=on]:hover:bg-primary data-[state=on]:hover:text-primary-foreground"
+
+type TextureTab = "pattern" | "ascii"
+
+/** Three ramp samples, so each tile reads as the texture it produces. */
+function charsetPreview(charset: keyof typeof ASCII_CHARSETS): string {
+  const ramp = ASCII_CHARSETS[charset]
+  const pick = (t: number) =>
+    ramp[Math.min(ramp.length - 1, Math.round(t * (ramp.length - 1)))] ?? " "
+  return `${pick(0.35)}${pick(0.7)}${pick(1)}`
+}
 
 export function PatternControl({
   popoverSide,
@@ -22,10 +40,14 @@ export function PatternControl({
   pattern,
   patternActive,
   patternColors,
+  ascii,
+  asciiActive,
   pickerLayout,
   onOpenChange,
-  onReset,
+  onResetPattern,
+  onResetAscii,
   setPattern,
+  setAscii,
   setPreviewVar,
   clearPreviewVarAfterPaint,
 }: {
@@ -36,15 +58,28 @@ export function PatternControl({
   pattern: BackdropPattern
   patternActive: boolean
   patternColors: string[]
+  ascii: BackdropAscii
+  asciiActive: boolean
   pickerLayout: BackdropPickerLayout
   onOpenChange?: (open: boolean) => void
-  onReset: () => void
+  onResetPattern: () => void
+  onResetAscii: () => void
   setPattern: (patch: Partial<BackdropPattern>) => void
+  setAscii: (patch: Partial<BackdropAscii>) => void
   setPreviewVar: (name: string, value: string | null) => void
   clearPreviewVarAfterPaint: (name: string) => void
 }) {
-  const isPresetColor = patternColors.some(
-    (c) => c.trim().toLowerCase() === pattern.color.trim().toLowerCase()
+  const [tab, setTab] = React.useState<TextureTab>(
+    asciiActive && !patternActive ? "ascii" : "pattern"
+  )
+  const tileClass = cn(
+    "relative aspect-square cursor-pointer overflow-hidden rounded-md border transition-all",
+    pickerLayout === "carousel" && "h-20 w-20 shrink-0"
+  )
+  const pickerClass = cn(
+    pickerLayout === "carousel"
+      ? "flex [scrollbar-width:none] gap-2 overflow-x-auto overflow-y-hidden px-1 py-1 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+      : "grid grid-cols-3 gap-2 pr-1"
   )
 
   return (
@@ -53,131 +88,215 @@ export function PatternControl({
       presentation={controlsVariant}
       hideTriggerWhenOpen={usesInlineControls}
       icon={RiGridLine}
-      label="Pattern"
-      active={patternActive}
-      title="Patterns"
-      description="Layer geometric textures on top of your backdrop."
-      onReset={onReset}
-      resetTitle="Reset patterns"
+      label="Texture"
+      active={patternActive || asciiActive}
+      title="Textures"
+      description="Layer geometric patterns over the backdrop, or redraw it as ASCII."
+      onReset={tab === "ascii" ? onResetAscii : onResetPattern}
+      resetTitle={tab === "ascii" ? "Reset ASCII" : "Reset patterns"}
       open={usesInlineControls ? inlineOpen : undefined}
       onOpenChange={usesInlineControls ? onOpenChange : undefined}
       contentClassName="w-[240px]"
       bodyClassName="pr-1"
       footer={
-        <div className="space-y-3">
-          <EffectSlider
-            label="Intensity"
-            value={pattern.intensity}
-            onChange={(v) => {
-              setPattern({ intensity: v })
-              clearPreviewVarAfterPaint("--bd-pattern-intensity")
-            }}
-            onPreview={(v) =>
-              setPreviewVar("--bd-pattern-intensity", `${v / 100}`)
-            }
-          />
+        tab === "ascii" ? (
+          <div className="space-y-3">
+            <EffectSlider
+              label="Resolution"
+              value={ascii.resolution}
+              onChange={(v) => setAscii({ resolution: v })}
+              min={ASCII_MIN_RESOLUTION}
+              max={ASCII_MAX_RESOLUTION}
+              step={1}
+              suffix=" cols"
+            />
 
-          <EffectSlider
-            label="Thickness"
-            value={pattern.thickness}
-            onChange={(v) => setPattern({ thickness: v })}
-            min={1}
-            max={10}
-            step={0.5}
-            suffix="px"
-          />
-
-          <div>
-            <span className="mb-2 block text-[11px] text-muted-foreground">
-              Colour
-            </span>
-            <div className="flex flex-wrap items-center gap-2">
-              {patternColors.map((c) => {
-                const isActive =
-                  pattern.color.trim().toLowerCase() === c.trim().toLowerCase()
-                return (
-                  <button
-                    key={c}
-                    onClick={() => setPattern({ color: c })}
-                    className={cn(
-                      "size-8 cursor-pointer rounded-full border border-border/60 transition-transform hover:scale-110",
-                      isActive && ACTIVE_COLOR_SWATCH_CLASS
-                    )}
-                    style={{ background: c }}
-                  />
-                )
-              })}
-              <ColorPickerPopover
-                value={pattern.color}
-                onChange={(hex) => setPattern({ color: hex })}
+            <div className="min-w-0 space-y-2">
+              <span className="text-[11px] text-muted-foreground">Ink</span>
+              <ToggleGroup
+                type="single"
+                value={ascii.colored ? "source" : "solid"}
+                onValueChange={(v) =>
+                  v && setAscii({ colored: v === "source" })
+                }
+                className="flex w-full rounded-md bg-secondary/60 p-1"
               >
-                <button
-                  aria-label="Custom pattern color"
-                  className={cn(
-                    "relative size-8 cursor-pointer rounded-full border border-border/60 transition-transform hover:scale-110",
-                    !isPresetColor && ACTIVE_COLOR_SWATCH_CLASS
-                  )}
-                  style={{
-                    background: isPresetColor
-                      ? "conic-gradient(from 180deg at 50% 50%, #f87171, #fbbf24, #34d399, #60a5fa, #a78bfa, #f472b6, #f87171)"
-                      : pattern.color,
-                  }}
-                >
-                  <span className="absolute inset-0 flex items-center justify-center rounded-full bg-black/30 text-white">
-                    <RiGradienterLine className="size-3.5" />
-                  </span>
-                </button>
-              </ColorPickerPopover>
+                <ToggleGroupItem value="source" className={TOGGLE_ITEM_CLASS}>
+                  Source colour
+                </ToggleGroupItem>
+                <ToggleGroupItem value="solid" className={TOGGLE_ITEM_CLASS}>
+                  Single colour
+                </ToggleGroupItem>
+              </ToggleGroup>
             </div>
+
+            <div className="min-w-0 space-y-2">
+              <span className="text-[11px] text-muted-foreground">Ramp</span>
+              <ToggleGroup
+                type="single"
+                value={ascii.inverted ? "inverted" : "normal"}
+                onValueChange={(v) =>
+                  v && setAscii({ inverted: v === "inverted" })
+                }
+                className="flex w-full rounded-md bg-secondary/60 p-1"
+              >
+                <ToggleGroupItem value="normal" className={TOGGLE_ITEM_CLASS}>
+                  Normal
+                </ToggleGroupItem>
+                <ToggleGroupItem value="inverted" className={TOGGLE_ITEM_CLASS}>
+                  Inverted
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+
+            {ascii.colored ? null : (
+              <ColorSwatches
+                label="Characters"
+                presets={ASCII_COLOR_PRESETS}
+                value={ascii.color}
+                onChange={(color) => setAscii({ color })}
+              />
+            )}
           </div>
-        </div>
+        ) : (
+          <div className="space-y-3">
+            <EffectSlider
+              label="Intensity"
+              value={pattern.intensity}
+              onChange={(v) => {
+                setPattern({ intensity: v })
+                clearPreviewVarAfterPaint("--bd-pattern-intensity")
+              }}
+              onPreview={(v) =>
+                setPreviewVar("--bd-pattern-intensity", `${v / 100}`)
+              }
+            />
+
+            <EffectSlider
+              label="Thickness"
+              value={pattern.thickness}
+              onChange={(v) => setPattern({ thickness: v })}
+              min={1}
+              max={10}
+              step={0.5}
+              suffix="px"
+            />
+
+            <ColorSwatches
+              label="Colour"
+              presets={patternColors}
+              value={pattern.color}
+              onChange={(color) => setPattern({ color })}
+            />
+          </div>
+        )
       }
     >
-      <div
-        className={cn(
-          pickerLayout === "carousel"
-            ? "flex [scrollbar-width:none] gap-2 overflow-x-auto overflow-y-hidden px-1 py-1 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
-            : "grid grid-cols-3 gap-2 pr-1"
-        )}
-      >
-        <button
-          key="none"
-          onClick={() => setPattern({ ids: [] })}
-          title="None"
-          className={cn(
-            "relative flex aspect-square cursor-pointer items-center justify-center overflow-hidden rounded-md border bg-secondary/40 text-[10px] font-medium text-muted-foreground transition-all",
-            pickerLayout === "carousel" && "h-20 w-20 shrink-0",
-            pattern.ids.length === 0
-              ? "border-foreground text-foreground ring-1 ring-foreground/30"
-              : "border-dashed border-border/60 hover:border-foreground/30 hover:text-foreground"
-          )}
+      <div className="space-y-2">
+        <ToggleGroup
+          type="single"
+          value={tab}
+          onValueChange={(v) => v && setTab(v as TextureTab)}
+          className="flex w-full rounded-md bg-secondary/60 p-1"
         >
-          None
-        </button>
-        {BACKDROP_PATTERNS.map((p) => {
-          const selected = pattern.ids.includes(p.id)
-          return (
+          <ToggleGroupItem value="pattern" className={TOGGLE_ITEM_CLASS}>
+            Pattern
+            {patternActive ? (
+              <span className="ml-1 size-1 rounded-full bg-current" />
+            ) : null}
+          </ToggleGroupItem>
+          <ToggleGroupItem value="ascii" className={TOGGLE_ITEM_CLASS}>
+            ASCII
+            {asciiActive ? (
+              <span className="ml-1 size-1 rounded-full bg-current" />
+            ) : null}
+          </ToggleGroupItem>
+        </ToggleGroup>
+
+        {tab === "ascii" ? (
+          <div className={pickerClass}>
             <button
-              key={p.id}
-              onClick={() =>
-                setPattern({
-                  ids: selected
-                    ? pattern.ids.filter((v) => v !== p.id)
-                    : [...pattern.ids, p.id],
-                })
-              }
-              style={patternCssFor(p.id, pattern.color, pattern.thickness)}
+              onClick={() => setAscii({ enabled: false })}
+              title="Off"
               className={cn(
-                "relative aspect-square cursor-pointer overflow-hidden rounded-md border bg-neutral-900 transition-all",
-                pickerLayout === "carousel" && "h-20 w-20 shrink-0",
-                selected
-                  ? "border-foreground ring-1 ring-foreground/30"
-                  : "border-border/60 hover:border-foreground/30"
+                tileClass,
+                "flex items-center justify-center bg-secondary/40 text-[10px] font-medium text-muted-foreground",
+                !ascii.enabled
+                  ? "border-foreground text-foreground ring-1 ring-foreground/30"
+                  : "border-dashed border-border/60 hover:border-foreground/30 hover:text-foreground"
               )}
-              title={p.name}
-            />
-          )
-        })}
+            >
+              Off
+            </button>
+            {ASCII_CHARSET_OPTIONS.map((option) => {
+              const selected = ascii.enabled && ascii.charset === option.id
+              return (
+                <button
+                  key={option.id}
+                  onClick={() =>
+                    setAscii({ enabled: true, charset: option.id })
+                  }
+                  title={option.label}
+                  className={cn(
+                    tileClass,
+                    "flex flex-col items-center justify-center gap-0.5 bg-neutral-900 font-mono text-[13px] leading-none text-neutral-200",
+                    selected
+                      ? "border-foreground ring-1 ring-foreground/30"
+                      : "border-border/60 hover:border-foreground/30"
+                  )}
+                >
+                  <span className="tracking-[0.15em]">
+                    {charsetPreview(option.id)}
+                  </span>
+                  <span className="text-[8px] tracking-tight text-neutral-400">
+                    {option.label}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        ) : (
+          <div className={pickerClass}>
+            <button
+              key="none"
+              onClick={() => setPattern({ ids: [] })}
+              title="None"
+              className={cn(
+                tileClass,
+                "flex items-center justify-center bg-secondary/40 text-[10px] font-medium text-muted-foreground",
+                pattern.ids.length === 0
+                  ? "border-foreground text-foreground ring-1 ring-foreground/30"
+                  : "border-dashed border-border/60 hover:border-foreground/30 hover:text-foreground"
+              )}
+            >
+              None
+            </button>
+            {BACKDROP_PATTERNS.map((p) => {
+              const selected = pattern.ids.includes(p.id)
+              return (
+                <button
+                  key={p.id}
+                  onClick={() =>
+                    setPattern({
+                      ids: selected
+                        ? pattern.ids.filter((v) => v !== p.id)
+                        : [...pattern.ids, p.id],
+                    })
+                  }
+                  style={patternCssFor(p.id, pattern.color, pattern.thickness)}
+                  className={cn(
+                    tileClass,
+                    "bg-neutral-900",
+                    selected
+                      ? "border-foreground ring-1 ring-foreground/30"
+                      : "border-border/60 hover:border-foreground/30"
+                  )}
+                  title={p.name}
+                />
+              )
+            })}
+          </div>
+        )}
       </div>
     </BackdropControlPopover>
   )

--- a/components/editor/inspector/backdrop-section.tsx
+++ b/components/editor/inspector/backdrop-section.tsx
@@ -25,6 +25,10 @@ import {
   NEUTRAL_MEDIA_ADJUSTMENTS,
   slotMediaFxPreviewVar,
 } from "@/lib/editor/css-utils"
+import {
+  DEFAULT_BACKDROP_ASCII,
+  resolveBackdropAscii,
+} from "@/lib/editor/ascii-backdrop"
 import { isVideoSrc } from "@/lib/editor/media-type"
 import { useScreenshotStyleTarget } from "@/lib/editor/screenshot-style-target"
 import {
@@ -85,6 +89,7 @@ export function BackdropSection({
   const setBackdropEffects = useEditorStore((s) => s.setBackdropEffects)
   const setBackdropPattern = useEditorStore((s) => s.setBackdropPattern)
   const setBackdropFilter = useEditorStore((s) => s.setBackdropFilter)
+  const setBackdropAscii = useEditorStore((s) => s.setBackdropAscii)
   const setOverlay = useEditorStore((s) => s.setOverlay)
   const setPortrait = useEditorStore((s) => s.setPortrait)
   const setCanvasBorderRadius = useEditorStore((s) => s.setCanvasBorderRadius)
@@ -229,6 +234,15 @@ export function BackdropSection({
     [applyStyle]
   )
 
+  const ascii = React.useMemo(
+    () => resolveBackdropAscii(backdrop.ascii),
+    [backdrop.ascii]
+  )
+  const setAscii = React.useCallback(
+    (patch: Partial<typeof ascii>) => setBackdropAscii({ ...ascii, ...patch }),
+    [ascii, setBackdropAscii]
+  )
+
   const setPattern = React.useCallback(
     (patch: Partial<typeof pattern>) =>
       setBackdropPattern({ ...pattern, ...patch }),
@@ -318,6 +332,7 @@ export function BackdropSection({
   const effectsGrade = effectsTarget === "backdrop" ? backdropGrade : mediaGrade
   const overlayActive = overlay.id !== null
   const patternActive = pattern.ids.length > 0
+  const asciiActive = ascii.enabled
   const portraitActive = portrait.mode !== "off"
   const lightingActive = activeLighting.intensity > 0
   const shouldRenderControl = React.useCallback(
@@ -422,9 +437,11 @@ export function BackdropSection({
             pattern={pattern}
             patternActive={patternActive}
             patternColors={patternColors}
+            ascii={ascii}
+            asciiActive={asciiActive}
             pickerLayout={pickerLayout}
             onOpenChange={handleInlineControlOpenChange("pattern")}
-            onReset={() =>
+            onResetPattern={() =>
               setBackdropPattern({
                 ids: [],
                 intensity: 50,
@@ -432,7 +449,9 @@ export function BackdropSection({
                 color: "#FFFFFF",
               })
             }
+            onResetAscii={() => setBackdropAscii({ ...DEFAULT_BACKDROP_ASCII })}
             setPattern={setPattern}
+            setAscii={setAscii}
             setPreviewVar={setPreviewVar}
             clearPreviewVarAfterPaint={clearPreviewVarAfterPaint}
           />

--- a/lib/editor/animation-playback.ts
+++ b/lib/editor/animation-playback.ts
@@ -7,6 +7,7 @@
 // turns that progress into concrete CSS override vars. Kept React-free so it's
 // testable and shared between live playback and (later) the exporter.
 
+import { DEFAULT_BACKDROP_ASCII } from "./ascii-backdrop"
 import { clipProgressEase, clipReleaseEase, clipReleaseMs } from "./clip-easing"
 import { hexToRgb } from "./color-utils"
 import {
@@ -24,6 +25,7 @@ import type {
   AnimationEffect,
   AssetFilter,
   Background,
+  BackdropAscii,
   BackdropEffects,
   BackdropLighting,
   BackdropPattern,
@@ -68,6 +70,7 @@ export const DEFAULT_BASELINE: ClipBaseline = {
   mediaFilter: DEFAULT_CANVAS_BASE.mediaFilter ?? "none",
   portrait: DEFAULT_CANVAS_BASE.portrait,
   pattern: DEFAULT_CANVAS_BASE.backdrop.pattern,
+  ascii: DEFAULT_CANVAS_BASE.backdrop.ascii ?? DEFAULT_BACKDROP_ASCII,
   overlay: DEFAULT_CANVAS_BASE.overlay,
   border: DEFAULT_CANVAS_BASE.border,
   borderRadius: DEFAULT_CANVAS_BASE.borderRadius,
@@ -931,6 +934,106 @@ export function resolveAnimatePatternStack(
   return { base, layers }
 }
 
+/** True when two ASCII treatments render differently. */
+export function asciiDiffer(a: BackdropAscii, b: BackdropAscii): boolean {
+  return (
+    a.enabled !== b.enabled ||
+    a.resolution !== b.resolution ||
+    a.charset !== b.charset ||
+    a.colored !== b.colored ||
+    a.inverted !== b.inverted ||
+    a.color !== b.color
+  )
+}
+
+/** CSS var carrying an ASCII keyframe layer's crossfade opacity. */
+export const asciiLayerOpacityVar = (clipId: string) =>
+  `--canvas-ascii-op-${clipId}`
+
+/** CSS var for the pre-first-keyframe base ASCII layer's crossfade opacity. */
+export const ASCII_BASE_OPACITY_VAR = "--canvas-ascii-op-base"
+
+export type AnimateAsciiLayer = {
+  id: string
+  ascii: BackdropAscii
+  /** The background THIS layer's glyphs are sampled from. */
+  background: Background
+  /** Opacity at REST (not playing): true (1) ONLY for the selected keyframe. */
+  restOpaque: boolean
+}
+
+export type AnimateAsciiStack = {
+  /** ASCII shown before the first ASCII/background keyframe (changed FROM). */
+  base: BackdropAscii
+  /** The background the base layer's glyphs are sampled from. */
+  baseBackground: Background
+  /** One layer per ASCII/background keyframe, chronological (bottom → top). */
+  layers: AnimateAsciiLayer[]
+}
+
+export const EMPTY_ASCII_STACK: AnimateAsciiStack = {
+  base: DEFAULT_CANVAS_BASE.backdrop.ascii ?? DEFAULT_BACKDROP_ASCII,
+  baseBackground: DEFAULT_CANVAS_BASE.background,
+  layers: [],
+}
+
+/**
+ * A clip that needs its own ASCII layer. Background keyframes count as well as
+ * ASCII ones: the glyphs are sampled FROM the background, so a background swap
+ * under a live ASCII treatment has to re-render the characters, not just the
+ * (covered) background beneath them. The frame sampler chains the same clip set.
+ */
+export const clipOwnsAsciiLayer = (c: AnimationClip) =>
+  clipAffectsMain(c) && (clipOwns(c, "ascii") || clipOwns(c, "background"))
+
+/**
+ * Build the ASCII keyframe layers for Animate mode — the crossfade chain, not
+ * the opaque one the background/filter stacks use. An ASCII keyframe that turns
+ * the effect OFF renders an empty layer, and only a chain can fade the layer
+ * BENEATH it back out to reveal the untouched background; plain stacked opacity
+ * would leave the previous ASCII sitting there forever.
+ */
+export function resolveAnimateAsciiStack(
+  clips: readonly AnimationClip[],
+  committedAscii: BackdropAscii,
+  committedBackground: Background,
+  selectedClipId: string | null
+): AnimateAsciiStack {
+  const sorted = [...clips].sort((a, b) => a.startMs - b.startMs)
+  const asciiClips = sorted.filter(clipOwnsAsciiLayer)
+  if (asciiClips.length === 0) return EMPTY_ASCII_STACK
+
+  const firstBaseline = clipBaseline(asciiClips[0])
+  const base = firstBaseline.ascii ?? committedAscii
+  const baseBackground = firstBaseline.background ?? committedBackground
+
+  const selectedIndex = asciiClips.findIndex((c) => c.id === selectedClipId)
+  const restCutoff =
+    selectedIndex === -1 ? asciiClips.length - 1 : selectedIndex
+
+  // A clip that only animates the background carries no ASCII edit of its own,
+  // so it inherits whatever ASCII was in force at that point in the timeline —
+  // otherwise a background swap would blank the glyphs mid-timeline.
+  let carriedAscii = base
+  const layers: AnimateAsciiLayer[] = asciiClips.map((c, i) => {
+    const pose = clipPose(c)
+    const ascii =
+      c.id === selectedClipId
+        ? committedAscii
+        : clipOwns(c, "ascii")
+          ? (pose.ascii ?? carriedAscii)
+          : carriedAscii
+    carriedAscii = ascii
+    return {
+      id: c.id,
+      ascii,
+      background: pose.background ?? committedBackground,
+      restOpaque: i === restCutoff,
+    }
+  })
+  return { base, baseBackground, layers }
+}
+
 /** True when two overlays are a different selection (texture, opacity, side). */
 export function overlaysDiffer(a: Overlay, b: Overlay): boolean {
   return a.id !== b.id || a.opacity !== b.opacity || a.position !== b.position
@@ -1261,6 +1364,7 @@ export function poseAtCut(
     if (owns("portrait"))
       mid.portrait = disc(fromPose.portrait, toPose.portrait)
     if (owns("pattern")) mid.pattern = disc(fromPose.pattern, toPose.pattern)
+    if (owns("ascii")) mid.ascii = disc(fromPose.ascii, toPose.ascii)
     if (owns("overlay")) mid.overlay = disc(fromPose.overlay, toPose.overlay)
   }
 

--- a/lib/editor/animation-playback.ts
+++ b/lib/editor/animation-playback.ts
@@ -1024,10 +1024,19 @@ export function resolveAnimateAsciiStack(
   const asciiClips = sorted.filter(clipOwnsAsciiLayer)
   if (asciiClips.length === 0) return EMPTY_ASCII_STACK
 
-  const firstBaseline = clipBaseline(asciiClips[0])
-  const base = firstBaseline.ascii ?? committedAscii
-  const baseBackground = firstBaseline.background ?? committedBackground
-  const baseFilter = firstBaseline.filter ?? committedFilter
+  // Each axis reveals FROM the first clip that owns THAT axis — the same clip
+  // the sibling stack reads its base from (bgClips[0], filterClips[0]). Taking
+  // all three from the combined set's first clip would sample the base glyphs
+  // from one background while the background stack renders another beneath
+  // them, since per-clip baselines are captured at different times.
+  const firstOwnerBaseline = (effect: AnimationEffect) => {
+    const owner = asciiClips.find((c) => clipOwns(c, effect))
+    return owner ? clipBaseline(owner) : null
+  }
+  const base = firstOwnerBaseline("ascii")?.ascii ?? committedAscii
+  const baseBackground =
+    firstOwnerBaseline("background")?.background ?? committedBackground
+  const baseFilter = firstOwnerBaseline("filter")?.filter ?? committedFilter
 
   // Which layer holds at rest. A selected keyframe that owns none of these
   // effects still has a POSITION on the timeline, so the layer in force there

--- a/lib/editor/animation-playback.ts
+++ b/lib/editor/animation-playback.ts
@@ -1027,7 +1027,14 @@ export function resolveAnimateAsciiStack(
     return {
       id: c.id,
       ascii,
-      background: pose.background ?? committedBackground,
+      // The open keyframe's edits live on the committed canvas, not in its
+      // stored pose — so read the background from there too, or the glyphs
+      // would sample the pre-edit background while the layer beneath shows
+      // the new one. Matches resolveAnimateBgStack.
+      background:
+        c.id === selectedClipId
+          ? committedBackground
+          : (pose.background ?? committedBackground),
       restOpaque: i === restCutoff,
     }
   })

--- a/lib/editor/animation-playback.ts
+++ b/lib/editor/animation-playback.ts
@@ -1011,32 +1011,32 @@ export function resolveAnimateAsciiStack(
   const restCutoff =
     selectedIndex === -1 ? asciiClips.length - 1 : selectedIndex
 
-  // A clip that only animates the background carries no ASCII edit of its own,
-  // so it inherits whatever ASCII was in force at that point in the timeline —
-  // otherwise a background swap would blank the glyphs mid-timeline.
+  // Each axis carries forward whatever was in force at that point in the
+  // timeline, taking a clip's pose only for the axis it actually OWNS — the
+  // same rule resolveKeyframePose applies via latestOwner(). A clip's captured
+  // pose holds a value for both axes regardless of ownership, so trusting it
+  // blindly would let an ASCII-only keyframe re-assert a stale background (and
+  // a background-only keyframe blank the glyphs).
   let carriedAscii = base
+  let carriedBackground = baseBackground
   const layers: AnimateAsciiLayer[] = asciiClips.map((c, i) => {
     const pose = clipPose(c)
-    const ascii =
-      c.id === selectedClipId
-        ? committedAscii
-        : clipOwns(c, "ascii")
-          ? (pose.ascii ?? carriedAscii)
-          : carriedAscii
+    // The open keyframe's edits live on the committed canvas, not in its stored
+    // pose, so both axes read from there — matching resolveAnimateBgStack.
+    const selected = c.id === selectedClipId
+    const ascii = selected
+      ? committedAscii
+      : clipOwns(c, "ascii")
+        ? (pose.ascii ?? carriedAscii)
+        : carriedAscii
+    const background = selected
+      ? committedBackground
+      : clipOwns(c, "background")
+        ? (pose.background ?? carriedBackground)
+        : carriedBackground
     carriedAscii = ascii
-    return {
-      id: c.id,
-      ascii,
-      // The open keyframe's edits live on the committed canvas, not in its
-      // stored pose — so read the background from there too, or the glyphs
-      // would sample the pre-edit background while the layer beneath shows
-      // the new one. Matches resolveAnimateBgStack.
-      background:
-        c.id === selectedClipId
-          ? committedBackground
-          : (pose.background ?? committedBackground),
-      restOpaque: i === restCutoff,
-    }
+    carriedBackground = background
+    return { id: c.id, ascii, background, restOpaque: i === restCutoff }
   })
   return { base, baseBackground, layers }
 }

--- a/lib/editor/animation-playback.ts
+++ b/lib/editor/animation-playback.ts
@@ -958,33 +958,46 @@ export type AnimateAsciiLayer = {
   ascii: BackdropAscii
   /** The background THIS layer's glyphs are sampled from. */
   background: Background
+  /** The filter preset THIS layer renders with. */
+  filter: AssetFilter
   /** Opacity at REST (not playing): true (1) ONLY for the selected keyframe. */
   restOpaque: boolean
 }
 
 export type AnimateAsciiStack = {
-  /** ASCII shown before the first ASCII/background keyframe (changed FROM). */
+  /** ASCII shown before the first ASCII/background/filter keyframe. */
   base: BackdropAscii
   /** The background the base layer's glyphs are sampled from. */
   baseBackground: Background
-  /** One layer per ASCII/background keyframe, chronological (bottom → top). */
+  /** The filter preset the base layer renders with. */
+  baseFilter: AssetFilter
+  /**
+   * True when the BASE holds at rest — the selected keyframe sits before the
+   * first ASCII layer (or is one nothing owns), so no layer should be showing.
+   */
+  baseRestOpaque: boolean
+  /** One layer per ASCII/background/filter keyframe, chronological (bottom → top). */
   layers: AnimateAsciiLayer[]
 }
 
 export const EMPTY_ASCII_STACK: AnimateAsciiStack = {
   base: DEFAULT_CANVAS_BASE.backdrop.ascii ?? DEFAULT_BACKDROP_ASCII,
   baseBackground: DEFAULT_CANVAS_BASE.background,
+  baseFilter: DEFAULT_CANVAS_BASE.backdrop.filter,
+  baseRestOpaque: false,
   layers: [],
 }
 
 /**
- * A clip that needs its own ASCII layer. Background keyframes count as well as
- * ASCII ones: the glyphs are sampled FROM the background, so a background swap
- * under a live ASCII treatment has to re-render the characters, not just the
- * (covered) background beneath them. The frame sampler chains the same clip set.
+ * A clip that needs its own ASCII layer. Background and filter keyframes count
+ * as well as ASCII ones: an active ASCII layer COVERS the background it was
+ * sampled from, so a background swap has to re-render the characters and a
+ * filter swap has to re-grade them — animating the (hidden) layer underneath
+ * would show nothing. The frame sampler chains the same clip set.
  */
 export const clipOwnsAsciiLayer = (c: AnimationClip) =>
-  clipAffectsMain(c) && (clipOwns(c, "ascii") || clipOwns(c, "background"))
+  clipAffectsMain(c) &&
+  (clipOwns(c, "ascii") || clipOwns(c, "background") || clipOwns(c, "filter"))
 
 /**
  * Build the ASCII keyframe layers for Animate mode — the crossfade chain, not
@@ -995,10 +1008,18 @@ export const clipOwnsAsciiLayer = (c: AnimationClip) =>
  */
 export function resolveAnimateAsciiStack(
   clips: readonly AnimationClip[],
-  committedAscii: BackdropAscii,
-  committedBackground: Background,
+  committed: {
+    ascii: BackdropAscii
+    background: Background
+    filter: AssetFilter
+  },
   selectedClipId: string | null
 ): AnimateAsciiStack {
+  const {
+    ascii: committedAscii,
+    background: committedBackground,
+    filter: committedFilter,
+  } = committed
   const sorted = [...clips].sort((a, b) => a.startMs - b.startMs)
   const asciiClips = sorted.filter(clipOwnsAsciiLayer)
   if (asciiClips.length === 0) return EMPTY_ASCII_STACK
@@ -1006,10 +1027,28 @@ export function resolveAnimateAsciiStack(
   const firstBaseline = clipBaseline(asciiClips[0])
   const base = firstBaseline.ascii ?? committedAscii
   const baseBackground = firstBaseline.background ?? committedBackground
+  const baseFilter = firstBaseline.filter ?? committedFilter
 
-  const selectedIndex = asciiClips.findIndex((c) => c.id === selectedClipId)
-  const restCutoff =
-    selectedIndex === -1 ? asciiClips.length - 1 : selectedIndex
+  // Which layer holds at rest. A selected keyframe that owns none of these
+  // effects still has a POSITION on the timeline, so the layer in force there
+  // is the last one starting at or before it — showing the final layer instead
+  // would preview a state that never exists at that playhead.
+  const selectedClip = selectedClipId
+    ? (clips.find((c) => c.id === selectedClipId) ?? null)
+    : null
+  const directIndex = asciiClips.findIndex((c) => c.id === selectedClipId)
+  let restCutoff: number
+  if (directIndex !== -1) {
+    restCutoff = directIndex
+  } else if (selectedClip) {
+    // -1 when the selection precedes every ASCII layer: the base holds.
+    restCutoff = asciiClips.reduce(
+      (last, c, i) => (c.startMs <= selectedClip.startMs ? i : last),
+      -1
+    )
+  } else {
+    restCutoff = asciiClips.length - 1
+  }
 
   // Each axis carries forward whatever was in force at that point in the
   // timeline, taking a clip's pose only for the axis it actually OWNS — the
@@ -1019,10 +1058,11 @@ export function resolveAnimateAsciiStack(
   // a background-only keyframe blank the glyphs).
   let carriedAscii = base
   let carriedBackground = baseBackground
+  let carriedFilter = baseFilter
   const layers: AnimateAsciiLayer[] = asciiClips.map((c, i) => {
     const pose = clipPose(c)
     // The open keyframe's edits live on the committed canvas, not in its stored
-    // pose, so both axes read from there — matching resolveAnimateBgStack.
+    // pose, so every axis reads from there — matching resolveAnimateBgStack.
     const selected = c.id === selectedClipId
     const ascii = selected
       ? committedAscii
@@ -1034,11 +1074,23 @@ export function resolveAnimateAsciiStack(
       : clipOwns(c, "background")
         ? (pose.background ?? carriedBackground)
         : carriedBackground
+    const filter = selected
+      ? committedFilter
+      : clipOwns(c, "filter")
+        ? (pose.filter ?? carriedFilter)
+        : carriedFilter
     carriedAscii = ascii
     carriedBackground = background
-    return { id: c.id, ascii, background, restOpaque: i === restCutoff }
+    carriedFilter = filter
+    return { id: c.id, ascii, background, filter, restOpaque: i === restCutoff }
   })
-  return { base, baseBackground, layers }
+  return {
+    base,
+    baseBackground,
+    baseFilter,
+    baseRestOpaque: restCutoff === -1,
+    layers,
+  }
 }
 
 /** True when two overlays are a different selection (texture, opacity, side). */

--- a/lib/editor/apply-animation-frame.ts
+++ b/lib/editor/apply-animation-frame.ts
@@ -47,6 +47,9 @@ import {
   lerp,
   patternLayerOpacityVar,
   PATTERN_BASE_OPACITY_VAR,
+  asciiLayerOpacityVar,
+  ASCII_BASE_OPACITY_VAR,
+  clipOwnsAsciiLayer,
   portraitLayerOpacityVar,
   PORTRAIT_BASE_OPACITY_VAR,
   overlayLayerOpacityVar,
@@ -313,12 +316,14 @@ export function clearAnimationFrameVars(
   for (const v of CANVAS_FX_VARS) setVar(canvasEl, v, null)
   setVar(canvasEl, PORTRAIT_BASE_OPACITY_VAR, null)
   setVar(canvasEl, PATTERN_BASE_OPACITY_VAR, null)
+  setVar(canvasEl, ASCII_BASE_OPACITY_VAR, null)
   setVar(canvasEl, OVERLAY_BASE_OPACITY_VAR, null)
   for (const c of clips) {
     setVar(canvasEl, backgroundLayerOpacityVar(c.id), null)
     setVar(canvasEl, filterLayerOpacityVar(c.id), null)
     setVar(canvasEl, portraitLayerOpacityVar(c.id), null)
     setVar(canvasEl, patternLayerOpacityVar(c.id), null)
+    setVar(canvasEl, asciiLayerOpacityVar(c.id), null)
     setVar(canvasEl, overlayLayerOpacityVar(c.id), null)
   }
   for (const v of SCOPE_VARS) setVar(mainScopeEl, v, null)
@@ -823,6 +828,25 @@ export function applyAnimationFrameAtTime({
         const next = patternClips[i + 1]
         const pOut = next ? clipsProgressAt([next], playheadMs) : 0
         setVar(canvasEl, patternLayerOpacityVar(c.id), String(pIn * (1 - pOut)))
+      })
+    }
+
+    // ascii crossfade chain
+    // Background keyframes get an ASCII layer too — see clipOwnsAsciiLayer.
+    const asciiClips = clips
+      .filter(clipOwnsAsciiLayer)
+      .sort((a, b) => a.startMs - b.startMs)
+    if (asciiClips.length > 0) {
+      setVar(
+        canvasEl,
+        ASCII_BASE_OPACITY_VAR,
+        String(1 - clipsProgressAt([asciiClips[0]], playheadMs))
+      )
+      asciiClips.forEach((c, i) => {
+        const pIn = clipsProgressAt([c], playheadMs)
+        const next = asciiClips[i + 1]
+        const pOut = next ? clipsProgressAt([next], playheadMs) : 0
+        setVar(canvasEl, asciiLayerOpacityVar(c.id), String(pIn * (1 - pOut)))
       })
     }
 

--- a/lib/editor/ascii-backdrop.ts
+++ b/lib/editor/ascii-backdrop.ts
@@ -309,8 +309,17 @@ export function backgroundSampleKey(
  */
 const pendingSamples = new Set<Promise<void>>()
 
+/**
+ * Whether anything has sampled this session — i.e. whether glyphs can exist at
+ * all. An empty pending set does NOT mean the DOM is ready: a sample's tracking
+ * handler is attached before the caller's, so the set empties an earlier
+ * microtask than the `setPixels` that draws the result. Only a session that
+ * never sampled can skip the wait outright.
+ */
+let hasSampled = false
+
 export async function waitForAsciiBackdrops(): Promise<void> {
-  if (pendingSamples.size === 0) return
+  if (!hasSampled) return
   // No deadline: returning with work still pending is exactly the race this
   // exists to close — a bounded wait would hand the exporter a half-drawn
   // backdrop and call it done. Every sample is guaranteed to settle (see
@@ -320,7 +329,9 @@ export async function waitForAsciiBackdrops(): Promise<void> {
     await Promise.all([...pendingSamples])
   }
   // A settled sample is still only React state — give it the frames it needs to
-  // commit the grid into the DOM the exporter is about to read.
+  // commit the grid into the DOM the exporter is about to read. This runs even
+  // when nothing was pending, because "settled" and "painted" are not the same
+  // instant and the exporter reads the painted DOM.
   await new Promise<void>((resolve) => {
     if (typeof requestAnimationFrame !== "function") {
       resolve()
@@ -339,6 +350,7 @@ export function sampleBackgroundPixels(
   cols: number,
   rows: number
 ): Promise<Uint8ClampedArray | null> {
+  hasSampled = true
   const sample = sampleBackgroundPixelsUncached(background, cols, rows)
   // Never rejects, so the tracked copy can't raise an unhandled rejection —
   // the caller still sees the original promise's failure.

--- a/lib/editor/ascii-backdrop.ts
+++ b/lib/editor/ascii-backdrop.ts
@@ -1,0 +1,305 @@
+import type {
+  Background,
+  BackdropAscii,
+  BackdropAsciiCharset,
+} from "./state-types"
+
+export const ASCII_CHARSETS: Record<BackdropAsciiCharset, string> = {
+  standard: " .:-=+*#%@",
+  dense:
+    " .'`^\",:;Il!i~+_-?][}{1)(|\\/tfjrxnuvczXYUJCLQ0OZmwqpdbkhao*#MW&8%B@$",
+  blocks: " ░▒▓█",
+  binary: " ..01",
+  dots: " .·:∙•●",
+  circles: " ·○◔◑◕●",
+  stars: " ·˙*✳✻✼❋",
+}
+
+export const ASCII_CHARSET_OPTIONS: {
+  id: BackdropAsciiCharset
+  label: string
+}[] = [
+  { id: "standard", label: "Standard" },
+  { id: "dense", label: "Dense" },
+  { id: "blocks", label: "Blocks" },
+  { id: "binary", label: "Binary" },
+  { id: "dots", label: "Dots" },
+  { id: "circles", label: "Circles" },
+  { id: "stars", label: "Stars" },
+]
+
+export const ASCII_MIN_RESOLUTION = 20
+export const ASCII_MAX_RESOLUTION = 200
+
+/**
+ * Character cell width ÷ height. Monospace glyphs are roughly twice as tall as
+ * they are wide, so the sampling grid uses the same ratio and the picture keeps
+ * the background's aspect instead of squashing it.
+ */
+export const ASCII_CELL_ASPECT = 0.5
+
+export const ASCII_FONT_FAMILY =
+  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+
+export const DEFAULT_BACKDROP_ASCII: BackdropAscii = {
+  enabled: false,
+  resolution: 90,
+  charset: "standard",
+  colored: true,
+  inverted: false,
+  color: "#FFFFFF",
+}
+
+export function resolveBackdropAscii(
+  ascii: BackdropAscii | undefined
+): BackdropAscii {
+  return ascii
+    ? { ...DEFAULT_BACKDROP_ASCII, ...ascii }
+    : DEFAULT_BACKDROP_ASCII
+}
+
+export function isAsciiBackdropActive(
+  ascii: BackdropAscii | undefined,
+  background: Background
+): boolean {
+  return Boolean(ascii?.enabled) && background.type !== "none"
+}
+
+/** Rows that keep square-ish cells for a canvas of the given aspect ratio. */
+export function asciiRowCount(
+  cols: number,
+  width: number,
+  height: number
+): number {
+  if (!(width > 0) || !(height > 0)) return 0
+  const cellWidth = width / cols
+  const cellHeight = cellWidth / ASCII_CELL_ASPECT
+  return Math.max(1, Math.round(height / cellHeight))
+}
+
+export type AsciiGrid = {
+  cols: number
+  rows: number
+  /** `cols * rows` characters, row-major. */
+  chars: string
+  /** `cols * rows` CSS colours, row-major. Empty when the grid is monochrome. */
+  colors: string[]
+}
+
+function luminance(r: number, g: number, b: number): number {
+  return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
+}
+
+/** Quantize to 32 levels per channel so runs of near-identical colour merge. */
+function quantizedColor(r: number, g: number, b: number): string {
+  const q = (v: number) => Math.min(255, (v & 0xf8) + 4)
+  return `rgb(${q(r)},${q(g)},${q(b)})`
+}
+
+export function gridFromImageData(
+  data: Uint8ClampedArray,
+  cols: number,
+  rows: number,
+  options: {
+    charset: BackdropAsciiCharset
+    inverted: boolean
+    colored: boolean
+  }
+): AsciiGrid {
+  const ramp = ASCII_CHARSETS[options.charset] ?? ASCII_CHARSETS.standard
+  const last = ramp.length - 1
+  const chars = new Array<string>(cols * rows)
+  const colors = options.colored ? new Array<string>(cols * rows) : []
+  for (let i = 0; i < cols * rows; i++) {
+    const p = i * 4
+    const r = data[p]
+    const g = data[p + 1]
+    const b = data[p + 2]
+    const alpha = data[p + 3] / 255
+    // Unpainted pixels read as "dark" rather than as whatever the RGB happens
+    // to be, so a transparent background maps to the sparse end of the ramp.
+    const lum = luminance(r, g, b) * alpha
+    const level = options.inverted ? 1 - lum : lum
+    chars[i] = ramp[Math.max(0, Math.min(last, Math.round(level * last)))]
+    if (options.colored) colors[i] = quantizedColor(r, g, b)
+  }
+  return { cols, rows, chars: chars.join(""), colors }
+}
+
+/**
+ * The plate the glyphs sit on: the background's own darkest tone, dimmed. The
+ * ASCII layer covers the background it was sampled from, so drawing characters
+ * straight onto that background would leave them near-invisible — and picking
+ * the colour by hand is a knob nobody wants to turn. Deriving it keeps the
+ * canvas reading as the same artwork.
+ */
+export function asciiPlateColor(
+  data: Uint8ClampedArray,
+  cells: number
+): string {
+  let best = Number.POSITIVE_INFINITY
+  let rgb: [number, number, number] = [0, 0, 0]
+  for (let i = 0; i < cells; i++) {
+    const p = i * 4
+    const alpha = data[p + 3] / 255
+    const lum = luminance(data[p], data[p + 1], data[p + 2]) * alpha
+    if (lum < best) {
+      best = lum
+      rgb = [data[p] * alpha, data[p + 1] * alpha, data[p + 2] * alpha]
+    }
+  }
+  const dim = 0.55
+  return `rgb(${Math.round(rgb[0] * dim)},${Math.round(rgb[1] * dim)},${Math.round(
+    rgb[2] * dim
+  )})`
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
+function isSameOriginUrl(url: string): boolean {
+  try {
+    return new URL(url, window.location.href).origin === window.location.origin
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Reading pixels back needs an untainted canvas, so anything cross-origin goes
+ * through the same proxy the exporter uses.
+ */
+function readableImageUrl(url: string): string {
+  if (!url || url.startsWith("data:") || url.startsWith("blob:")) return url
+  if (isSameOriginUrl(url)) return url
+  try {
+    const parsed = new URL(url)
+    if (!["http:", "https:"].includes(parsed.protocol)) return url
+    return `/api/export/image?url=${encodeURIComponent(url)}`
+  } catch {
+    return url
+  }
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.crossOrigin = "anonymous"
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error(`ascii backdrop: cannot load ${src}`))
+    img.src = src
+  })
+}
+
+/**
+ * Rasterize a CSS background value at the grid's resolution. Gradients and
+ * solids have no canvas equivalent, so they are painted by the browser inside a
+ * `<foreignObject>` and read back — cheap here because the grid is tiny.
+ */
+async function rasterizeCssBackground(
+  value: string,
+  cols: number,
+  rows: number
+): Promise<HTMLImageElement> {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${cols}" height="${rows}"><foreignObject width="100%" height="100%"><div xmlns="http://www.w3.org/1999/xhtml" style="width:${cols}px;height:${rows}px;background:${escapeXml(
+    value
+  )}"></div></foreignObject></svg>`
+  return loadImage(
+    `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+  )
+}
+
+/** Cover-fit source rect, matching `background-size: cover` on the canvas. */
+function coverRect(
+  sw: number,
+  sh: number,
+  dw: number,
+  dh: number
+): [number, number, number, number] {
+  if (!(sw > 0) || !(sh > 0)) return [0, 0, sw, sh]
+  const scale = Math.max(dw / sw, dh / sh)
+  const w = dw / scale
+  const h = dh / scale
+  return [(sw - w) / 2, (sh - h) / 2, w, h]
+}
+
+const sampleCache = new Map<string, Uint8ClampedArray>()
+const SAMPLE_CACHE_LIMIT = 24
+
+export function backgroundSampleKey(
+  background: Background,
+  cols: number,
+  rows: number
+): string {
+  return `${background.type}|${background.value}|${cols}x${rows}`
+}
+
+/**
+ * RGBA for a `cols × rows` downsample of the background, one pixel per
+ * character cell.
+ */
+export async function sampleBackgroundPixels(
+  background: Background,
+  cols: number,
+  rows: number
+): Promise<Uint8ClampedArray | null> {
+  if (background.type === "none" || cols < 1 || rows < 1) return null
+  const key = backgroundSampleKey(background, cols, rows)
+  const cached = sampleCache.get(key)
+  if (cached) return cached
+
+  const canvas = document.createElement("canvas")
+  canvas.width = cols
+  canvas.height = rows
+  const ctx = canvas.getContext("2d", { willReadFrequently: true })
+  if (!ctx) return null
+
+  if (background.type === "image") {
+    const img = await loadImage(readableImageUrl(background.value))
+    const [sx, sy, sw, sh] = coverRect(
+      img.naturalWidth,
+      img.naturalHeight,
+      cols,
+      rows
+    )
+    ctx.drawImage(img, sx, sy, sw, sh, 0, 0, cols, rows)
+  } else {
+    const img = await rasterizeCssBackground(background.value, cols, rows)
+    ctx.drawImage(img, 0, 0, cols, rows)
+  }
+
+  const { data } = ctx.getImageData(0, 0, cols, rows)
+  if (sampleCache.size >= SAMPLE_CACHE_LIMIT) {
+    const oldest = sampleCache.keys().next().value
+    if (oldest !== undefined) sampleCache.delete(oldest)
+  }
+  sampleCache.set(key, data)
+  return data
+}
+
+let advanceRatio: number | null = null
+
+/**
+ * Width of one glyph as a fraction of font size for {@link ASCII_FONT_FAMILY}.
+ * Measured once — the ratio differs per platform (Menlo ≈ 0.6, Consolas ≈ 0.55)
+ * and the grid has to line up with whichever font actually resolves.
+ */
+export function monospaceAdvanceRatio(): number {
+  if (advanceRatio !== null) return advanceRatio
+  const fallback = 0.6
+  try {
+    const ctx = document.createElement("canvas").getContext("2d")
+    if (!ctx) return fallback
+    ctx.font = `100px ${ASCII_FONT_FAMILY}`
+    const width = ctx.measureText("M").width / 100
+    advanceRatio = width > 0.2 && width < 1.5 ? width : fallback
+  } catch {
+    advanceRatio = fallback
+  }
+  return advanceRatio
+}

--- a/lib/editor/ascii-backdrop.ts
+++ b/lib/editor/ascii-backdrop.ts
@@ -3,6 +3,7 @@ import type {
   BackdropAscii,
   BackdropAsciiCharset,
 } from "./state-types"
+import { clampNumber, editorValueSchemas } from "./value-schemas"
 
 export const ASCII_CHARSETS: Record<BackdropAsciiCharset, string> = {
   standard: " .:-=+*#%@",
@@ -28,8 +29,19 @@ export const ASCII_CHARSET_OPTIONS: {
   { id: "stars", label: "Stars" },
 ]
 
-export const ASCII_MIN_RESOLUTION = 20
-export const ASCII_MAX_RESOLUTION = 200
+// The one range for the ASCII column count — the slider, the store writer and
+// the renderer all read it from the Zod schema so they can't drift apart.
+const asciiResolutionRange = editorValueSchemas.asciiResolution
+export const ASCII_MIN_RESOLUTION = asciiResolutionRange.minValue ?? 20
+export const ASCII_MAX_RESOLUTION = asciiResolutionRange.maxValue ?? 200
+
+/** Clamp and round a column count to the schema's range. */
+export function normalizeAsciiResolution(raw: number): number {
+  return Math.round(
+    clampNumber(raw, ASCII_MIN_RESOLUTION, ASCII_MAX_RESOLUTION) ??
+      DEFAULT_BACKDROP_ASCII.resolution
+  )
+}
 
 /**
  * Character cell width ÷ height. Monospace glyphs are roughly twice as tall as
@@ -53,9 +65,10 @@ export const DEFAULT_BACKDROP_ASCII: BackdropAscii = {
 export function resolveBackdropAscii(
   ascii: BackdropAscii | undefined
 ): BackdropAscii {
-  return ascii
-    ? { ...DEFAULT_BACKDROP_ASCII, ...ascii }
-    : DEFAULT_BACKDROP_ASCII
+  if (!ascii) return DEFAULT_BACKDROP_ASCII
+  const merged = { ...DEFAULT_BACKDROP_ASCII, ...ascii }
+  const resolution = normalizeAsciiResolution(merged.resolution)
+  return resolution === merged.resolution ? merged : { ...merged, resolution }
 }
 
 export function isAsciiBackdropActive(
@@ -240,10 +253,57 @@ export function backgroundSampleKey(
 }
 
 /**
+ * Sampling is async, but export rasterizes (or clones) whatever is in the DOM
+ * *now* — so an export fired right after ASCII is switched on, or after its
+ * background/resolution changes, would capture a canvas with no glyphs on it.
+ * Every in-flight sample registers here and the export paths await this first.
+ */
+const pendingSamples = new Set<Promise<void>>()
+
+export async function waitForAsciiBackdrops(timeoutMs = 4000): Promise<void> {
+  if (pendingSamples.size === 0) return
+  const deadline = Date.now() + timeoutMs
+  while (pendingSamples.size > 0 && Date.now() < deadline) {
+    await Promise.race([
+      Promise.all([...pendingSamples]),
+      new Promise((resolve) =>
+        setTimeout(resolve, Math.max(0, deadline - Date.now()))
+      ),
+    ])
+  }
+  // A settled sample is still only React state — give it the frames it needs to
+  // commit the grid into the DOM the exporter is about to read.
+  await new Promise<void>((resolve) => {
+    if (typeof requestAnimationFrame !== "function") {
+      resolve()
+      return
+    }
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+  })
+}
+
+/**
  * RGBA for a `cols × rows` downsample of the background, one pixel per
  * character cell.
  */
-export async function sampleBackgroundPixels(
+export function sampleBackgroundPixels(
+  background: Background,
+  cols: number,
+  rows: number
+): Promise<Uint8ClampedArray | null> {
+  const sample = sampleBackgroundPixelsUncached(background, cols, rows)
+  // Never rejects, so the tracked copy can't raise an unhandled rejection —
+  // the caller still sees the original promise's failure.
+  const settled = sample.then(
+    () => undefined,
+    () => undefined
+  )
+  pendingSamples.add(settled)
+  void settled.then(() => pendingSamples.delete(settled))
+  return sample
+}
+
+async function sampleBackgroundPixelsUncached(
   background: Background,
   cols: number,
   rows: number

--- a/lib/editor/ascii-backdrop.ts
+++ b/lib/editor/ascii-backdrop.ts
@@ -199,12 +199,29 @@ function readableImageUrl(url: string): string {
   }
 }
 
+/**
+ * An `<img>` that never fires load or error (a stalled request) would otherwise
+ * leave a sample pending forever — and export waits for every pending sample.
+ * Bounding it here is what lets that wait be unbounded: every sample settles.
+ */
+const IMAGE_LOAD_TIMEOUT_MS = 15_000
+
 function loadImage(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image()
+    const timer = setTimeout(() => {
+      img.src = ""
+      reject(new Error(`ascii backdrop: timed out loading ${src}`))
+    }, IMAGE_LOAD_TIMEOUT_MS)
     img.crossOrigin = "anonymous"
-    img.onload = () => resolve(img)
-    img.onerror = () => reject(new Error(`ascii backdrop: cannot load ${src}`))
+    img.onload = () => {
+      clearTimeout(timer)
+      resolve(img)
+    }
+    img.onerror = () => {
+      clearTimeout(timer)
+      reject(new Error(`ascii backdrop: cannot load ${src}`))
+    }
     img.src = src
   })
 }
@@ -260,16 +277,15 @@ export function backgroundSampleKey(
  */
 const pendingSamples = new Set<Promise<void>>()
 
-export async function waitForAsciiBackdrops(timeoutMs = 4000): Promise<void> {
+export async function waitForAsciiBackdrops(): Promise<void> {
   if (pendingSamples.size === 0) return
-  const deadline = Date.now() + timeoutMs
-  while (pendingSamples.size > 0 && Date.now() < deadline) {
-    await Promise.race([
-      Promise.all([...pendingSamples]),
-      new Promise((resolve) =>
-        setTimeout(resolve, Math.max(0, deadline - Date.now()))
-      ),
-    ])
+  // No deadline: returning with work still pending is exactly the race this
+  // exists to close — a bounded wait would hand the exporter a half-drawn
+  // backdrop and call it done. Every sample is guaranteed to settle (see
+  // IMAGE_LOAD_TIMEOUT_MS), and the loop re-checks because a settling sample
+  // can queue another one.
+  while (pendingSamples.size > 0) {
+    await Promise.all([...pendingSamples])
   }
   // A settled sample is still only React state — give it the frames it needs to
   // commit the grid into the DOM the exporter is about to read.

--- a/lib/editor/ascii-backdrop.ts
+++ b/lib/editor/ascii-backdrop.ts
@@ -90,6 +90,38 @@ export function asciiRowCount(
   return Math.max(1, Math.round(height / cellHeight))
 }
 
+/**
+ * Ceiling on cells (≈ DOM nodes) in one grid. Rows scale with the canvas's
+ * aspect, so the column count alone doesn't bound the grid: 200 columns is
+ * ~11k cells on 16:9 but ~36k on a 9:16 story canvas, and Animate mode mounts
+ * one grid per ASCII/background/filter keyframe. This trades a few columns on
+ * tall canvases for a bounded node count. Landscape at full resolution is
+ * unaffected.
+ */
+export const ASCII_MAX_CELLS = 12_000
+
+/**
+ * The grid to actually render: the requested columns, reduced if the resulting
+ * cell count would blow the budget. Both dimensions shrink together so the
+ * characters keep their aspect.
+ */
+export function asciiGridSize(
+  requestedCols: number,
+  width: number,
+  height: number
+): { cols: number; rows: number } {
+  const cols = normalizeAsciiResolution(requestedCols)
+  const rows = asciiRowCount(cols, width, height)
+  if (rows < 1) return { cols, rows: 0 }
+  const cells = cols * rows
+  if (cells <= ASCII_MAX_CELLS) return { cols, rows }
+  const scaled = Math.max(
+    ASCII_MIN_RESOLUTION,
+    Math.floor(cols * Math.sqrt(ASCII_MAX_CELLS / cells))
+  )
+  return { cols: scaled, rows: asciiRowCount(scaled, width, height) }
+}
+
 export type AsciiGrid = {
   cols: number
   rows: number

--- a/lib/editor/export.ts
+++ b/lib/editor/export.ts
@@ -1,6 +1,7 @@
 import { toSvg, getFontEmbedCSS } from "html-to-image"
 
 import { triggerAnchorDownload } from "@/lib/download"
+import { waitForAsciiBackdrops } from "./ascii-backdrop"
 import { supportsObjectViewBox } from "./crop-utils"
 import { shouldProxyAssetUrl } from "./export-assets"
 import { replaceCloneVideosWithFrames } from "./export-video-frames"
@@ -572,6 +573,9 @@ async function rasterizeNodeToCanvas(
   outputHeight: number,
   backgroundColor?: string
 ): Promise<HTMLCanvasElement> {
+  // ASCII backdrops paint their glyphs from an async sample of the background;
+  // capturing mid-sample would export a blank (or stale) backdrop.
+  await waitForAsciiBackdrops()
   const svgUrl = await toSvg(node, {
     ...options,
     width: outputWidth,
@@ -826,6 +830,9 @@ export async function prepareAnimationCapture(
   canvasId: string,
   targetWidth = 1280
 ): Promise<AnimationCapture> {
+  // The clone below is a snapshot: React never renders into it, so any ASCII
+  // sample still in flight would be missing from EVERY exported frame.
+  await waitForAsciiBackdrops()
   const node = findCanvasElement(canvasId)
   if (!node) throw new Error("Canvas not found")
 

--- a/lib/editor/export.ts
+++ b/lib/editor/export.ts
@@ -573,9 +573,6 @@ async function rasterizeNodeToCanvas(
   outputHeight: number,
   backgroundColor?: string
 ): Promise<HTMLCanvasElement> {
-  // ASCII backdrops paint their glyphs from an async sample of the background;
-  // capturing mid-sample would export a blank (or stale) backdrop.
-  await waitForAsciiBackdrops()
   const svgUrl = await toSvg(node, {
     ...options,
     width: outputWidth,
@@ -630,6 +627,10 @@ export async function exportCanvas(
   resolution: ExportResolution,
   options: ExportCaptureOptions = { watermark: true }
 ): Promise<string> {
+  // ASCII backdrops paint their glyphs from an async sample of the background,
+  // and the export clone below is a snapshot React never renders into again —
+  // so this must happen BEFORE prepareExportNode, not before the rasterize.
+  await waitForAsciiBackdrops()
   const node = findCanvasElement(canvasId)
   if (!node) throw new Error("Canvas not found")
 
@@ -830,8 +831,9 @@ export async function prepareAnimationCapture(
   canvasId: string,
   targetWidth = 1280
 ): Promise<AnimationCapture> {
-  // The clone below is a snapshot: React never renders into it, so any ASCII
-  // sample still in flight would be missing from EVERY exported frame.
+  // ASCII backdrops paint their glyphs from an async sample of the background,
+  // and the export clone below is a snapshot React never renders into again —
+  // so this must happen BEFORE prepareExportNode, not before the rasterize.
   await waitForAsciiBackdrops()
   const node = findCanvasElement(canvasId)
   if (!node) throw new Error("Canvas not found")
@@ -1025,6 +1027,10 @@ export async function prepareFastAnimationCapture(
   canvasId: string,
   targetWidth = 1280
 ): Promise<AnimationCapture> {
+  // ASCII backdrops paint their glyphs from an async sample of the background,
+  // and the export clone below is a snapshot React never renders into again —
+  // so this must happen BEFORE prepareExportNode, not before the rasterize.
+  await waitForAsciiBackdrops()
   const node = findCanvasElement(canvasId)
   if (!node) throw new Error("Canvas not found")
 
@@ -1162,6 +1168,10 @@ export async function captureCanvasAsPngBlob(
   targetWidth = SHARE_RESOLUTION_WIDTH,
   options: ExportCaptureOptions = {}
 ): Promise<Blob> {
+  // ASCII backdrops paint their glyphs from an async sample of the background,
+  // and the export clone below is a snapshot React never renders into again —
+  // so this must happen BEFORE prepareExportNode, not before the rasterize.
+  await waitForAsciiBackdrops()
   const node = findCanvasElement(canvasId)
   if (!node) throw new Error("Canvas not found")
 

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -57,6 +57,27 @@ export type BackdropPattern = {
   color: string
 }
 
+export type BackdropAsciiCharset =
+  | "standard"
+  | "dense"
+  | "blocks"
+  | "binary"
+  | "dots"
+  | "circles"
+  | "stars"
+
+export type BackdropAscii = {
+  enabled: boolean
+  /** Number of character columns across the canvas. Higher = finer detail. */
+  resolution: number
+  charset: BackdropAsciiCharset
+  /** Sample the background's own colour per character instead of `color`. */
+  colored: boolean
+  /** Reverse the ramp so bright pixels get the sparse characters. */
+  inverted: boolean
+  color: string
+}
+
 export type BackdropLightingTarget = "outer" | "inner"
 
 export type BackdropLighting = {
@@ -71,6 +92,7 @@ export type Backdrop = {
   pattern: BackdropPattern
   lighting: BackdropLighting
   filter: AssetFilter
+  ascii?: BackdropAscii
 }
 
 export type ShadowType =

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -440,6 +440,7 @@ export type AnimationEffect =
   | "mediaFilter"
   | "portrait"
   | "pattern"
+  | "ascii"
   | "overlay"
   | "border"
   | "borderRadius"
@@ -500,6 +501,7 @@ export type ClipBaseline = {
   mediaFilter?: AssetFilter
   portrait?: Portrait
   pattern?: BackdropPattern
+  ascii?: BackdropAscii
   overlay?: Overlay
   border?: Border
   borderRadius?: number

--- a/lib/editor/store/actions/canvas-style.ts
+++ b/lib/editor/store/actions/canvas-style.ts
@@ -1,3 +1,4 @@
+import { normalizeAsciiResolution } from "../../ascii-backdrop"
 import { LAYOUT_PRESETS, PRESENT_PRESETS } from "../../present-presets"
 import {
   resolveActivePresetGeometry,
@@ -328,10 +329,19 @@ export const createCanvasStyleActions = ({
         "pattern"
       ),
     setBackdropAscii: (a, canvasId) =>
-      commitCanvas(
+      commitCanvasEffect(
         canvasId,
-        (canvas) => ({ backdrop: { ...canvas.backdrop, ascii: a } }),
-        "backdrop-ascii"
+        (canvas) => ({
+          backdrop: {
+            ...canvas.backdrop,
+            ascii: {
+              ...a,
+              resolution: normalizeAsciiResolution(a.resolution),
+            },
+          },
+        }),
+        "backdrop-ascii",
+        "ascii"
       ),
     setBackdropLighting: (l, canvasId) =>
       commitCanvasEffect(

--- a/lib/editor/store/actions/canvas-style.ts
+++ b/lib/editor/store/actions/canvas-style.ts
@@ -327,6 +327,12 @@ export const createCanvasStyleActions = ({
         "backdrop-pattern",
         "pattern"
       ),
+    setBackdropAscii: (a, canvasId) =>
+      commitCanvas(
+        canvasId,
+        (canvas) => ({ backdrop: { ...canvas.backdrop, ascii: a } }),
+        "backdrop-ascii"
+      ),
     setBackdropLighting: (l, canvasId) =>
       commitCanvasEffect(
         canvasId,

--- a/lib/editor/store/animation-helpers.ts
+++ b/lib/editor/store/animation-helpers.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_BACKDROP_ASCII } from "../ascii-backdrop"
 import { NEUTRAL_MEDIA_ADJUSTMENTS } from "../css-utils"
 import {
   clipAffectsMain,
@@ -75,6 +76,7 @@ export const captureClipPose = (canvas: CanvasState): ClipBaseline => {
     mediaFilter: main.filter,
     portrait: canvas.portrait,
     pattern: canvas.backdrop.pattern,
+    ascii: canvas.backdrop.ascii ?? DEFAULT_BACKDROP_ASCII,
     overlay: canvas.overlay,
     border: main.border,
     borderRadius: main.borderRadius,
@@ -157,6 +159,8 @@ export const applyPoseToCanvas = (
     filter: pose.filter ?? canvas.backdrop.filter,
     // Fall back to the live value for poses captured before pattern animated.
     pattern: pose.pattern ?? canvas.backdrop.pattern,
+    // Fall back to the live value for poses captured before ASCII animated.
+    ascii: pose.ascii ?? canvas.backdrop.ascii,
   },
   screenshotSlots: canvas.screenshotSlots.map((s) => {
     const sp = pose.slots[s.id]
@@ -304,6 +308,7 @@ const EFFECT_MAIN_POSE_FIELDS: Record<
   mediaFilter: ["mediaFilter"],
   portrait: ["portrait"],
   pattern: ["pattern"],
+  ascii: ["ascii"],
   overlay: ["overlay"],
   border: ["border"],
   borderRadius: ["borderRadius"],
@@ -562,6 +567,10 @@ export const resolveKeyframePose = (
     ),
     portrait: mainReveal("portrait", (p) => p.portrait ?? canvas.portrait),
     pattern: mainReveal("pattern", (p) => p.pattern ?? canvas.backdrop.pattern),
+    ascii: mainReveal(
+      "ascii",
+      (p) => p.ascii ?? canvas.backdrop.ascii ?? DEFAULT_BACKDROP_ASCII
+    ),
     overlay: mainReveal("overlay", (p) => p.overlay ?? canvas.overlay),
     border: mainReveal("border", (p) => p.border ?? canvas.border),
     crop: mainReveal("crop", (p) => poseCrop(p, canvas.lastCropRegion)),

--- a/lib/editor/store/defaults.ts
+++ b/lib/editor/store/defaults.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_BACKDROP_ASCII } from "../ascii-backdrop"
 import { NEUTRAL_MEDIA_ADJUSTMENTS } from "../css-utils"
 import { DEFAULT_IMAGE_BACKGROUND_ENTRY } from "../presets"
 import type { CanvasState, EditorState } from "../state-types"
@@ -64,6 +65,7 @@ export const DEFAULT_CANVAS_BASE: Omit<CanvasState, "id" | "position"> = {
       color: "#FFFFFF",
     },
     filter: "none",
+    ascii: { ...DEFAULT_BACKDROP_ASCII },
   },
   tilt: { rx: 0, ry: 0, rz: 0 },
   scale: 100,

--- a/lib/editor/store/draft-persistence.ts
+++ b/lib/editor/store/draft-persistence.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_BACKDROP_ASCII } from "../ascii-backdrop"
 import { NEUTRAL_MEDIA_ADJUSTMENTS } from "../css-utils"
 import { getBlobForObjectUrl, registerObjectUrl } from "../media-type"
 import { BACKGROUND_LIBRARY } from "../presets"
@@ -545,6 +546,11 @@ function normalizeCanvasState(
       lighting: {
         ...fallbackBackdrop.lighting,
         ...(sourceBackdrop?.lighting ?? {}),
+      },
+      ascii: {
+        ...DEFAULT_BACKDROP_ASCII,
+        ...(fallbackBackdrop.ascii ?? {}),
+        ...(sourceBackdrop?.ascii ?? {}),
       },
     },
     mediaAdjustments: {

--- a/lib/editor/store/draft-persistence.ts
+++ b/lib/editor/store/draft-persistence.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_BACKDROP_ASCII } from "../ascii-backdrop"
+import { DEFAULT_BACKDROP_ASCII, resolveBackdropAscii } from "../ascii-backdrop"
 import { NEUTRAL_MEDIA_ADJUSTMENTS } from "../css-utils"
 import { getBlobForObjectUrl, registerObjectUrl } from "../media-type"
 import { BACKGROUND_LIBRARY } from "../presets"
@@ -547,11 +547,13 @@ function normalizeCanvasState(
         ...fallbackBackdrop.lighting,
         ...(sourceBackdrop?.lighting ?? {}),
       },
-      ascii: {
+      // Same normalizer the store writer uses, so a hand-edited or pre-clamp
+      // draft can't land an out-of-range column count in state.
+      ascii: resolveBackdropAscii({
         ...DEFAULT_BACKDROP_ASCII,
         ...(fallbackBackdrop.ascii ?? {}),
         ...(sourceBackdrop?.ascii ?? {}),
-      },
+      }),
     },
     mediaAdjustments: {
       ...NEUTRAL_MEDIA_ADJUSTMENTS,

--- a/lib/editor/store/types.ts
+++ b/lib/editor/store/types.ts
@@ -11,6 +11,7 @@ import type {
   AssetElement,
   AssetFilter,
   Background,
+  BackdropAscii,
   BackdropEffects,
   BackdropLighting,
   BackdropPattern,
@@ -203,6 +204,7 @@ export type EditorActions = {
   setMainScreenshotBorder: (b: Border, canvasId?: string) => void
   setBackdropEffects: (e: BackdropEffects, canvasId?: string) => void
   setBackdropPattern: (p: BackdropPattern, canvasId?: string) => void
+  setBackdropAscii: (a: BackdropAscii, canvasId?: string) => void
   setBackdropLighting: (l: BackdropLighting, canvasId?: string) => void
   setMainScreenshotBackdropLighting: (
     l: BackdropLighting,

--- a/lib/editor/store/use-editor.tsx
+++ b/lib/editor/store/use-editor.tsx
@@ -371,6 +371,8 @@ export function useEditor(): EditorContext {
       store.setBackdropEffects(e, canvasId ?? targetId),
     setBackdropPattern: (p, canvasId) =>
       store.setBackdropPattern(p, canvasId ?? targetId),
+    setBackdropAscii: (a, canvasId) =>
+      store.setBackdropAscii(a, canvasId ?? targetId),
     setBackdropLighting: (l, canvasId) =>
       store.setBackdropLighting(l, canvasId ?? targetId),
     setMainScreenshotBackdropLighting: (l, canvasId) =>

--- a/lib/editor/value-schemas.ts
+++ b/lib/editor/value-schemas.ts
@@ -19,6 +19,7 @@ export const editorValueSchemas = {
   borderRadius: rangeSchema(0, 48),
   canvasRadius: rangeSchema(0, 80),
   patternThickness: rangeSchema(1, 10),
+  asciiResolution: rangeSchema(20, 200),
   brightness: rangeSchema(0, 200),
   contrast: rangeSchema(0, 200),
   saturation: rangeSchema(0, 200),

--- a/tests/components/editor/canvas-backdrop.test.tsx
+++ b/tests/components/editor/canvas-backdrop.test.tsx
@@ -81,13 +81,25 @@ describe("CanvasBackdrop", () => {
    */
   it("always reads the effects preview var, with an identity fallback", () => {
     const { container } = render(<CanvasBackdrop {...baseProps()} />)
-    const layer = container.querySelector<HTMLElement>(
-      ".bg-transparency-checker"
-    )
-    expect(layer?.style.filter).toBe("var(--bd-fx-preview, brightness(1))")
+    const grade = container.querySelector<HTMLElement>("[data-backdrop-grade]")
+    expect(grade?.style.filter).toBe("var(--bd-fx-preview, brightness(1))")
   })
 
-  it("keeps the preview var valid alongside a backdrop asset filter", () => {
+  it("uses the committed effects filter as the preview fallback", () => {
+    const { container } = render(
+      <CanvasBackdrop {...baseProps({ effectsFilter: "brightness(120%)" })} />
+    )
+    const grade = container.querySelector<HTMLElement>("[data-backdrop-grade]")
+    expect(grade?.style.filter).toBe("var(--bd-fx-preview, brightness(120%))")
+  })
+
+  /**
+   * The grade applies once, to the group — not to each layer inside it. An ASCII
+   * layer covers the background it was sampled from, so filtering both compounds
+   * them (a 50% `opacity()` leg rendering as ~75%). The asset-filter PRESET stays
+   * per layer, which is how a filter animation chains.
+   */
+  it("grades the composed group once, leaving the preset on the layer", () => {
     const { container } = render(
       <CanvasBackdrop
         {...baseProps({
@@ -95,20 +107,14 @@ describe("CanvasBackdrop", () => {
         })}
       />
     )
-    const filter = container.querySelector<HTMLElement>(
-      ".bg-transparency-checker"
-    )?.style.filter
-    expect(filter).toContain("var(--bd-fx-preview, brightness(1))")
-    expect(filter).not.toContain("none")
-  })
+    const grade = container.querySelector<HTMLElement>("[data-backdrop-grade]")
+    expect(grade?.style.filter).toBe("var(--bd-fx-preview, brightness(1))")
 
-  it("uses the committed effects filter as the preview fallback", () => {
-    const { container } = render(
-      <CanvasBackdrop {...baseProps({ effectsFilter: "brightness(120%)" })} />
-    )
     const layer = container.querySelector<HTMLElement>(
       ".bg-transparency-checker"
     )
-    expect(layer?.style.filter).toBe("var(--bd-fx-preview, brightness(120%))")
+    expect(layer?.style.filter).not.toContain("--bd-fx-preview")
+    expect(layer?.style.filter).not.toBe("none")
+    expect(layer?.style.filter.length).toBeGreaterThan(0)
   })
 })

--- a/tests/lib/editor/animation-ascii-frame.test.ts
+++ b/tests/lib/editor/animation-ascii-frame.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  applyAnimationFrameAtTime,
+  clearAnimationFrameVars,
+} from "@/lib/editor/apply-animation-frame"
+import {
+  asciiLayerOpacityVar,
+  ASCII_BASE_OPACITY_VAR,
+} from "@/lib/editor/animation-playback"
+import { DEFAULT_BACKDROP_ASCII } from "@/lib/editor/ascii-backdrop"
+import { captureClipPose, useEditorStore } from "@/lib/editor/store"
+import type { AnimationClip, CanvasState } from "@/lib/editor/state-types"
+
+const baseCanvas = (): CanvasState => {
+  const s = useEditorStore.getState().present
+  return s.canvases.find((c) => c.id === s.activeCanvasId)!
+}
+
+const asciiClip = (
+  id: string,
+  startMs: number,
+  effects: AnimationClip["effects"] = ["ascii"]
+): AnimationClip => {
+  const canvas = baseCanvas()
+  const pose = captureClipPose(canvas)
+  return {
+    id,
+    startMs,
+    durationMs: 1000,
+    target: { scope: "main" },
+    effects,
+    easing: "linear",
+    baseline: { ...pose, ascii: DEFAULT_BACKDROP_ASCII },
+    pose: { ...pose, ascii: { ...DEFAULT_BACKDROP_ASCII, enabled: true } },
+  }
+}
+
+const applyAt = (el: HTMLElement, clips: AnimationClip[], timeMs: number) =>
+  applyAnimationFrameAtTime({
+    canvasEl: el,
+    canvas: baseCanvas(),
+    globalAspect: { id: "auto", w: 16, h: 9 },
+    clips,
+    timeMs,
+  })
+
+const num = (el: HTMLElement, name: string) =>
+  Number(el.style.getPropertyValue(name))
+
+describe("animated ASCII → crossfade vars", () => {
+  let el: HTMLElement
+
+  beforeEach(() => {
+    useEditorStore.getState().reset()
+    el = document.createElement("div")
+    document.body.appendChild(el)
+  })
+
+  it("fades the base out as the first keyframe fades in", () => {
+    const clip = asciiClip("k1", 0)
+
+    applyAt(el, [clip], 0)
+    expect(num(el, ASCII_BASE_OPACITY_VAR)).toBe(1)
+    expect(num(el, asciiLayerOpacityVar("k1"))).toBe(0)
+
+    applyAt(el, [clip], 1000)
+    expect(num(el, ASCII_BASE_OPACITY_VAR)).toBe(0)
+    expect(num(el, asciiLayerOpacityVar("k1"))).toBe(1)
+  })
+
+  it("chains keyframes so an earlier layer eases out under the next", () => {
+    const first = asciiClip("k1", 0)
+    const second = asciiClip("k2", 1000)
+
+    // Mid-way through the second keyframe: the first is on its way out and the
+    // second on its way in — never both fully opaque, never both gone.
+    applyAt(el, [first, second], 1500)
+    const out = num(el, asciiLayerOpacityVar("k1"))
+    const incoming = num(el, asciiLayerOpacityVar("k2"))
+    expect(out).toBeGreaterThan(0)
+    expect(out).toBeLessThan(1)
+    expect(incoming).toBeGreaterThan(0)
+    expect(incoming).toBeLessThan(1)
+
+    // Past the end the last keyframe holds and the earlier one is gone.
+    applyAt(el, [first, second], 2000)
+    expect(num(el, asciiLayerOpacityVar("k1"))).toBe(0)
+    expect(num(el, asciiLayerOpacityVar("k2"))).toBe(1)
+  })
+
+  it("gives a background keyframe its own ASCII layer", () => {
+    const asciiK = asciiClip("k1", 0)
+    const bgK = asciiClip("bg", 1000, ["background"])
+
+    applyAt(el, [asciiK, bgK], 2000)
+    // The background swap drives its own layer, so the glyphs re-render for the
+    // new background instead of holding the previous one.
+    expect(num(el, asciiLayerOpacityVar("bg"))).toBe(1)
+    expect(num(el, asciiLayerOpacityVar("k1"))).toBe(0)
+  })
+
+  it("clears every ASCII var at rest so the committed backdrop shows", () => {
+    const clip = asciiClip("k1", 0)
+    applyAt(el, [clip], 1000)
+    clearAnimationFrameVars(el, [clip])
+
+    expect(el.style.getPropertyValue(ASCII_BASE_OPACITY_VAR)).toBe("")
+    expect(el.style.getPropertyValue(asciiLayerOpacityVar("k1"))).toBe("")
+  })
+})

--- a/tests/lib/editor/animation-ascii.test.ts
+++ b/tests/lib/editor/animation-ascii.test.ts
@@ -139,6 +139,28 @@ describe("resolveAnimateAsciiStack", () => {
     expect(stack.layers[0].ascii).toBe(live)
   })
 
+  it("samples the open keyframe's glyphs from the live background", () => {
+    // Editing a keyframe writes to the committed canvas, not to the clip's
+    // stored pose — so a background change while it is open must reach the
+    // ASCII layer, or the glyphs would lag one edit behind the background.
+    const stack = resolveAnimateAsciiStack(
+      [
+        clip("k1", 0, ["ascii", "background"], {
+          ascii: ascii(),
+          background: committedBg,
+        }),
+        clip("k2", 1000, ["ascii"], { ascii: ascii({ charset: "dots" }) }),
+      ],
+      ascii(),
+      otherBg,
+      "k1"
+    )
+
+    expect(stack.layers[0].background).toEqual(otherBg)
+    // Unselected keyframes still read their own stored pose.
+    expect(stack.layers[1].background).toEqual(committedBg)
+  })
+
   it("holds the last layer at rest when no keyframe is open", () => {
     const stack = resolveAnimateAsciiStack(
       [

--- a/tests/lib/editor/animation-ascii.test.ts
+++ b/tests/lib/editor/animation-ascii.test.ts
@@ -14,6 +14,7 @@ import {
 import { DEFAULT_CANVAS_BASE } from "@/lib/editor/store/defaults"
 import type {
   AnimationClip,
+  AssetFilter,
   BackdropAscii,
   Background,
 } from "@/lib/editor/state-types"
@@ -34,7 +35,11 @@ const clip = (
   id: string,
   startMs: number,
   effects: AnimationClip["effects"],
-  pose?: Partial<{ ascii: BackdropAscii; background: Background }>
+  pose?: Partial<{
+    ascii: BackdropAscii
+    background: Background
+    filter: AssetFilter
+  }>
 ): AnimationClip => ({
   id,
   startMs,
@@ -68,6 +73,7 @@ const clip = (
         backdropEffects: DEFAULT_CANVAS_BASE.backdrop.effects,
         background: pose.background ?? committedBg,
         ascii: pose.ascii,
+        filter: pose.filter,
         slots: {},
       }
     : undefined,
@@ -77,8 +83,7 @@ describe("resolveAnimateAsciiStack", () => {
   it("is empty when no clip touches ASCII or the background", () => {
     const stack = resolveAnimateAsciiStack(
       [clip("a", 0, ["tilt"])],
-      ascii(),
-      committedBg,
+      { ascii: ascii(), background: committedBg, filter: "none" },
       null
     )
     expect(stack).toBe(EMPTY_ASCII_STACK)
@@ -90,8 +95,7 @@ describe("resolveAnimateAsciiStack", () => {
         clip("k2", 1000, ["ascii"], { ascii: ascii({ charset: "blocks" }) }),
         clip("k1", 0, ["ascii"], { ascii: ascii({ charset: "dots" }) }),
       ],
-      ascii(),
-      committedBg,
+      { ascii: ascii(), background: committedBg, filter: "none" },
       null
     )
 
@@ -108,8 +112,7 @@ describe("resolveAnimateAsciiStack", () => {
         clip("bg", 500, ["background"], { background: otherBg }),
         clip("k1", 0, ["ascii"], { ascii: ascii({ charset: "blocks" }) }),
       ],
-      ascii(),
-      committedBg,
+      { ascii: ascii(), background: committedBg, filter: "none" },
       null
     )
 
@@ -134,8 +137,7 @@ describe("resolveAnimateAsciiStack", () => {
           background: committedBg,
         }),
       ],
-      ascii(),
-      committedBg,
+      { ascii: ascii(), background: committedBg, filter: "none" },
       null
     )
 
@@ -152,8 +154,7 @@ describe("resolveAnimateAsciiStack", () => {
         clip("k1", 0, ["ascii"], { ascii: ascii({ charset: "dots" }) }),
         clip("k2", 1000, ["ascii"], { ascii: ascii({ charset: "blocks" }) }),
       ],
-      live,
-      committedBg,
+      { ascii: live, background: committedBg, filter: "none" },
       "k1"
     )
 
@@ -174,8 +175,7 @@ describe("resolveAnimateAsciiStack", () => {
         }),
         clip("k2", 1000, ["ascii"], { ascii: ascii({ charset: "dots" }) }),
       ],
-      ascii(),
-      otherBg,
+      { ascii: ascii(), background: otherBg, filter: "none" },
       "k1"
     )
 
@@ -191,13 +191,58 @@ describe("resolveAnimateAsciiStack", () => {
         clip("k1", 0, ["ascii"], { ascii: ascii(), background: committedBg }),
         clip("bg", 1000, ["background"], { background: otherBg }),
       ],
-      ascii(),
-      committedBg,
+      { ascii: ascii(), background: committedBg, filter: "none" },
       null
     )
 
     expect(stack.layers[0].background).toEqual(committedBg)
     expect(stack.layers[1].background).toEqual(otherBg)
+  })
+
+  it("gives a filter keyframe its own layer and carries the preset forward", () => {
+    // An active ASCII layer COVERS the background, so animating the filter on
+    // the hidden background beneath would show nothing.
+    const stack = resolveAnimateAsciiStack(
+      [
+        clip("k1", 0, ["ascii"], { ascii: ascii() }),
+        clip("fx", 1000, ["filter"], { filter: "noir" }),
+        clip("k2", 2000, ["ascii"], { ascii: ascii({ charset: "dots" }) }),
+      ],
+      { ascii: ascii(), background: committedBg, filter: "none" },
+      null
+    )
+
+    expect(stack.layers.map((l) => l.id)).toEqual(["k1", "fx", "k2"])
+    expect(stack.layers.map((l) => l.filter)).toEqual(["none", "noir", "noir"])
+  })
+
+  it("holds the layer in force when the selected keyframe owns nothing of its own", () => {
+    // Selecting a tilt-only keyframe between two ASCII keyframes must preview
+    // the state at ITS point on the timeline, not the timeline's end state.
+    const clips = [
+      clip("k1", 0, ["ascii"], { ascii: ascii({ charset: "blocks" }) }),
+      clip("tilt", 500, ["tilt"]),
+      clip("k2", 1000, ["ascii"], { ascii: ascii({ charset: "stars" }) }),
+    ]
+    const committed = {
+      ascii: ascii(),
+      background: committedBg,
+      filter: "none" as const,
+    }
+
+    const mid = resolveAnimateAsciiStack(clips, committed, "tilt")
+    expect(mid.layers.map((l) => l.restOpaque)).toEqual([true, false])
+    expect(mid.layers[0].ascii.charset).toBe("blocks")
+    expect(mid.baseRestOpaque).toBe(false)
+
+    // A selection before every ASCII keyframe falls back to the base layer.
+    const early = resolveAnimateAsciiStack(
+      [clip("tilt", 0, ["tilt"]), clips[2]],
+      committed,
+      "tilt"
+    )
+    expect(early.layers.every((l) => !l.restOpaque)).toBe(true)
+    expect(early.baseRestOpaque).toBe(true)
   })
 
   it("holds the last layer at rest when no keyframe is open", () => {
@@ -206,8 +251,7 @@ describe("resolveAnimateAsciiStack", () => {
         clip("k1", 0, ["ascii"], { ascii: ascii() }),
         clip("k2", 1000, ["ascii"], { ascii: ascii({ enabled: false }) }),
       ],
-      ascii(),
-      committedBg,
+      { ascii: ascii(), background: committedBg, filter: "none" },
       null
     )
     expect(stack.layers.map((l) => l.restOpaque)).toEqual([false, true])

--- a/tests/lib/editor/animation-ascii.test.ts
+++ b/tests/lib/editor/animation-ascii.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  DEFAULT_BACKDROP_ASCII,
+  ASCII_MAX_RESOLUTION,
+  ASCII_MIN_RESOLUTION,
+  normalizeAsciiResolution,
+} from "@/lib/editor/ascii-backdrop"
+import {
+  asciiDiffer,
+  EMPTY_ASCII_STACK,
+  resolveAnimateAsciiStack,
+} from "@/lib/editor/animation-playback"
+import { DEFAULT_CANVAS_BASE } from "@/lib/editor/store/defaults"
+import type {
+  AnimationClip,
+  BackdropAscii,
+  Background,
+} from "@/lib/editor/state-types"
+
+const committedBg: Background = {
+  type: "gradient",
+  value: "linear-gradient(#000,#fff)",
+}
+const otherBg: Background = { type: "solid", value: "#123456" }
+
+const ascii = (over: Partial<BackdropAscii> = {}): BackdropAscii => ({
+  ...DEFAULT_BACKDROP_ASCII,
+  enabled: true,
+  ...over,
+})
+
+const clip = (
+  id: string,
+  startMs: number,
+  effects: AnimationClip["effects"],
+  pose?: Partial<{ ascii: BackdropAscii; background: Background }>
+): AnimationClip => ({
+  id,
+  startMs,
+  durationMs: 500,
+  target: { scope: "main" },
+  effects,
+  baseline: {
+    ...DEFAULT_CANVAS_BASE.backdrop,
+    tilt: DEFAULT_CANVAS_BASE.tilt,
+    scale: DEFAULT_CANVAS_BASE.scale,
+    screenshotPosition: DEFAULT_CANVAS_BASE.screenshotPosition,
+    screenshotOffset: DEFAULT_CANVAS_BASE.screenshotOffset,
+    padding: DEFAULT_CANVAS_BASE.padding,
+    canvasBorderRadius: DEFAULT_CANVAS_BASE.canvasBorderRadius,
+    shadow: DEFAULT_CANVAS_BASE.shadow,
+    backdropEffects: DEFAULT_CANVAS_BASE.backdrop.effects,
+    background: committedBg,
+    ascii: DEFAULT_BACKDROP_ASCII,
+    slots: {},
+  },
+  pose: pose
+    ? {
+        ...DEFAULT_CANVAS_BASE.backdrop,
+        tilt: DEFAULT_CANVAS_BASE.tilt,
+        scale: DEFAULT_CANVAS_BASE.scale,
+        screenshotPosition: DEFAULT_CANVAS_BASE.screenshotPosition,
+        screenshotOffset: DEFAULT_CANVAS_BASE.screenshotOffset,
+        padding: DEFAULT_CANVAS_BASE.padding,
+        canvasBorderRadius: DEFAULT_CANVAS_BASE.canvasBorderRadius,
+        shadow: DEFAULT_CANVAS_BASE.shadow,
+        backdropEffects: DEFAULT_CANVAS_BASE.backdrop.effects,
+        background: pose.background ?? committedBg,
+        ascii: pose.ascii,
+        slots: {},
+      }
+    : undefined,
+})
+
+describe("resolveAnimateAsciiStack", () => {
+  it("is empty when no clip touches ASCII or the background", () => {
+    const stack = resolveAnimateAsciiStack(
+      [clip("a", 0, ["tilt"])],
+      ascii(),
+      committedBg,
+      null
+    )
+    expect(stack).toBe(EMPTY_ASCII_STACK)
+  })
+
+  it("builds one layer per ASCII keyframe, easing from the first clip's baseline", () => {
+    const stack = resolveAnimateAsciiStack(
+      [
+        clip("k2", 1000, ["ascii"], { ascii: ascii({ charset: "blocks" }) }),
+        clip("k1", 0, ["ascii"], { ascii: ascii({ charset: "dots" }) }),
+      ],
+      ascii(),
+      committedBg,
+      null
+    )
+
+    // Chronological, bottom → top, regardless of input order.
+    expect(stack.layers.map((l) => l.id)).toEqual(["k1", "k2"])
+    expect(stack.base).toEqual(DEFAULT_BACKDROP_ASCII)
+    expect(stack.layers[0].ascii.charset).toBe("dots")
+    expect(stack.layers[1].ascii.charset).toBe("blocks")
+  })
+
+  it("gives a background keyframe its own layer so the glyphs follow the swap", () => {
+    const stack = resolveAnimateAsciiStack(
+      [
+        clip("bg", 500, ["background"], { background: otherBg }),
+        clip("k1", 0, ["ascii"], { ascii: ascii({ charset: "blocks" }) }),
+      ],
+      ascii(),
+      committedBg,
+      null
+    )
+
+    expect(stack.layers.map((l) => l.id)).toEqual(["k1", "bg"])
+    expect(stack.layers[0].background).toEqual(committedBg)
+    expect(stack.layers[1].background).toEqual(otherBg)
+    // The background-only keyframe carries the ASCII in force at that point,
+    // rather than blanking the glyphs mid-timeline.
+    expect(stack.layers[1].ascii.charset).toBe("blocks")
+    expect(stack.layers[1].ascii.enabled).toBe(true)
+  })
+
+  it("shows only the selected keyframe's layer at rest, and reads it live", () => {
+    const live = ascii({ charset: "stars", resolution: 120 })
+    const stack = resolveAnimateAsciiStack(
+      [
+        clip("k1", 0, ["ascii"], { ascii: ascii({ charset: "dots" }) }),
+        clip("k2", 1000, ["ascii"], { ascii: ascii({ charset: "blocks" }) }),
+      ],
+      live,
+      committedBg,
+      "k1"
+    )
+
+    expect(stack.layers.map((l) => l.restOpaque)).toEqual([true, false])
+    // The open keyframe renders the committed (being-edited) value.
+    expect(stack.layers[0].ascii).toBe(live)
+  })
+
+  it("holds the last layer at rest when no keyframe is open", () => {
+    const stack = resolveAnimateAsciiStack(
+      [
+        clip("k1", 0, ["ascii"], { ascii: ascii() }),
+        clip("k2", 1000, ["ascii"], { ascii: ascii({ enabled: false }) }),
+      ],
+      ascii(),
+      committedBg,
+      null
+    )
+    expect(stack.layers.map((l) => l.restOpaque)).toEqual([false, true])
+  })
+})
+
+describe("asciiDiffer", () => {
+  it("sees every rendered field", () => {
+    const base = ascii()
+    expect(asciiDiffer(base, { ...base })).toBe(false)
+    expect(asciiDiffer(base, { ...base, enabled: false })).toBe(true)
+    expect(asciiDiffer(base, { ...base, resolution: 150 })).toBe(true)
+    expect(asciiDiffer(base, { ...base, charset: "binary" })).toBe(true)
+    expect(asciiDiffer(base, { ...base, colored: !base.colored })).toBe(true)
+    expect(asciiDiffer(base, { ...base, inverted: !base.inverted })).toBe(true)
+    expect(asciiDiffer(base, { ...base, color: "#FF0000" })).toBe(true)
+  })
+})
+
+describe("normalizeAsciiResolution", () => {
+  it("reads its range from the shared value schema", () => {
+    expect(ASCII_MIN_RESOLUTION).toBe(20)
+    expect(ASCII_MAX_RESOLUTION).toBe(200)
+  })
+
+  it("clamps and rounds anything the UI or a draft can hand it", () => {
+    expect(normalizeAsciiResolution(5)).toBe(ASCII_MIN_RESOLUTION)
+    expect(normalizeAsciiResolution(9999)).toBe(ASCII_MAX_RESOLUTION)
+    expect(normalizeAsciiResolution(90.6)).toBe(91)
+    expect(normalizeAsciiResolution(Number.NaN)).toBe(
+      DEFAULT_BACKDROP_ASCII.resolution
+    )
+  })
+})

--- a/tests/lib/editor/animation-ascii.test.ts
+++ b/tests/lib/editor/animation-ascii.test.ts
@@ -122,6 +122,29 @@ describe("resolveAnimateAsciiStack", () => {
     expect(stack.layers[1].ascii.enabled).toBe(true)
   })
 
+  it("carries a background keyframe forward onto later ASCII-only keyframes", () => {
+    // The ASCII keyframe's own pose still holds the pre-swap background (a
+    // captured pose carries every axis, owned or not). Playback shows the
+    // swapped background at that point, so the glyphs must too.
+    const stack = resolveAnimateAsciiStack(
+      [
+        clip("bg", 0, ["background"], { background: otherBg }),
+        clip("k1", 1000, ["ascii"], {
+          ascii: ascii({ charset: "dots" }),
+          background: committedBg,
+        }),
+      ],
+      ascii(),
+      committedBg,
+      null
+    )
+
+    expect(stack.layers.map((l) => l.id)).toEqual(["bg", "k1"])
+    expect(stack.layers[0].background).toEqual(otherBg)
+    expect(stack.layers[1].background).toEqual(otherBg)
+    expect(stack.layers[1].ascii.charset).toBe("dots")
+  })
+
   it("shows only the selected keyframe's layer at rest, and reads it live", () => {
     const live = ascii({ charset: "stars", resolution: 120 })
     const stack = resolveAnimateAsciiStack(
@@ -157,8 +180,24 @@ describe("resolveAnimateAsciiStack", () => {
     )
 
     expect(stack.layers[0].background).toEqual(otherBg)
-    // Unselected keyframes still read their own stored pose.
-    expect(stack.layers[1].background).toEqual(committedBg)
+    // The later ASCII-only keyframe doesn't own the background, so it inherits
+    // the live edit rather than re-asserting the background in its own pose.
+    expect(stack.layers[1].background).toEqual(otherBg)
+  })
+
+  it("keeps a later background keyframe's own swap", () => {
+    const stack = resolveAnimateAsciiStack(
+      [
+        clip("k1", 0, ["ascii"], { ascii: ascii(), background: committedBg }),
+        clip("bg", 1000, ["background"], { background: otherBg }),
+      ],
+      ascii(),
+      committedBg,
+      null
+    )
+
+    expect(stack.layers[0].background).toEqual(committedBg)
+    expect(stack.layers[1].background).toEqual(otherBg)
   })
 
   it("holds the last layer at rest when no keyframe is open", () => {

--- a/tests/lib/editor/animation-ascii.test.ts
+++ b/tests/lib/editor/animation-ascii.test.ts
@@ -199,6 +199,45 @@ describe("resolveAnimateAsciiStack", () => {
     expect(stack.layers[1].background).toEqual(otherBg)
   })
 
+  it("reveals each axis from the first clip that owns it", () => {
+    // Baselines are captured per clip at different times, so the ASCII-only
+    // keyframe's baseline background can differ from the background keyframe's.
+    // The base layer has to sample the one the background stack renders (which
+    // reads bgClips[0]'s baseline), or the pre-keyframe glyphs would be drawn
+    // from a background nobody is looking at.
+    const asciiFirst = clip("k1", 0, ["ascii"], { ascii: ascii() })
+    const bgLater: AnimationClip = {
+      ...clip("bg", 1000, ["background"], { background: otherBg }),
+      baseline: {
+        ...clip("bg", 1000, ["background"]).baseline!,
+        background: otherBg,
+      },
+    }
+
+    const stack = resolveAnimateAsciiStack(
+      [asciiFirst, bgLater],
+      { ascii: ascii(), background: committedBg, filter: "none" },
+      null
+    )
+
+    // asciiFirst's baseline says committedBg; the background stack reveals from
+    // bgLater's baseline, so the ASCII base must too.
+    expect(stack.baseBackground).toEqual(otherBg)
+    expect(stack.base).toEqual(DEFAULT_BACKDROP_ASCII)
+  })
+
+  it("falls back to the committed values when no clip owns an axis", () => {
+    const stack = resolveAnimateAsciiStack(
+      [clip("k1", 0, ["ascii"], { ascii: ascii() })],
+      { ascii: ascii(), background: committedBg, filter: "bw" },
+      null
+    )
+    // No background or filter keyframe exists, so both hold at the committed
+    // value for the whole timeline.
+    expect(stack.baseBackground).toEqual(committedBg)
+    expect(stack.baseFilter).toBe("bw")
+  })
+
   it("gives a filter keyframe its own layer and carries the preset forward", () => {
     // An active ASCII layer COVERS the background, so animating the filter on
     // the hidden background beneath would show nothing.

--- a/tests/lib/editor/ascii-backdrop.test.ts
+++ b/tests/lib/editor/ascii-backdrop.test.ts
@@ -193,4 +193,20 @@ describe("waitForAsciiBackdrops", () => {
     await Promise.all([sample, wait])
     expect(order).toEqual(["sample", "wait"])
   })
+
+  it("waits for a sample queued while an earlier one was settling", async () => {
+    const order: string[] = []
+    const bg: Background = { type: "solid", value: "#0a0a0a" }
+
+    const first = sampleBackgroundPixels(bg, 4, 2).then(() => {
+      order.push("first")
+      // A resolution change mid-wait queues another sample; returning before
+      // it settles would hand the exporter the half-updated grid.
+      return sampleBackgroundPixels(bg, 8, 4).then(() => order.push("second"))
+    })
+    const wait = waitForAsciiBackdrops().then(() => order.push("wait"))
+
+    await Promise.all([first, wait])
+    expect(order).toEqual(["first", "second", "wait"])
+  })
 })

--- a/tests/lib/editor/ascii-backdrop.test.ts
+++ b/tests/lib/editor/ascii-backdrop.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ASCII_CHARSETS,
+  ASCII_CELL_ASPECT,
+  asciiPlateColor,
+  asciiRowCount,
+  DEFAULT_BACKDROP_ASCII,
+  gridFromImageData,
+  isAsciiBackdropActive,
+  resolveBackdropAscii,
+} from "@/lib/editor/ascii-backdrop"
+import type { Background } from "@/lib/editor/state-types"
+
+function pixels(colors: [number, number, number, number][]): Uint8ClampedArray {
+  return new Uint8ClampedArray(colors.flat())
+}
+
+describe("ascii backdrop grid", () => {
+  it("maps dark pixels to the sparse end of the ramp and bright ones to the dense end", () => {
+    const ramp = ASCII_CHARSETS.standard
+    const grid = gridFromImageData(
+      pixels([
+        [0, 0, 0, 255],
+        [255, 255, 255, 255],
+      ]),
+      2,
+      1,
+      { charset: "standard", inverted: false, colored: false }
+    )
+    expect(grid.chars).toBe(`${ramp[0]}${ramp[ramp.length - 1]}`)
+  })
+
+  it("reverses the ramp when inverted", () => {
+    const ramp = ASCII_CHARSETS.standard
+    const grid = gridFromImageData(
+      pixels([
+        [0, 0, 0, 255],
+        [255, 255, 255, 255],
+      ]),
+      2,
+      1,
+      { charset: "standard", inverted: true, colored: false }
+    )
+    expect(grid.chars).toBe(`${ramp[ramp.length - 1]}${ramp[0]}`)
+  })
+
+  it("treats transparent pixels as dark regardless of their rgb", () => {
+    const grid = gridFromImageData(pixels([[255, 255, 255, 0]]), 1, 1, {
+      charset: "standard",
+      inverted: false,
+      colored: false,
+    })
+    expect(grid.chars).toBe(ASCII_CHARSETS.standard[0])
+  })
+
+  it("emits one quantized colour per cell only when coloured", () => {
+    const source = pixels([
+      [200, 10, 10, 255],
+      [201, 11, 11, 255],
+    ])
+    const colored = gridFromImageData(source, 2, 1, {
+      charset: "blocks",
+      inverted: false,
+      colored: true,
+    })
+    expect(colored.colors).toHaveLength(2)
+    // Near-identical neighbours quantize to one value so runs can merge.
+    expect(colored.colors[0]).toBe(colored.colors[1])
+
+    const mono = gridFromImageData(source, 2, 1, {
+      charset: "blocks",
+      inverted: false,
+      colored: false,
+    })
+    expect(mono.colors).toHaveLength(0)
+  })
+
+  it("fills the grid for every charset", () => {
+    for (const charset of Object.keys(
+      ASCII_CHARSETS
+    ) as (keyof typeof ASCII_CHARSETS)[]) {
+      const grid = gridFromImageData(
+        pixels([
+          [0, 0, 0, 255],
+          [128, 128, 128, 255],
+          [255, 255, 255, 255],
+          [64, 64, 64, 255],
+        ]),
+        2,
+        2,
+        { charset, inverted: false, colored: false }
+      )
+      expect(grid.chars).toHaveLength(4)
+      expect(
+        [...grid.chars].every((c) => ASCII_CHARSETS[charset].includes(c))
+      ).toBe(true)
+    }
+  })
+})
+
+describe("ascii plate colour", () => {
+  it("darkens the darkest sampled tone so the glyphs read against it", () => {
+    const plate = asciiPlateColor(
+      pixels([
+        [200, 200, 200, 255],
+        [40, 60, 100, 255],
+      ]),
+      2
+    )
+    expect(plate).toBe("rgb(22,33,55)")
+  })
+
+  it("treats transparent samples as black rather than their rgb", () => {
+    expect(asciiPlateColor(pixels([[255, 255, 255, 0]]), 1)).toBe("rgb(0,0,0)")
+  })
+})
+
+describe("ascii backdrop layout", () => {
+  it("derives rows from the aspect ratio, not the pixel size", () => {
+    expect(asciiRowCount(80, 1600, 900)).toBe(asciiRowCount(80, 800, 450))
+  })
+
+  it("keeps cells twice as tall as they are wide", () => {
+    const cols = 100
+    const width = 1000
+    const height = 1000
+    const rows = asciiRowCount(cols, width, height)
+    const cellAspect = width / cols / (height / rows)
+    expect(cellAspect).toBeCloseTo(ASCII_CELL_ASPECT, 5)
+  })
+
+  it("never returns zero rows for a rendered canvas", () => {
+    expect(asciiRowCount(200, 500, 4)).toBe(1)
+    expect(asciiRowCount(80, 0, 0)).toBe(0)
+  })
+})
+
+describe("ascii backdrop state", () => {
+  it("fills missing fields from the defaults on legacy drafts", () => {
+    expect(resolveBackdropAscii(undefined)).toEqual(DEFAULT_BACKDROP_ASCII)
+    expect(
+      resolveBackdropAscii({ enabled: true, charset: "blocks" } as never)
+    ).toMatchObject({
+      enabled: true,
+      charset: "blocks",
+      resolution: DEFAULT_BACKDROP_ASCII.resolution,
+    })
+  })
+
+  it("stays inactive without a background to sample", () => {
+    const none: Background = { type: "none", value: "" }
+    const gradient: Background = {
+      type: "gradient",
+      value: "linear-gradient(#000,#fff)",
+    }
+    expect(
+      isAsciiBackdropActive({ ...DEFAULT_BACKDROP_ASCII, enabled: true }, none)
+    ).toBe(false)
+    expect(
+      isAsciiBackdropActive(
+        { ...DEFAULT_BACKDROP_ASCII, enabled: true },
+        gradient
+      )
+    ).toBe(true)
+    expect(isAsciiBackdropActive(undefined, gradient)).toBe(false)
+  })
+})

--- a/tests/lib/editor/ascii-backdrop.test.ts
+++ b/tests/lib/editor/ascii-backdrop.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vitest"
 import {
   ASCII_CHARSETS,
   ASCII_CELL_ASPECT,
+  ASCII_MAX_CELLS,
+  ASCII_MIN_RESOLUTION,
+  asciiGridSize,
   asciiPlateColor,
   asciiRowCount,
   DEFAULT_BACKDROP_ASCII,
@@ -208,5 +211,29 @@ describe("waitForAsciiBackdrops", () => {
 
     await Promise.all([first, wait])
     expect(order).toEqual(["first", "second", "wait"])
+  })
+})
+
+describe("asciiGridSize", () => {
+  it("leaves a landscape canvas at its requested resolution", () => {
+    const { cols, rows } = asciiGridSize(200, 1600, 900)
+    expect(cols).toBe(200)
+    expect(cols * rows).toBeLessThanOrEqual(ASCII_MAX_CELLS)
+  })
+
+  it("trims columns on a tall canvas, where rows multiply the cell count", () => {
+    // 200 columns on 9:16 is ~36k cells before the budget, and Animate mode
+    // mounts one grid per ASCII/background/filter keyframe.
+    const unbounded = 200 * asciiRowCount(200, 900, 1600)
+    expect(unbounded).toBeGreaterThan(ASCII_MAX_CELLS)
+
+    const { cols, rows } = asciiGridSize(200, 900, 1600)
+    expect(cols).toBeLessThan(200)
+    expect(cols * rows).toBeLessThanOrEqual(ASCII_MAX_CELLS)
+  })
+
+  it("never trims below the minimum resolution", () => {
+    const { cols } = asciiGridSize(200, 10, 40000)
+    expect(cols).toBeGreaterThanOrEqual(ASCII_MIN_RESOLUTION)
   })
 })

--- a/tests/lib/editor/ascii-backdrop.test.ts
+++ b/tests/lib/editor/ascii-backdrop.test.ts
@@ -173,12 +173,36 @@ describe("ascii backdrop state", () => {
 })
 
 describe("waitForAsciiBackdrops", () => {
-  it("resolves straight away when nothing is sampling", async () => {
+  // Must stay the first test that touches the module's sampling state: it
+  // asserts the never-sampled path, which no later sample can restore.
+  it("resolves straight away when nothing has ever sampled", async () => {
     let done = false
     await waitForAsciiBackdrops().then(() => {
       done = true
     })
     expect(done).toBe(true)
+  })
+
+  it("still waits for a paint after the last sample has settled", async () => {
+    // The pending set empties an earlier microtask than the setPixels that
+    // draws the result, so an empty set is not proof the glyphs are in the DOM.
+    // Export reads the painted DOM, so the commit wait has to run anyway.
+    await sampleBackgroundPixels({ type: "solid", value: "#111" }, 4, 2)
+    // Drain the microtasks that retire the tracking entry, so the pending set
+    // is genuinely empty here — the exact state the early return keyed on.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const order: string[] = []
+    const frame = new Promise<void>((resolve) =>
+      requestAnimationFrame(() => {
+        order.push("frame")
+        resolve()
+      })
+    )
+    const wait = waitForAsciiBackdrops().then(() => order.push("wait"))
+
+    await Promise.all([frame, wait])
+    expect(order).toEqual(["frame", "wait"])
   })
 
   it("does not resolve until an in-flight sample has settled", async () => {

--- a/tests/lib/editor/ascii-backdrop.test.ts
+++ b/tests/lib/editor/ascii-backdrop.test.ts
@@ -9,6 +9,8 @@ import {
   gridFromImageData,
   isAsciiBackdropActive,
   resolveBackdropAscii,
+  sampleBackgroundPixels,
+  waitForAsciiBackdrops,
 } from "@/lib/editor/ascii-backdrop"
 import type { Background } from "@/lib/editor/state-types"
 
@@ -164,5 +166,31 @@ describe("ascii backdrop state", () => {
       )
     ).toBe(true)
     expect(isAsciiBackdropActive(undefined, gradient)).toBe(false)
+  })
+})
+
+describe("waitForAsciiBackdrops", () => {
+  it("resolves straight away when nothing is sampling", async () => {
+    let done = false
+    await waitForAsciiBackdrops().then(() => {
+      done = true
+    })
+    expect(done).toBe(true)
+  })
+
+  it("does not resolve until an in-flight sample has settled", async () => {
+    const order: string[] = []
+    // jsdom has no 2d context, so this settles fast — the point is that the
+    // wait observes it at all. Export clones the DOM the instant this resolves,
+    // so a wait that races the sample would clone a backdrop with no glyphs.
+    const sample = sampleBackgroundPixels(
+      { type: "gradient", value: "linear-gradient(#000,#fff)" },
+      4,
+      2
+    ).then(() => order.push("sample"))
+    const wait = waitForAsciiBackdrops().then(() => order.push("wait"))
+
+    await Promise.all([sample, wait])
+    expect(order).toEqual(["sample", "wait"])
   })
 })

--- a/tests/lib/editor/store/backdrop-ascii.test.ts
+++ b/tests/lib/editor/store/backdrop-ascii.test.ts
@@ -141,6 +141,26 @@ describe("ascii backdrop draft hydration", () => {
     )
   })
 
+  it("clamps a persisted resolution outside the schema's range", () => {
+    const canvas = createCanvas("saved", { x: 0, y: 0 })
+    const hydrate = (resolution: number) =>
+      normalizeEditorState({
+        activeCanvasId: "saved",
+        canvases: [
+          {
+            ...canvas,
+            backdrop: {
+              ...canvas.backdrop,
+              ascii: { ...DEFAULT_BACKDROP_ASCII, resolution },
+            },
+          },
+        ],
+      }).canvases[0]?.backdrop.ascii?.resolution
+
+    expect(hydrate(9999)).toBe(200)
+    expect(hydrate(1)).toBe(20)
+  })
+
   it("keeps saved ASCII settings and backfills fields added later", () => {
     const canvas = createCanvas("saved", { x: 0, y: 0 })
     const normalized = normalizeEditorState({

--- a/tests/lib/editor/store/backdrop-ascii.test.ts
+++ b/tests/lib/editor/store/backdrop-ascii.test.ts
@@ -75,6 +75,57 @@ describe("setBackdropAscii", () => {
   })
 })
 
+describe("ascii resolution validation", () => {
+  beforeEach(() => store.getState().reset())
+
+  it("clamps and rounds whatever the UI hands the store", () => {
+    store
+      .getState()
+      .setBackdropAscii({ ...DEFAULT_BACKDROP_ASCII, resolution: 9999 })
+    expect(activeCanvas().backdrop.ascii?.resolution).toBe(200)
+
+    store
+      .getState()
+      .setBackdropAscii({ ...DEFAULT_BACKDROP_ASCII, resolution: 4 })
+    expect(activeCanvas().backdrop.ascii?.resolution).toBe(20)
+
+    store
+      .getState()
+      .setBackdropAscii({ ...DEFAULT_BACKDROP_ASCII, resolution: 88.7 })
+    expect(activeCanvas().backdrop.ascii?.resolution).toBe(89)
+  })
+})
+
+describe("ascii in animate mode", () => {
+  beforeEach(() => store.getState().reset())
+
+  it("registers the open keyframe as owning the effect", () => {
+    const clipId = store.getState().addAnimationClip()
+    store.getState().setIsAnimateMode(true)
+    store.getState().selectAnimationClip(clipId)
+
+    store
+      .getState()
+      .setBackdropAscii({ ...DEFAULT_BACKDROP_ASCII, enabled: true })
+
+    // The open keyframe reads its value from the committed canvas (poses are
+    // resolved later) — ownership is what makes it animate at all.
+    const clip = activeCanvas().animation?.clips.find((c) => c.id === clipId)
+    expect(clip?.effects ?? []).toContain("ascii")
+    expect(activeCanvas().backdrop.ascii?.enabled).toBe(true)
+  })
+
+  it("captures ASCII in a clip's baseline so it eases from the committed look", () => {
+    store
+      .getState()
+      .setBackdropAscii({ ...DEFAULT_BACKDROP_ASCII, charset: "blocks" })
+    const clipId = store.getState().addAnimationClip()
+
+    const clip = activeCanvas().animation?.clips.find((c) => c.id === clipId)
+    expect(clip?.baseline?.ascii?.charset).toBe("blocks")
+  })
+})
+
 describe("ascii backdrop draft hydration", () => {
   it("fills in the defaults for drafts saved before ASCII existed", () => {
     const canvas = createCanvas("legacy", { x: 0, y: 0 })

--- a/tests/lib/editor/store/backdrop-ascii.test.ts
+++ b/tests/lib/editor/store/backdrop-ascii.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  DEFAULT_BACKDROP_ASCII,
+  resolveBackdropAscii,
+} from "@/lib/editor/ascii-backdrop"
+import { useEditorStore } from "@/lib/editor/store"
+import { createCanvas } from "@/lib/editor/store/defaults"
+import { normalizeEditorState } from "@/lib/editor/store/draft-persistence"
+
+const store = useEditorStore
+
+const activeCanvas = () => {
+  const s = store.getState().present
+  return s.canvases.find((c) => c.id === s.activeCanvasId)!
+}
+
+describe("setBackdropAscii", () => {
+  beforeEach(() => store.getState().reset())
+
+  it("writes the ASCII settings onto the active canvas and is undoable", () => {
+    store.getState().setBackdropAscii({
+      ...DEFAULT_BACKDROP_ASCII,
+      enabled: true,
+      charset: "blocks",
+      resolution: 140,
+    })
+
+    expect(activeCanvas().backdrop.ascii).toMatchObject({
+      enabled: true,
+      charset: "blocks",
+      resolution: 140,
+    })
+
+    store.getState().undo()
+    expect(activeCanvas().backdrop.ascii?.enabled).toBe(false)
+  })
+
+  it("leaves the rest of the backdrop untouched", () => {
+    store.getState().setBackdropPattern({
+      ids: [2],
+      intensity: 70,
+      thickness: 2,
+      color: "#FF0000",
+    })
+    store
+      .getState()
+      .setBackdropAscii({ ...DEFAULT_BACKDROP_ASCII, enabled: true })
+
+    const { backdrop } = activeCanvas()
+    expect(backdrop.pattern).toMatchObject({ ids: [2], intensity: 70 })
+    expect(backdrop.ascii?.enabled).toBe(true)
+  })
+
+  it("targets a specific canvas when one is named", () => {
+    const otherId = store.getState().addCanvas()
+    expect(otherId).toBeTruthy()
+    const firstId = store.getState().present.canvases[0].id
+    store.getState().setActiveCanvasId(firstId)
+
+    store
+      .getState()
+      .setBackdropAscii(
+        { ...DEFAULT_BACKDROP_ASCII, enabled: true },
+        otherId ?? undefined
+      )
+
+    const canvases = store.getState().present.canvases
+    expect(
+      canvases.find((c) => c.id === otherId)?.backdrop.ascii?.enabled
+    ).toBe(true)
+    expect(
+      canvases.find((c) => c.id === firstId)?.backdrop.ascii?.enabled
+    ).toBe(false)
+  })
+})
+
+describe("ascii backdrop draft hydration", () => {
+  it("fills in the defaults for drafts saved before ASCII existed", () => {
+    const canvas = createCanvas("legacy", { x: 0, y: 0 })
+    const { ascii: _dropped, ...legacyBackdrop } = canvas.backdrop
+
+    const normalized = normalizeEditorState({
+      activeCanvasId: "legacy",
+      canvases: [{ ...canvas, backdrop: legacyBackdrop }],
+    })
+
+    expect(normalized.canvases[0]?.backdrop.ascii).toEqual(
+      DEFAULT_BACKDROP_ASCII
+    )
+  })
+
+  it("keeps saved ASCII settings and backfills fields added later", () => {
+    const canvas = createCanvas("saved", { x: 0, y: 0 })
+    const normalized = normalizeEditorState({
+      activeCanvasId: "saved",
+      canvases: [
+        {
+          ...canvas,
+          backdrop: {
+            ...canvas.backdrop,
+            ascii: { enabled: true, charset: "dots" } as never,
+          },
+        },
+      ],
+    })
+
+    expect(normalized.canvases[0]?.backdrop.ascii).toEqual(
+      resolveBackdropAscii({ enabled: true, charset: "dots" } as never)
+    )
+  })
+})


### PR DESCRIPTION
Turns any canvas background — gradient, solid, or image — into ASCII art from the Backdrop section, keyframable in Animate mode.

## UI

`Backdrop → Texture` is now one control with two tabs instead of two separate tiles:

- **Pattern** — the existing geometric textures, unchanged.
- **ASCII** — 7 charset tiles (Standard, Dense, Blocks, Binary, Dots, Circles, Stars) plus Off, with **Resolution** (20–200 columns), **Ink** (sample the background's own colours, or one colour of your choosing), and **Ramp** (normal / inverted).

The header reset button is scoped to the active tab, so resetting patterns no longer wipes the ASCII settings and vice versa.

There is deliberately no "colour behind the glyphs" control. The plate is derived from the background's own darkest sampled tone, dimmed — the thing behind the ASCII *is* the background it was sampled from, so a manual picker there was a knob with no good answer.

## How it renders

`lib/editor/ascii-backdrop.ts` + `components/editor/canvas/ascii-backdrop.tsx`

- The background is downsampled to one pixel per character cell. Images go through `drawImage` (cross-origin ones via the existing `/api/export/image` proxy, so the readback canvas isn't tainted); gradients and solids are painted by the browser inside a tiny `<foreignObject>` and read back — cheap, because the grid is only ~90×50. Samples are cached per background + grid size.
- **Glyphs are real DOM text, not a `<canvas>`.** Export rasterizes the DOM at up to 8K; a canvas element would be captured at its own screen-sized resolution and upscaled into mush. Text re-rasterizes sharp at any pixel ratio.
- Font size comes from a runtime-measured monospace advance ratio, so one glyph advance is exactly one cell whichever mono font the platform resolves (Menlo ≈ 0.6, Consolas ≈ 0.55).
- Rows derive from the canvas aspect ratio alone, so editor zoom rescales the glyphs without triggering a resample.
- Coloured cells quantize to 32 levels per channel and merge into runs, keeping a 90-column grid at a few hundred spans instead of ~4,000.

## Animate mode

ASCII is a full `AnimationEffect`, wired through the standard checklist (union → `ClipBaseline` → `DEFAULT_BASELINE` → pose capture/apply/resolve → `commitCanvasEffect` → frame sampler → renderer → timeline icon).

It uses the **crossfade chain** the pattern/portrait/overlay stacks use, not the opaque background stack. That distinction matters: a keyframe that turns ASCII *off* renders an empty layer, and only a chain can fade the layer *beneath* it back out to reveal the untouched background — plain stacked opacity would leave the previous ASCII sitting there forever.

**Background keyframes get an ASCII layer of their own** (`clipOwnsAsciiLayer`). The glyphs are sampled *from* the background, so a background swap under a live ASCII treatment has to re-render the characters rather than restyle a background that the opaque ASCII plate is covering anyway. A background-only keyframe inherits whatever ASCII was in force at that point in the timeline, so the glyphs don't blank mid-animation.

**WebKit/Safari:** every transition is plain `opacity` on a plain element — no blend modes, no `backdrop-filter`, no `mix-blend-mode` — which is the same compositing path the pattern and portrait stacks already take. Playback and export share one sampler (`applyAnimationFrameAtTime`), so preview matches export on every engine.

## State

`backdrop.ascii` is optional on `Backdrop`, so every existing draft, template, and preset keeps type-checking untouched. `resolveBackdropAscii()` fills defaults on read, and draft hydration backfills the field for drafts saved before this existed.

The column count validates through `editorValueSchemas.asciiResolution`; `ASCII_MIN_RESOLUTION` / `ASCII_MAX_RESOLUTION` derive from that schema and the store action clamps and rounds, so the range can't drift between the slider, the writer and the renderer.

## Export timing

Sampling is async, but export rasterizes (stills) or clones (video) whatever is in the DOM at that instant — an export fired right after ASCII was switched on, or right after its background or resolution changed, could capture a backdrop with no glyphs on it. In-flight samples now register centrally, and `rasterizeNodeToCanvas` and `prepareAnimationCapture` await `waitForAsciiBackdrops()` (bounded, plus the frames React needs to commit the grid) before capturing.

## Tests

29 new tests:

- **Grid** — ramp mapping (dark → sparse, bright → dense), inversion, transparent pixels reading as dark rather than as their stale RGB, colour quantization/merging, and every charset producing in-ramp characters.
- **Plate colour** — darkest-tone derivation and alpha handling.
- **Layout** — rows follow aspect not pixel size, cells stay 2:1, never zero rows for a rendered canvas.
- **Animate stack** — chronological layers regardless of clip order, base from the first clip's baseline, background keyframes getting their own layer and carrying the ASCII in force, only the selected keyframe opaque at rest (reading the live value), last layer holding otherwise.
- **Frame vars** — base fades out as the first keyframe fades in, chained keyframes overlap without either going fully opaque or fully gone, the last one holds, and every var clears at rest.
- **Store** — `setBackdropAscii` commits, undoes, targets a named canvas, leaves the rest of the backdrop alone, registers the open keyframe as owning `ascii`, captures ASCII in a clip's baseline, and clamps/rounds the resolution.
- **Drafts** — pre-ASCII drafts hydrate to defaults; saved settings survive with later-added fields backfilled.

Full suite passes (1419 tests), plus `typecheck` and `lint:strict`.

## Changelog

The v2.2.0 entry is now "Glass frames & ASCII backdrops", with items covering the charsets, the tuning controls, keyframing, and export sharpness.

## Verification note

Verified live in the editor. **Not** verified by me: an actual PNG/video export with ASCII enabled, and Safari specifically. The DOM-text rendering and plain-opacity crossfades are chosen precisely so both hold up there, but worth one real export and one Safari pass before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ASCII texture backdrops with configurable character sets, resolution, colors, inversion, and live previews.
  * Added animated ASCII backdrop transitions and crossfades for keyframes and background changes.
  * Improved exported images and animations with sharper, resolution-independent ASCII rendering.
  * Added color swatches and seamless saving/restoring of ASCII backdrop settings across drafts and canvases.

* **Bug Fixes**
  * Improved backdrop rendering reliability during background changes and incomplete sampling.

* **Tests**
  * Added coverage for ASCII rendering, animation, settings updates, exports, and legacy drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds configurable, animatable ASCII canvas backdrops and integrates them with persistence and export readiness.
- Samples backgrounds into resolution-controlled character grids rendered as scalable DOM text.
- Adds texture controls for charset, ink, ramp direction, and validated resolution.
- Carries ASCII state through animation stacks and waits for sampling and React commits before export.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/editor/canvas/ascii-backdrop.tsx | Renders sampled ASCII grids as DOM text and updates them when the background or grid dimensions change. |
| components/editor/canvas/canvas-backdrop.tsx | Integrates committed and animated ASCII layers with background and filter composition. |
| lib/editor/animation-playback.ts | Builds chronological ASCII crossfade layers while resolving each base axis from its first owning keyframe. |
| lib/editor/ascii-backdrop.ts | Implements grid generation, background sampling, caching, resolution normalization, and export-readiness tracking. |
| lib/editor/export.ts | Awaits ASCII sampling and DOM commitment before all relevant export-cloning paths. |
| lib/editor/store/actions/canvas-style.ts | Persists ASCII settings through the standard animation-aware commit path and normalizes resolution. |
| components/editor/inspector/backdrop-section-parts/pattern-control.tsx | Combines pattern and ASCII texture controls with tab-scoped resets and schema-derived resolution bounds. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20shivabhattacharjee%2Ftokokino%20PR%20%2366%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=shivabhattacharjee%2Ftokokino&pr=66&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (6): Last reviewed commit: ["fix(ascii): reveal each base axis from t..."](https://github.com/shivabhattacharjee/tokokino/commit/bc88e0d36b67882ff1a59c3cc319dc33365bf96d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52998000)</sub>

<!-- /greptile_comment -->