### PR TITLE
fix: improve Safari ASCII performance and watermark export

### DIFF
--- a/components/editor/canvas/ascii-backdrop.tsx
+++ b/components/editor/canvas/ascii-backdrop.tsx
@@ -17,6 +17,14 @@ import type { BackdropAscii, Background } from "@/lib/editor/state-types"
 
 type Segment = { text: string; color: string; start: number }
 
+function escapeSvg(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
 /**
  * Merge neighbouring cells that quantized to the same colour so a coloured grid
  * renders as a few hundred spans instead of one per character.
@@ -35,12 +43,67 @@ function rowSegments(grid: AsciiGrid, row: number): Segment[] {
 }
 
 /**
+ * Package the glyph tree as one SVG image resource. Keeping the thousands of
+ * coloured text runs out of the live DOM lets WebKit cache/composite the layer
+ * as a replaced image while the screenshot moves, without sacrificing vector
+ * text when html-to-image captures a high-resolution export.
+ */
+function asciiSvgDataUrl({
+  grid,
+  width,
+  height,
+  cellWidth,
+  cellHeight,
+  fontSize,
+  ascii,
+}: {
+  grid: AsciiGrid
+  width: number
+  height: number
+  cellWidth: number
+  cellHeight: number
+  fontSize: number
+  ascii: BackdropAscii
+}): string | null {
+  if (!(width > 0) || !(height > 0) || !(fontSize > 0)) return null
+
+  const runs: string[] = []
+  for (let row = 0; row < grid.rows; row++) {
+    const y = (row + 0.5) * cellHeight
+    if (!ascii.colored) {
+      const text = grid.chars.slice(row * grid.cols, (row + 1) * grid.cols)
+      const geometry = asciiRunGeometry(0, text.length, cellWidth)
+      runs.push(
+        `<text x="${geometry.x}" y="${y}" textLength="${geometry.width}" lengthAdjust="spacingAndGlyphs" dominant-baseline="central" fill="${escapeSvg(ascii.color)}" xml:space="preserve">${escapeSvg(text)}</text>`
+      )
+      continue
+    }
+
+    for (const segment of rowSegments(grid, row)) {
+      const geometry = asciiRunGeometry(
+        segment.start,
+        segment.text.length,
+        cellWidth
+      )
+      runs.push(
+        `<text x="${geometry.x}" y="${y}" textLength="${geometry.width}" lengthAdjust="spacingAndGlyphs" dominant-baseline="central" fill="${escapeSvg(segment.color)}" xml:space="preserve">${escapeSvg(segment.text)}</text>`
+      )
+    }
+  }
+
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" ` +
+    `font-family="${escapeSvg(ASCII_FONT_FAMILY)}" font-size="${fontSize}" style="font-variant-ligatures:none;overflow:hidden">${runs.join("")}</svg>`
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+}
+
+/**
  * Renders the canvas background as ASCII characters.
  *
- * The glyphs are real DOM text rather than a `<canvas>` because export
+ * The glyphs live in an SVG-backed image rather than a `<canvas>` because export
  * rasterizes the DOM at up to 8K — a canvas would be captured at its own
- * (screen-sized) resolution and upscaled into mush, while text re-renders sharp
- * at any pixel ratio.
+ * (screen-sized) resolution and upscaled into mush, while the SVG re-renders
+ * sharply at any pixel ratio without thousands of live DOM nodes.
  */
 function AsciiBackdropImpl({
   background,
@@ -135,6 +198,18 @@ function AsciiBackdropImpl({
   const fontSize = cellWidth / monospaceAdvanceRatio()
   const userOpacity = (ascii.opacity ?? 100) / 100
   const committedOpacity = `var(--bd-ascii-opacity, ${userOpacity})`
+  const glyphImageUrl = React.useMemo(() => {
+    if (!grid) return null
+    return asciiSvgDataUrl({
+      grid,
+      width: size.width,
+      height: size.height,
+      cellWidth,
+      cellHeight,
+      fontSize,
+      ascii,
+    })
+  }, [ascii, cellHeight, cellWidth, fontSize, grid, size.height, size.width])
 
   return (
     <div
@@ -152,73 +227,28 @@ function AsciiBackdropImpl({
           filter: `${filter ?? "brightness(1)"} opacity(${committedOpacity})`,
         }}
       >
-        {grid ? (
-          <svg
+        {glyphImageUrl ? (
+          <img
             aria-hidden
             data-export-ascii-glyphs="true"
+            src={glyphImageUrl}
+            alt=""
+            draggable={false}
             width={size.width}
             height={size.height}
-            viewBox={`0 0 ${size.width} ${size.height}`}
-            preserveAspectRatio="none"
             style={{
               display: "block",
+              width: size.width,
+              height: size.height,
+              maxWidth: "none",
               overflow: "hidden",
-              fontFamily: ASCII_FONT_FAMILY,
-              fontSize: `${fontSize}px`,
-              fontVariantLigatures: "none",
               transform: asciiResolutionPreviewTransform(
                 displayCols,
                 ascii.resolution
               ),
               transformOrigin: "0 0",
             }}
-          >
-            {Array.from({ length: grid.rows }, (_, row) => {
-              const y = (row + 0.5) * cellHeight
-              if (!ascii.colored) {
-                const text = grid.chars.slice(
-                  row * grid.cols,
-                  (row + 1) * grid.cols
-                )
-                const geometry = asciiRunGeometry(0, text.length, cellWidth)
-                return (
-                  <text
-                    key={row}
-                    x={geometry.x}
-                    y={y}
-                    textLength={geometry.width}
-                    lengthAdjust="spacingAndGlyphs"
-                    dominantBaseline="central"
-                    fill={ascii.color}
-                    xmlSpace="preserve"
-                  >
-                    {text}
-                  </text>
-                )
-              }
-              return rowSegments(grid, row).map((segment) => {
-                const geometry = asciiRunGeometry(
-                  segment.start,
-                  segment.text.length,
-                  cellWidth
-                )
-                return (
-                  <text
-                    key={`${row}:${segment.start}`}
-                    x={geometry.x}
-                    y={y}
-                    textLength={geometry.width}
-                    lengthAdjust="spacingAndGlyphs"
-                    dominantBaseline="central"
-                    fill={segment.color}
-                    xmlSpace="preserve"
-                  >
-                    {segment.text}
-                  </text>
-                )
-              })
-            })}
-          </svg>
+          />
         ) : null}
       </div>
     </div>

--- a/lib/editor/export-clone.ts
+++ b/lib/editor/export-clone.ts
@@ -4,9 +4,15 @@ import {
   neutralizeUnsupportedExportBackdropFilters,
 } from "./export-glass"
 
-export const WATERMARK_LOGO_SRC = "/logo.png"
 const WATERMARK_PREFIX = "Designed by"
 const WATERMARK_APP_NAME = "Tokokino"
+
+export type ExportWatermarkLogoPlacement = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
 
 function makeExportStyle(scopeId: string, neutralizePortraitFx = false) {
   const exportStyle = document.createElement("style")
@@ -50,7 +56,10 @@ function makeExportStyle(scopeId: string, neutralizePortraitFx = false) {
 function appendWatermark(node: HTMLElement, width: number, height: number) {
   const watermark = document.createElement("div")
   const prefix = document.createElement("span")
-  const logo = document.createElement("img")
+  // Keep only a layout placeholder in the foreignObject clone. WebKit can drop
+  // decoded <img> subresources while rasterizing it, so the real logo is drawn
+  // onto the finished canvas at this placeholder's measured position.
+  const logo = document.createElement("span")
   const label = document.createElement("span")
   const minEdge = Math.max(1, Math.min(width, height))
   const scale = Math.max(0.72, Math.min(1.35, minEdge / 720))
@@ -82,12 +91,12 @@ function appendWatermark(node: HTMLElement, width: number, height: number) {
   prefix.style.opacity = "0.78"
   prefix.style.whiteSpace = "nowrap"
 
-  logo.src = WATERMARK_LOGO_SRC
-  logo.alt = ""
+  logo.setAttribute("data-export-watermark-logo", "true")
+  logo.setAttribute("aria-hidden", "true")
   logo.style.width = `${Math.round(20 * scale)}px`
   logo.style.height = `${Math.round(20 * scale)}px`
   logo.style.display = "block"
-  logo.style.filter = "drop-shadow(0 1px 1px rgba(0, 0, 0, 0.18))"
+  logo.style.flexShrink = "0"
 
   label.textContent = WATERMARK_APP_NAME
   label.style.whiteSpace = "nowrap"
@@ -96,6 +105,26 @@ function appendWatermark(node: HTMLElement, width: number, height: number) {
   watermark.appendChild(logo)
   watermark.appendChild(label)
   node.appendChild(watermark)
+}
+
+export function measureExportWatermarkLogo(
+  root: HTMLElement
+): ExportWatermarkLogoPlacement | null {
+  const logo = root.querySelector<HTMLElement>(
+    '[data-export-watermark-logo="true"]'
+  )
+  if (!logo) return null
+
+  const rootRect = root.getBoundingClientRect()
+  const logoRect = logo.getBoundingClientRect()
+  if (!(logoRect.width > 0) || !(logoRect.height > 0)) return null
+
+  return {
+    x: logoRect.left - rootRect.left,
+    y: logoRect.top - rootRect.top,
+    width: logoRect.width,
+    height: logoRect.height,
+  }
 }
 
 export function prepareExportNode(

--- a/lib/editor/export-still.ts
+++ b/lib/editor/export-still.ts
@@ -5,7 +5,11 @@ import {
   rewriteExportAssets,
   waitForExportAssets,
 } from "./export-asset-rewrite"
-import { WATERMARK_LOGO_SRC, prepareExportNode } from "./export-clone"
+import {
+  measureExportWatermarkLogo,
+  prepareExportNode,
+  type ExportWatermarkLogoPlacement,
+} from "./export-clone"
 import {
   COPY_RESOLUTION_WIDTHS,
   EXPORT_FORMAT_EXTENSION,
@@ -32,9 +36,44 @@ import { bakeGlassFrost } from "./export-glass"
 import { canvasToBlob, clipCanvasToRoundedRect } from "./export-raster"
 import { rasterizeExportNode } from "./export-settle"
 import { replaceCloneVideosWithFrames } from "./export-video-frames"
+import { loadWatermarkLogo } from "./animation-export/watermark"
 
 function triggerDownload(url: string, filename: string) {
   triggerAnchorDownload(url, filename)
+}
+
+/**
+ * Paint the logo after the DOM clone has been rasterized. Safari can omit an
+ * image nested in the foreignObject while leaving its flex box and surrounding
+ * text intact; drawing onto the returned canvas removes that decode race.
+ */
+function paintExportWatermarkLogo(
+  canvas: HTMLCanvasElement,
+  placement: ExportWatermarkLogoPlacement | null,
+  renderedWidth: number,
+  renderedHeight: number,
+  logo: HTMLImageElement | null
+): void {
+  if (!placement || !logo || renderedWidth <= 0 || renderedHeight <= 0) return
+  const ctx = canvas.getContext("2d")
+  if (!ctx) return
+
+  const scaleX = canvas.width / renderedWidth
+  const scaleY = canvas.height / renderedHeight
+  ctx.save()
+  ctx.imageSmoothingEnabled = true
+  ctx.imageSmoothingQuality = "high"
+  ctx.shadowColor = "rgba(0, 0, 0, 0.18)"
+  ctx.shadowBlur = Math.max(scaleX, scaleY)
+  ctx.shadowOffsetY = scaleY
+  ctx.drawImage(
+    logo,
+    placement.x * scaleX,
+    placement.y * scaleY,
+    placement.width * scaleX,
+    placement.height * scaleY
+  )
+  ctx.restore()
 }
 
 export async function exportCanvas(
@@ -67,9 +106,9 @@ export async function exportCanvas(
     options
   )
   const { rewrites, preloadUrls } = rewriteExportAssets(exportTarget.node)
-  const assetUrls = options.watermark
-    ? [...preloadUrls, WATERMARK_LOGO_SRC]
-    : preloadUrls
+  const watermarkLogoPromise = options.watermark
+    ? loadWatermarkLogo()
+    : Promise.resolve(null)
 
   // No pixelRatio — rasterizeNodeToCanvas owns the scale (see exportScaleStyle).
   const baseOptions = {
@@ -87,11 +126,15 @@ export async function exportCanvas(
   })
 
   try {
-    await waitForExportAssets(assetUrls)
+    await waitForExportAssets(preloadUrls)
     await embedCloneImages(exportTarget.node)
     await bakeGlassFrost(exportTarget.node, renderedWidth, renderedHeight)
     // After the frost, so its textures are warmed with everything else.
     await warmEmbeddedImageDecodes(exportTarget.node)
+    const watermarkLogo = await watermarkLogoPromise
+    const watermarkPlacement = options.watermark
+      ? measureExportWatermarkLogo(exportTarget.node)
+      : null
     if (format === "png") {
       const canvas = await rasterizeExportNode(
         exportTarget.node,
@@ -100,6 +143,13 @@ export async function exportCanvas(
         renderedHeight,
         outputWidth,
         outputHeight
+      )
+      paintExportWatermarkLogo(
+        canvas,
+        watermarkPlacement,
+        renderedWidth,
+        renderedHeight,
+        watermarkLogo
       )
       const clipped = await clipCanvasToRoundedRect(
         canvas,
@@ -123,6 +173,13 @@ export async function exportCanvas(
         outputHeight,
         "#ffffff"
       )
+      paintExportWatermarkLogo(
+        canvas,
+        watermarkPlacement,
+        renderedWidth,
+        renderedHeight,
+        watermarkLogo
+      )
       const url = canvas.toDataURL("image/jpeg", 0.95)
       triggerDownload(url, filename)
       return filename
@@ -134,6 +191,13 @@ export async function exportCanvas(
       renderedHeight,
       outputWidth,
       outputHeight
+    )
+    paintExportWatermarkLogo(
+      canvas,
+      watermarkPlacement,
+      renderedWidth,
+      renderedHeight,
+      watermarkLogo
     )
     const webpBlob = await canvasToBlob(canvas, "image/webp", 0.95)
     const objectUrl = URL.createObjectURL(webpBlob)
@@ -176,17 +240,21 @@ export async function captureCanvasAsPngBlob(
     options
   )
   const { rewrites, preloadUrls } = rewriteExportAssets(exportTarget.node)
-  const assetUrls = options.watermark
-    ? [...preloadUrls, WATERMARK_LOGO_SRC]
-    : preloadUrls
+  const watermarkLogoPromise = options.watermark
+    ? loadWatermarkLogo()
+    : Promise.resolve(null)
 
   try {
-    await waitForExportAssets(assetUrls)
+    await waitForExportAssets(preloadUrls)
     await embedCloneImages(exportTarget.node)
     replaceCloneVideosWithFrames(node, exportTarget.node)
     await bakeGlassFrost(exportTarget.node, renderedWidth, renderedHeight)
     // After the frost, so its textures are warmed with everything else.
     await warmEmbeddedImageDecodes(exportTarget.node)
+    const watermarkLogo = await watermarkLogoPromise
+    const watermarkPlacement = options.watermark
+      ? measureExportWatermarkLogo(exportTarget.node)
+      : null
 
     // html-to-image is flaky on the first call (fonts/images not yet embedded
     // in the cloned document). Two attempts is the standard workaround.
@@ -206,6 +274,13 @@ export async function captureCanvasAsPngBlob(
           renderedHeight,
           Math.round(renderedWidth * pixelRatio),
           Math.round(renderedHeight * pixelRatio)
+        )
+        paintExportWatermarkLogo(
+          canvas,
+          watermarkPlacement,
+          renderedWidth,
+          renderedHeight,
+          watermarkLogo
         )
         blob = await canvasToBlob(canvas, "image/png")
         if (blob) break

--- a/tests/components/editor/ascii-backdrop.test.tsx
+++ b/tests/components/editor/ascii-backdrop.test.tsx
@@ -35,13 +35,13 @@ class FakeResizeObserver {
   disconnect() {}
 }
 
-describe("AsciiBackdrop fixed-cell SVG rows", () => {
+describe("AsciiBackdrop SVG image", () => {
   afterEach(() => {
     resize = null
     vi.unstubAllGlobals()
   })
 
-  it("gives every rendered row an explicit full-grid text length", async () => {
+  it("renders fixed-cell rows inside one SVG-backed image", async () => {
     vi.stubGlobal("ResizeObserver", FakeResizeObserver)
     const { container } = render(
       <AsciiBackdrop
@@ -67,8 +67,20 @@ describe("AsciiBackdrop fixed-cell SVG rows", () => {
       )
     })
 
-    const svg = container.querySelector("svg")
-    const rows = Array.from(container.querySelectorAll("svg text"))
+    const image = container.querySelector<HTMLImageElement>(
+      'img[data-export-ascii-glyphs="true"]'
+    )
+    expect(image).not.toBeNull()
+    expect(container.querySelector("svg")).toBeNull()
+
+    const source = image?.getAttribute("src") ?? ""
+    const encodedSvg = source.slice(source.indexOf(",") + 1)
+    const svgDocument = new DOMParser().parseFromString(
+      decodeURIComponent(encodedSvg),
+      "image/svg+xml"
+    )
+    const svg = svgDocument.documentElement
+    const rows = Array.from(svgDocument.querySelectorAll("text"))
     expect(svg).toHaveAttribute("viewBox", "0 0 200 100")
     expect(rows).toHaveLength(5)
     for (const row of rows) {

--- a/tests/components/editor/ascii-backdrop.test.tsx
+++ b/tests/components/editor/ascii-backdrop.test.tsx
@@ -81,12 +81,12 @@ describe("AsciiBackdrop SVG image", () => {
     )
     const svg = svgDocument.documentElement
     const rows = Array.from(svgDocument.querySelectorAll("text"))
-    expect(svg).toHaveAttribute("viewBox", "0 0 200 100")
+    expect(svg.getAttribute("viewBox")).toBe("0 0 200 100")
     expect(rows).toHaveLength(5)
     for (const row of rows) {
-      expect(row).toHaveAttribute("x", "0")
-      expect(row).toHaveAttribute("textLength", "200")
-      expect(row).toHaveAttribute("lengthAdjust", "spacingAndGlyphs")
+      expect(row.getAttribute("x")).toBe("0")
+      expect(row.getAttribute("textLength")).toBe("200")
+      expect(row.getAttribute("lengthAdjust")).toBe("spacingAndGlyphs")
     }
   })
 })


### PR DESCRIPTION
## Summary
Improves Safari editing and export reliability by flattening the live ASCII backdrop into a single SVG-backed image and drawing the still-export watermark logo after DOM rasterization.

## Type of Change
- [x] fix
- [ ] refactor
- [ ] delete
- [x] optimised
- [ ] docs

## Related Issues
None.

## Changes Made
- replace thousands of live ASCII SVG text nodes with one SVG data-URL image while retaining vector export quality
- preserve the ASCII export marker and resolution-preview transform
- replace the still watermark logo image inside the export clone with a measured placeholder
- paint the decoded logo onto final PNG, JPEG, WebP, clipboard, and share rasters to avoid WebKit foreignObject image drops
- update the ASCII component test for the single-image rendering contract

## Screenshots / Recordings (if UI)
Not attached. Browser verification was not run per project instructions.

## Checklist
- [ ] I ran pnpm lint
- [x] I ran pnpm typecheck
- [ ] I ran pnpm test
- [x] I did not include secrets or sensitive data
- [ ] I updated docs when behavior changed
- [x] I kept this PR focused and reasonably small

Tests, builds, and browser checks were not run per project instructions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the live ASCII glyph tree with a single SVG-backed image to reduce Safari compositing overhead and moves still-export logo painting out of DOM rasterization.
- Preserves ASCII export markers, dimensions, and resolution-preview transforms on the new image.
- Measures a watermark placeholder in the export clone and paints the decoded logo onto PNG, JPEG, WebP, clipboard, and share canvases.
- Updates the ASCII component test for the single-image rendering contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking defects identified.

The new ASCII image is escaped and awaited by the existing export asset pipeline, while watermark measurement and canvas painting follow the raster sizing contract across all changed still-export paths.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/editor/canvas/ascii-backdrop.tsx | Generates an escaped SVG data URL for ASCII glyphs and renders it as one correctly sized image while preserving export and preview attributes. |
| lib/editor/export-clone.ts | Replaces the cloned watermark image with a measurable layout placeholder and exposes its clone-relative placement. |
| lib/editor/export-still.ts | Loads the watermark logo separately and paints it at scaled placeholder coordinates on every still-export raster path. |
| tests/components/editor/ascii-backdrop.test.tsx | Updates coverage to verify the single-image contract and inspect the decoded SVG row geometry. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: optimise safari ascii and watermark"](https://github.com/shivabhattacharjee/tokokino/commit/8e0f08f977230907d12487b9228cfa0185ff280c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53483590)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ASCII backdrop rendering while preserving sizing and resolution across displays and exports.
  - Enhanced watermark placement and rendering in PNG, JPEG, WebP, and clipboard image exports.
  - Watermarks now maintain consistent scaling, smoothing, and shadow effects in exported images.

- **Tests**
  - Expanded coverage to verify encoded ASCII artwork renders correctly and preserves its layout during export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->