### PR TITLE
feat(marketing): /how-it-works and /use-cases pages, plus per-page social cards

### DIFF
--- a/app/compare/[slug]/page.tsx
+++ b/app/compare/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { Footer } from "@/components/landing/footer"
 import { Nav } from "@/components/landing/nav"
 import { RAIL_V_STYLE } from "@/components/landing/rail-styles"
 import { ScrollToTop } from "@/components/landing/scroll-to-top"
+import { pageMetadata } from "@/lib/seo/page-metadata"
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -39,17 +40,12 @@ export async function generateMetadata({
 
   if (!comparison) return {}
 
-  return {
+  return pageMetadata({
     title: comparison.metaTitle,
     description: comparison.metaDescription,
-    alternates: { canonical: `/compare/${comparison.slug}` },
-    openGraph: {
-      title: comparison.metaTitle,
-      description: comparison.metaDescription,
-      url: `/compare/${comparison.slug}`,
-      type: "article",
-    },
-  }
+    path: `/compare/${comparison.slug}`,
+    type: "article",
+  })
 }
 
 export default async function ComparePage({

--- a/app/globals.css
+++ b/app/globals.css
@@ -491,3 +491,25 @@ input[type="number"] {
   -moz-appearance: textfield !important;
   appearance: textfield !important;
 }
+
+@keyframes landing-page-in {
+  from {
+    opacity: 0.72;
+    filter: blur(14px);
+  }
+  to {
+    opacity: 1;
+    filter: none;
+  }
+}
+
+.landing-page-in {
+  animation: landing-page-in 1.45s cubic-bezier(0.22, 1, 0.36, 1) 0.18s
+    backwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landing-page-in {
+    animation: none;
+  }
+}

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -14,28 +14,20 @@ import { RAIL_V_STYLE } from "@/components/landing/rail-styles"
 import { ScrollToTop } from "@/components/landing/scroll-to-top"
 import { VectorCard } from "@/components/landing/vector-card"
 import {
-  AppStoreVector,
-  ChangelogVector,
   ClipVector,
   ClipboardVector,
   ContextVector,
-  DeckVector,
-  DemoVector,
   DepthVector,
   DevicesVector,
-  DocsVector,
   EasingVector,
   ExportVector,
   FrameVector,
   ImportVector,
-  LandingVector,
-  LaunchVector,
   LinkCardVector,
   RenderVector,
   ShapesVector,
   ShareVector,
   SlotsVector,
-  SocialVector,
   StyleVector,
   TargetVector,
   TextVector,
@@ -44,14 +36,16 @@ import {
   UrlVector,
 } from "@/components/landing/how-it-works-vectors"
 import { howItWorksStructuredData } from "@/lib/seo/how-it-works-structured-data"
+import { pageMetadata } from "@/lib/seo/page-metadata"
 import { serializeJsonLd } from "@/lib/seo/tokokino-structured-data"
 
-export const metadata: Metadata = {
+export const metadata: Metadata = pageMetadata({
   title: "How Tokokino works — from raw capture to polished export",
   description:
     "A step-by-step walkthrough of the Tokokino editor: import a screenshot, video, URL, or social post, frame it, style the scene, animate a demo on the timeline, and export a PNG, WebP, GIF, or WebM.",
-  alternates: { canonical: "/how-it-works" },
-}
+  path: "/how-it-works",
+  type: "article",
+})
 
 const CONTENT_WIDTH =
   "mx-auto max-w-[76rem] w-[calc(100%-1rem)] sm:w-[calc(100%-2rem)] md:w-[calc(100%-3rem)] lg:w-[calc(100%-4rem)] xl:w-full"
@@ -188,57 +182,6 @@ const EXPORT = [
     vector: <ShareVector />,
     meta: "View tracking",
     body: "Publish a composition to a public page and watch the views land.",
-  },
-] as const
-
-const USE_CASES = [
-  {
-    title: "Launch posts",
-    vector: <LaunchVector />,
-    meta: "16:9 / 1:1",
-    body: "A clean card for X, LinkedIn, or Product Hunt at the ratio the platform crops to.",
-  },
-  {
-    title: "Product demo clips",
-    vector: <DemoVector />,
-    meta: "GIF / WebM",
-    body: "Keyframe zooms and tilts over a recording, in a loop that autoplays inline.",
-  },
-  {
-    title: "App store screenshots",
-    vector: <AppStoreVector />,
-    meta: "9:16 frames",
-    body: "One capture in an iPhone, iPad, Pixel, or Galaxy frame, plus a headline layer.",
-  },
-  {
-    title: "Changelog entries",
-    vector: <ChangelogVector />,
-    meta: "Motion + labels",
-    body: "One image per release, annotated, with the same treatment every time.",
-  },
-  {
-    title: "Docs and guides",
-    vector: <DocsVector />,
-    meta: "Annotated stills",
-    body: "Crop to what matters and draw an arrow at the control you are describing.",
-  },
-  {
-    title: "Landing page visuals",
-    vector: <LandingVector />,
-    meta: "4K / 8K",
-    body: "Hero and feature imagery at widths that survive a retina display.",
-  },
-  {
-    title: "Social proof",
-    vector: <SocialVector />,
-    meta: "Post mockups",
-    body: "Render an X or Bluesky post as a styled card that belongs on your own site.",
-  },
-  {
-    title: "Decks and updates",
-    vector: <DeckVector />,
-    meta: "16:9",
-    body: "Slide-ready shots for investor updates, sales decks, and internal reviews.",
   },
 ] as const
 
@@ -550,27 +493,16 @@ export default function HowItWorksPage() {
             <div className="mt-6">
               <HowItWorksFlow />
             </div>
-          </Section>
 
-          <Section id="use-cases">
-            <div className="flex flex-col gap-2">
-              <span className="font-mono text-[10px] tracking-widest text-primary/80 uppercase">
-                {"// Use cases"}
-              </span>
-              <h2 className="text-2xl tracking-tight sm:text-3xl">
-                One workflow, pointed at very different jobs.
-              </h2>
-            </div>
-            <div className="mt-12 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-              {USE_CASES.map((useCase) => (
-                <VectorCard
-                  key={useCase.title}
-                  vector={useCase.vector}
-                  meta={useCase.meta}
-                  title={useCase.title}
-                  body={useCase.body}
-                />
-              ))}
+            <div className="mt-12 flex flex-col items-center gap-5 text-center">
+              <p className="max-w-md text-sm leading-7 text-balance text-foreground/58">
+                The steps stay the same whatever you are making. The jobs people
+                point them at do not.
+              </p>
+              <Link href="/use-cases" className={outlineCtaClass}>
+                Use cases
+                <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+              </Link>
             </div>
           </Section>
 

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -1,0 +1,638 @@
+import type { Metadata } from "next"
+import type { CSSProperties, ReactNode } from "react"
+import Link from "next/link"
+
+import { DashedH } from "@/components/landing/dashed-h"
+import { FaqColumn } from "@/components/landing/faq"
+import { FinalCta } from "@/components/landing/final-cta"
+import { Footer } from "@/components/landing/footer"
+import { FlickeringGrid } from "@/components/ui/flickering-grid"
+import { HowItWorksFlow } from "@/components/landing/how-it-works-flow"
+import { ArrowRight, StarIcon } from "@/components/landing/landing-svgs"
+import { Nav } from "@/components/landing/nav"
+import { RAIL_V_STYLE } from "@/components/landing/rail-styles"
+import { ScrollToTop } from "@/components/landing/scroll-to-top"
+import { VectorCard } from "@/components/landing/vector-card"
+import {
+  AppStoreVector,
+  ChangelogVector,
+  ClipVector,
+  ClipboardVector,
+  ContextVector,
+  DeckVector,
+  DemoVector,
+  DepthVector,
+  DevicesVector,
+  DocsVector,
+  EasingVector,
+  ExportVector,
+  FrameVector,
+  ImportVector,
+  LandingVector,
+  LaunchVector,
+  LinkCardVector,
+  RenderVector,
+  ShapesVector,
+  ShareVector,
+  SlotsVector,
+  SocialVector,
+  StyleVector,
+  TargetVector,
+  TextVector,
+  TimelineVector,
+  TrimVector,
+  UrlVector,
+} from "@/components/landing/how-it-works-vectors"
+import { howItWorksStructuredData } from "@/lib/seo/how-it-works-structured-data"
+import { serializeJsonLd } from "@/lib/seo/tokokino-structured-data"
+
+export const metadata: Metadata = {
+  title: "How Tokokino works — from raw capture to polished export",
+  description:
+    "A step-by-step walkthrough of the Tokokino editor: import a screenshot, video, URL, or social post, frame it, style the scene, animate a demo on the timeline, and export a PNG, WebP, GIF, or WebM.",
+  alternates: { canonical: "/how-it-works" },
+}
+
+const CONTENT_WIDTH =
+  "mx-auto max-w-[76rem] w-[calc(100%-1rem)] sm:w-[calc(100%-2rem)] md:w-[calc(100%-3rem)] lg:w-[calc(100%-4rem)] xl:w-full"
+
+const CAPTURE = [
+  {
+    title: "Screenshot file",
+    vector: <ImportVector />,
+    meta: "PNG · JPEG · WebP",
+    body: "Drag and drop, paste from the clipboard, or pick a file.",
+  },
+  {
+    title: "Live website",
+    vector: <UrlVector />,
+    meta: "Full page",
+    body: "Paste a URL and Tokokino captures the page at a device viewport.",
+  },
+  {
+    title: "Video and GIF",
+    vector: <ClipVector />,
+    meta: "MP4 · WebM · GIF",
+    body: "Drop a recording. Imported GIFs are re-encoded to run as video.",
+  },
+  {
+    title: "Social post",
+    vector: <LinkCardVector />,
+    meta: "X · Bluesky",
+    body: "Paste a post link and it renders as a themeable card mockup.",
+  },
+] as const
+
+const COMPOSE = [
+  {
+    title: "Device frames",
+    vector: <DevicesVector />,
+    meta: "Mockups",
+    body: "iPhone, iPad, Pixel, Galaxy, MacBook, plus Safari, Chrome, and Arc chrome.",
+  },
+  {
+    title: "Canvas shape",
+    vector: <FrameVector />,
+    meta: "Aspect · Radius",
+    body: "Aspect ratio, padding, corner radius, border, tilt, and scale.",
+  },
+  {
+    title: "Backgrounds",
+    vector: <StyleVector />,
+    meta: "Palettes",
+    body: "Gradients, image packs, Unsplash, or a palette sampled from your capture.",
+  },
+  {
+    title: "Depth and light",
+    vector: <DepthVector />,
+    meta: "6 shadows · 7 modes",
+    body: "Shadow types, portrait depth-of-field, backdrop patterns, 3D tilt.",
+  },
+] as const
+
+const CONTEXT = [
+  {
+    title: "Text layers",
+    vector: <TextVector />,
+    meta: "100+ fonts",
+    body: "Stroke, shadow, blend modes, and opacity on every floating label.",
+  },
+  {
+    title: "Images and shapes",
+    vector: <ShapesVector />,
+    meta: "106 shapes",
+    body: "Logos, SVGs, and 3D shapes with their own z-index and filters.",
+  },
+  {
+    title: "Annotations",
+    vector: <ContextVector />,
+    meta: "Arrows · Strokes",
+    body: "Point at what matters on a layer that never touches the capture.",
+  },
+  {
+    title: "Multi-shot slots",
+    vector: <SlotsVector />,
+    meta: "3 slots · 8 layouts",
+    body: "Side by Side, Depth Duo, Fan Out, Scatter, Perspective, and more.",
+  },
+] as const
+
+const ANIMATE = [
+  {
+    title: "Clips, not keyframes",
+    vector: <TimelineVector />,
+    meta: "Timeline",
+    body: "Add a clip, change properties while it is selected, and it owns them.",
+  },
+  {
+    title: "Easing you can drag",
+    vector: <EasingVector />,
+    meta: "Custom bezier",
+    body: "Linear, cubic, in, out, in-out, out-circ, or a curve you pull by hand.",
+  },
+  {
+    title: "Aim at one slot",
+    vector: <TargetVector />,
+    meta: "Per-slot",
+    body: "Point a clip at a single capture slot instead of the whole canvas.",
+  },
+  {
+    title: "Video on the same track",
+    vector: <TrimVector />,
+    meta: "Trim · Mute",
+    body: "Imported footage trims and mutes alongside the motion you built.",
+  },
+] as const
+
+const EXPORT = [
+  {
+    title: "Stills",
+    vector: <ExportVector />,
+    meta: "HD · 4K · 8K",
+    body: "PNG, JPEG, or WebP at 1920, 3840, or 7680px wide.",
+  },
+  {
+    title: "Video",
+    vector: <RenderVector />,
+    meta: "WebM · MP4 · GIF",
+    body: "Encoded on your device with WebCodecs — no queue, no upload.",
+  },
+  {
+    title: "Clipboard",
+    vector: <ClipboardVector />,
+    meta: "1080px PNG",
+    body: "Copy straight out of the editor without touching the filesystem.",
+  },
+  {
+    title: "Share link",
+    vector: <ShareVector />,
+    meta: "View tracking",
+    body: "Publish a composition to a public page and watch the views land.",
+  },
+] as const
+
+const USE_CASES = [
+  {
+    title: "Launch posts",
+    vector: <LaunchVector />,
+    meta: "16:9 / 1:1",
+    body: "A clean card for X, LinkedIn, or Product Hunt at the ratio the platform crops to.",
+  },
+  {
+    title: "Product demo clips",
+    vector: <DemoVector />,
+    meta: "GIF / WebM",
+    body: "Keyframe zooms and tilts over a recording, in a loop that autoplays inline.",
+  },
+  {
+    title: "App store screenshots",
+    vector: <AppStoreVector />,
+    meta: "9:16 frames",
+    body: "One capture in an iPhone, iPad, Pixel, or Galaxy frame, plus a headline layer.",
+  },
+  {
+    title: "Changelog entries",
+    vector: <ChangelogVector />,
+    meta: "Motion + labels",
+    body: "One image per release, annotated, with the same treatment every time.",
+  },
+  {
+    title: "Docs and guides",
+    vector: <DocsVector />,
+    meta: "Annotated stills",
+    body: "Crop to what matters and draw an arrow at the control you are describing.",
+  },
+  {
+    title: "Landing page visuals",
+    vector: <LandingVector />,
+    meta: "4K / 8K",
+    body: "Hero and feature imagery at widths that survive a retina display.",
+  },
+  {
+    title: "Social proof",
+    vector: <SocialVector />,
+    meta: "Post mockups",
+    body: "Render an X or Bluesky post as a styled card that belongs on your own site.",
+  },
+  {
+    title: "Decks and updates",
+    vector: <DeckVector />,
+    meta: "16:9",
+    body: "Slide-ready shots for investor updates, sales decks, and internal reviews.",
+  },
+] as const
+
+const STEP_SCHEMA = [
+  {
+    name: "Capture",
+    anchor: "capture",
+    body: "Drop a screenshot, paste from the clipboard, hand over a URL for Tokokino to capture at a chosen device viewport, or paste an X or Bluesky post link. Video and GIF files land on the same canvas.",
+  },
+  {
+    name: "Compose",
+    anchor: "compose",
+    body: "Wrap the capture in a device mockup or browser chrome, choose the canvas aspect ratio, then set padding, corner radius, border, tilt, and scale. Pick a background and add shadow, depth-of-field, and a colour grade.",
+  },
+  {
+    name: "Add context",
+    anchor: "context",
+    body: "Place text, logos, SVGs, and 3D shapes as layers. Draw arrows, shapes, and freehand strokes to point at what matters. Add up to three extra capture slots and arrange them with a layout preset.",
+  },
+  {
+    name: "Animate",
+    anchor: "animate",
+    body: "Add clips to the per-canvas timeline, each owning the properties you changed while it was selected, with an easing curve you can drag by hand. Imported video trims on the same timeline.",
+  },
+  {
+    name: "Export",
+    anchor: "export",
+    body: "Download a PNG, JPEG, or WebP at HD, 4K, or 8K, render the timeline as a GIF, WebM, or MP4 on your own device, copy straight to the clipboard, or publish a public link with view tracking.",
+  },
+] as const
+
+const FAQS = [
+  {
+    q: "Do I need an account to follow these steps?",
+    a: "No. Importing, editing, animating, and exporting all work without signing in. An account is only required for public share links, cloud drafts that follow you between devices, and saved custom presets.",
+  },
+  {
+    q: "How long does one visual take?",
+    a: "A framed screenshot on a styled background is usually under a minute — drop the capture, pick a template or preset, export. A keyframed demo takes longer because you are deciding what the motion should say, but the timeline is built for a handful of clips rather than a full edit.",
+  },
+  {
+    q: "Can Tokokino take the screenshot for me?",
+    a: "Yes. Paste a public URL and Tokokino captures the page at a device viewport you choose, including full-page captures. You can also paste an X or Bluesky post link to render the post itself as a mockup.",
+  },
+  {
+    q: "How do I turn a screen recording into a demo?",
+    a: "Drop the video onto the canvas. Trim and mute segments on the timeline, then add clips that keyframe zoom, position, tilt, and background so the camera moves with what you are showing. Export the result as WebM, MP4, or GIF.",
+  },
+  {
+    q: "Does my capture get uploaded anywhere?",
+    a: "Not by opening it. Editing and every export are done on your device, including video encoding. Files leave the browser only when you create a share link or save a cloud draft, and then it is the rendered output that is stored.",
+  },
+  {
+    q: "What happens if I lose my connection?",
+    a: "The editor can be kept on your device in one click, and your work in progress is stored in the browser, so it opens and keeps working with no network. Anything that needs the server — URL capture, share links — resumes when you are back online.",
+  },
+  {
+    q: "Can I apply the same look to a whole set of screenshots?",
+    a: "Yes. Save the look as a custom preset and re-apply it, or work in bulk edit mode, where multiple canvases sit on one board and can be styled and previewed together before export.",
+  },
+] as const
+
+const outlineCtaClass =
+  "group inline-flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-4 py-2 text-sm font-medium text-primary backdrop-blur-sm transition hover:border-primary/45 hover:text-primary/80"
+
+const linkClass =
+  "font-medium text-primary underline decoration-primary/35 underline-offset-4 transition-colors hover:text-primary/80"
+
+type Card = {
+  title: string
+  vector: ReactNode
+  meta: string
+  body: string
+}
+
+function SectionHeader({
+  eyebrow,
+  label,
+  headline,
+  subhead,
+  lead,
+}: {
+  eyebrow: string
+  label: string
+  headline: string
+  subhead: string
+  lead: ReactNode
+}) {
+  return (
+    <div className="grid gap-6 lg:grid-cols-2 lg:gap-16">
+      <div>
+        <span className="font-mono text-[10px] tracking-widest text-primary/80 uppercase">
+          {`// ${eyebrow}`}
+        </span>
+        <h2 className="mt-3 text-2xl font-medium tracking-[-0.025em] sm:text-3xl">
+          {label}
+        </h2>
+      </div>
+      <div className="max-w-xl">
+        <p className="text-2xl leading-[1.2] font-medium tracking-[-0.025em] text-balance sm:text-3xl">
+          {headline}
+          <br />
+          <span className="text-foreground/45">{subhead}</span>
+        </p>
+        <p className="mt-6 text-sm leading-7 text-foreground/58">{lead}</p>
+      </div>
+    </div>
+  )
+}
+
+function CardRow({ cards }: { cards: readonly Card[] }) {
+  return (
+    <div className="mt-12 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      {cards.map((card) => (
+        <VectorCard
+          key={card.title}
+          vector={card.vector}
+          meta={card.meta}
+          title={card.title}
+          body={card.body}
+        />
+      ))}
+    </div>
+  )
+}
+
+function Section({ id, children }: { id: string; children: ReactNode }) {
+  return (
+    <section
+      id={id}
+      className="scroll-mt-24 border-t border-border/50 pt-14 first:border-t-0 first:pt-0"
+    >
+      {children}
+    </section>
+  )
+}
+
+export default function HowItWorksPage() {
+  return (
+    <main
+      className="relative isolate min-h-svh bg-background text-foreground"
+      style={
+        {
+          "--rail": "color-mix(in oklch, var(--foreground) 20%, transparent)",
+        } as CSSProperties
+      }
+    >
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: serializeJsonLd(
+            howItWorksStructuredData({ steps: STEP_SCHEMA, faqs: FAQS })
+          ),
+        }}
+      />
+
+      <div className="pointer-events-none fixed inset-0 z-0">
+        <FlickeringGrid
+          color="rgb(255,255,255)"
+          maxOpacity={0.035}
+          flickerChance={0.08}
+          squareSize={3}
+          gridGap={8}
+          className="h-full w-full"
+        />
+      </div>
+
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <Nav />
+      </div>
+      <DashedH />
+
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <section className="landing-page-in relative flex flex-col items-center px-5 pt-14 pb-14 text-center sm:px-8 sm:pt-20 sm:pb-20 lg:px-12">
+          <span
+            style={{ "--landing-rise-duration": "0.6s" } as CSSProperties}
+            className="landing-rise font-mono text-[10px] tracking-[0.28em] text-primary/80 uppercase"
+          >
+            {"// How it works"}
+          </span>
+          <h1
+            style={
+              {
+                "--landing-rise-from": "12px",
+                "--landing-rise-duration": "0.7s",
+                "--landing-rise-delay": "0.1s",
+              } as CSSProperties
+            }
+            className="landing-rise mt-5 max-w-4xl text-[clamp(1.4rem,0.85rem+3.8vw,1.625rem)] leading-[1.1] font-medium tracking-[-0.035em] text-balance sm:text-5xl sm:leading-[1.06] sm:tracking-[-0.03em] lg:text-[3.75rem]"
+          >
+            From a raw capture to{" "}
+            <span className="text-primary">something worth shipping.</span>
+          </h1>
+          <p
+            style={
+              {
+                "--landing-rise-duration": "0.6s",
+                "--landing-rise-delay": "0.3s",
+              } as CSSProperties
+            }
+            className="landing-rise mt-6 max-w-xl text-[13px] leading-[1.6] text-balance text-foreground/58 sm:text-[15px] sm:leading-relaxed"
+          >
+            One editor for product visuals. Import a screenshot, recording, URL,
+            or social post, frame and style it, animate it on a timeline, then
+            export a still or a video — all in your browser.
+          </p>
+          <div
+            style={
+              {
+                "--landing-rise-duration": "0.6s",
+                "--landing-rise-delay": "0.4s",
+              } as CSSProperties
+            }
+            className="landing-rise mt-9 flex flex-wrap items-center justify-center gap-3"
+          >
+            <Link
+              href="/app"
+              className="group inline-flex items-center gap-2 rounded-md bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition hover:opacity-95"
+            >
+              Start editing
+              <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+            </Link>
+            <a
+              href="https://git.new/Tokokino"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-5 py-2.5 text-sm font-medium text-foreground/70 backdrop-blur-sm transition hover:border-foreground/30 hover:text-foreground"
+            >
+              <StarIcon className="size-3.5 text-yellow-400" />
+              Star on GitHub
+            </a>
+          </div>
+        </section>
+      </div>
+      <DashedH />
+
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <div className="landing-page-in flex flex-col gap-14 px-5 py-14 sm:px-8 sm:py-16 lg:px-12">
+          <Section id="capture">
+            <SectionHeader
+              eyebrow="Step one"
+              label="Capture"
+              headline="Product work rarely starts"
+              subhead="with a tidy image file"
+              lead="Screenshots, recordings, live pages, and social posts all come in the same door. Whatever you bring becomes the same kind of canvas, so everything after this behaves identically."
+            />
+            <CardRow cards={CAPTURE} />
+          </Section>
+
+          <Section id="compose">
+            <SectionHeader
+              eyebrow="Step two"
+              label="Compose"
+              headline="Framing decides what it is"
+              subhead="styling decides how it lands"
+              lead="Every treatment here is non-destructive — the original capture is kept behind each crop, frame, and filter, so nothing you try is a one-way door. Save a finished look as a preset and re-apply it across a whole set."
+            />
+            <CardRow cards={COMPOSE} />
+
+            <div className="mt-12 flex flex-col items-center gap-5 text-center">
+              <p className="max-w-md text-sm leading-7 text-balance text-foreground/58">
+                Rather not start from nothing? The template picker carries
+                ready-made compositions, several of them already animated.
+              </p>
+              <Link href="/showcase" className={outlineCtaClass}>
+                Showcase
+                <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+              </Link>
+            </div>
+          </Section>
+
+          <Section id="context">
+            <SectionHeader
+              eyebrow="Step three"
+              label="Context"
+              headline="A screenshot says here it is"
+              subhead="context says here is what matters"
+              lead="Labels, marks, and extra shots are what turn a picture of a screen into an explanation. Each one lives on its own layer, so you can rearrange the argument without re-cropping the evidence."
+            />
+            <CardRow cards={CONTEXT} />
+          </Section>
+
+          <Section id="animate">
+            <SectionHeader
+              eyebrow="Optional"
+              label="Animate"
+              headline="Motion built by describing states"
+              subhead="not by scrubbing keyframes"
+              lead="Each canvas carries its own timeline. The editor eases from the committed values into whatever a clip changed, so you write the destination and it works out the path."
+            />
+            <CardRow cards={ANIMATE} />
+          </Section>
+
+          <Section id="export">
+            <SectionHeader
+              eyebrow="Step four"
+              label="Export"
+              headline="The end of the same pipeline"
+              subhead="not a separate render service"
+              lead="Stills are rasterised from the canvas you have been looking at, and video is encoded on your own machine. The file appears without a queue, a watermark negotiation, or an upload."
+            />
+            <CardRow cards={EXPORT} />
+          </Section>
+
+          <Section id="overview">
+            <span className="font-mono text-[10px] tracking-widest text-primary/80 uppercase">
+              {"// End to end"}
+            </span>
+            <div className="mt-6">
+              <HowItWorksFlow />
+            </div>
+          </Section>
+
+          <Section id="use-cases">
+            <div className="flex flex-col gap-2">
+              <span className="font-mono text-[10px] tracking-widest text-primary/80 uppercase">
+                {"// Use cases"}
+              </span>
+              <h2 className="text-2xl tracking-tight sm:text-3xl">
+                One workflow, pointed at very different jobs.
+              </h2>
+            </div>
+            <div className="mt-12 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              {USE_CASES.map((useCase) => (
+                <VectorCard
+                  key={useCase.title}
+                  vector={useCase.vector}
+                  meta={useCase.meta}
+                  title={useCase.title}
+                  body={useCase.body}
+                />
+              ))}
+            </div>
+          </Section>
+
+          <Section id="local-first">
+            <SectionHeader
+              eyebrow="Local-first"
+              label="Where the work happens"
+              headline="Opening a capture"
+              subhead="does not upload it"
+              lead={
+                <>
+                  Editing, rasterising, and video encoding all run in the
+                  browser, and your work in progress is stored on the device, so
+                  a reload or a dropped connection does not cost you the
+                  composition. The server side is deliberately small and always
+                  explicit: capturing a URL, fetching a social post, syncing a
+                  cloud draft, publishing a share link. In each case it is the
+                  request you made or the rendered output — never the source
+                  capture sitting on your canvas. The project is open source
+                  under AGPL-3.0, so the boundary can be read rather than
+                  trusted; see the{" "}
+                  <Link href="/about" className={linkClass}>
+                    about page
+                  </Link>{" "}
+                  or the{" "}
+                  <Link href="/privacy" className={linkClass}>
+                    privacy policy
+                  </Link>
+                  .
+                </>
+              }
+            />
+          </Section>
+
+          <Section id="faq">
+            <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between md:gap-16">
+              <div className="shrink-0 md:w-64 md:pt-1">
+                <span className="font-mono text-[10px] tracking-widest text-primary/80 uppercase">
+                  {"// FAQ"}
+                </span>
+                <h2 className="mt-3 text-2xl font-medium tracking-[-0.025em] sm:text-3xl">
+                  Questions
+                </h2>
+              </div>
+              <div className="min-w-0 flex-1">
+                <FaqColumn items={FAQS} />
+              </div>
+            </div>
+          </Section>
+        </div>
+      </div>
+
+      <DashedH />
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <FinalCta />
+      </div>
+
+      <DashedH />
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <Footer />
+      </div>
+      <ScrollToTop />
+    </main>
+  )
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -26,6 +26,8 @@ Last updated: ${UPDATED_AT}
 
 ## Product guides
 
+- [How it works](${SITE_URL}/how-it-works): Step-by-step walkthrough of capture, framing, styling, annotation, animation, and export.
+- [Use cases](${SITE_URL}/use-cases): Launch posts, store listings, demo clips, changelog images, docs stills, and social proof.
 - [Comparisons](${SITE_URL}/compare): Tokokino compared with adjacent screenshot and design tools.
 - [Tokokino vs PostSpark](${SITE_URL}/compare/tokokino-vs-postspark): Screenshot, social-post, video, and storage workflow comparison.
 - [Tokokino vs Pika](${SITE_URL}/compare/tokokino-vs-pika): Image-first mockup and animated-demo workflow comparison.

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -57,6 +57,12 @@ const routes = [
     lastModified: LANDING_MODIFIED,
   },
   {
+    path: "/how-it-works",
+    changeFrequency: "monthly",
+    priority: 0.8,
+    lastModified: "2026-08-28",
+  },
+  {
     path: "/showcase",
     changeFrequency: "weekly",
     priority: 0.8,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -33,18 +33,6 @@ const routes = [
     lastModified: LANDING_MODIFIED,
   },
   {
-    path: "/#use-cases",
-    changeFrequency: "weekly",
-    priority: 0.8,
-    lastModified: LANDING_MODIFIED,
-  },
-  {
-    path: "/#how-it-works",
-    changeFrequency: "weekly",
-    priority: 0.8,
-    lastModified: LANDING_MODIFIED,
-  },
-  {
     path: "/#faq",
     changeFrequency: "weekly",
     priority: 0.7,
@@ -55,6 +43,12 @@ const routes = [
     changeFrequency: "weekly",
     priority: 0.7,
     lastModified: LANDING_MODIFIED,
+  },
+  {
+    path: "/use-cases",
+    changeFrequency: "monthly",
+    priority: 0.8,
+    lastModified: "2026-08-28",
   },
   {
     path: "/how-it-works",

--- a/app/use-cases/page.tsx
+++ b/app/use-cases/page.tsx
@@ -1,0 +1,483 @@
+import type { Metadata } from "next"
+import type { CSSProperties, ReactNode } from "react"
+import Link from "next/link"
+
+import { DashedH } from "@/components/landing/dashed-h"
+import { DitherField } from "@/components/landing/dither-field"
+import { FaqColumn } from "@/components/landing/faq"
+import { FinalCta } from "@/components/landing/final-cta"
+import { Footer } from "@/components/landing/footer"
+import { HowItWorksFlow } from "@/components/landing/how-it-works-flow"
+import { ArrowRight, StarIcon } from "@/components/landing/landing-svgs"
+import { Nav } from "@/components/landing/nav"
+import { RAIL_V_STYLE } from "@/components/landing/rail-styles"
+import { ScrollToTop } from "@/components/landing/scroll-to-top"
+import { VectorCard } from "@/components/landing/vector-card"
+import {
+  AnnounceVector,
+  AppStoreVector,
+  ChangelogVector,
+  ClipboardVector,
+  CompareVector,
+  DeckVector,
+  DemoVector,
+  DocsVector,
+  ExportVector,
+  LandingVector,
+  LaunchVector,
+  MultiDeviceVector,
+  RenderVector,
+  ShareVector,
+  SocialVector,
+  WalkthroughVector,
+} from "@/components/landing/how-it-works-vectors"
+import { FlickeringGrid } from "@/components/ui/flickering-grid"
+import { pageMetadata } from "@/lib/seo/page-metadata"
+import { useCasesStructuredData } from "@/lib/seo/use-cases-structured-data"
+import { serializeJsonLd } from "@/lib/seo/tokokino-structured-data"
+
+export const metadata: Metadata = pageMetadata({
+  title: "Use cases — what people build with Tokokino",
+  description:
+    "Launch posts, app store screenshots, animated product demos, changelog images, documentation stills, landing page visuals, and social proof — all from one browser-based editor.",
+  path: "/use-cases",
+})
+
+const CONTENT_WIDTH =
+  "mx-auto max-w-[76rem] w-[calc(100%-1rem)] sm:w-[calc(100%-2rem)] md:w-[calc(100%-3rem)] lg:w-[calc(100%-4rem)] xl:w-full"
+
+const SHIPPING = [
+  {
+    title: "Launch posts",
+    meta: "16:9 / 1:1",
+    vector: <LaunchVector />,
+    body: "A framed shot on a backdrop that suits your brand, at the ratio X, LinkedIn, or Product Hunt crops to.",
+  },
+  {
+    title: "Product demo clips",
+    meta: "GIF / WebM",
+    vector: <DemoVector />,
+    body: "Keyframe zooms and tilts over a screen recording so the viewer looks where you want them to.",
+  },
+  {
+    title: "Changelog entries",
+    meta: "Motion + labels",
+    vector: <ChangelogVector />,
+    body: "One image per release, annotated, with a saved preset keeping the treatment identical every time.",
+  },
+  {
+    title: "Landing page visuals",
+    meta: "4K / 8K",
+    vector: <LandingVector />,
+    body: "Hero and feature imagery at export widths that still look sharp on a retina display.",
+  },
+] as const
+
+const DEVICES = [
+  {
+    title: "App store screenshots",
+    meta: "9:16 frames",
+    vector: <AppStoreVector />,
+    body: "One capture in an iPhone, iPad, Pixel, or Galaxy frame, with a headline layer over the top.",
+  },
+  {
+    title: "Tablet and desktop sets",
+    meta: "Multi-device",
+    vector: <MultiDeviceVector />,
+    body: "The same screen shown across sizes, so a responsive product reads as one product.",
+  },
+  {
+    title: "Side-by-side comparisons",
+    meta: "3 extra slots",
+    vector: <CompareVector />,
+    body: "Before and after, or two flows at once, arranged with a layout preset instead of by hand.",
+  },
+  {
+    title: "Presentation stills",
+    meta: "16:9",
+    vector: <DeckVector />,
+    body: "Slide-ready shots for investor updates, sales decks, and internal reviews at a consistent ratio.",
+  },
+] as const
+
+const EXPLAINING = [
+  {
+    title: "Docs and guides",
+    meta: "Annotated stills",
+    vector: <DocsVector />,
+    body: "Crop to the region that matters and draw an arrow at the control you are describing.",
+  },
+  {
+    title: "Feature announcements",
+    meta: "Text + marks",
+    vector: <AnnounceVector />,
+    body: "Label the new thing, dim the rest, and let one image carry the whole explanation.",
+  },
+  {
+    title: "Social proof",
+    meta: "Post mockups",
+    vector: <SocialVector />,
+    body: "Render an X or Bluesky post as a styled card that belongs on your site rather than in a screenshot.",
+  },
+  {
+    title: "Onboarding walkthroughs",
+    meta: "Timeline",
+    vector: <WalkthroughVector />,
+    body: "A short loop that shows the path through a flow, exported small enough to autoplay inline.",
+  },
+] as const
+
+const OUTPUT = [
+  {
+    title: "Stills",
+    meta: "HD · 4K · 8K",
+    vector: <ExportVector />,
+    body: "PNG, JPEG, or WebP at 1920, 3840, or 7680px wide.",
+  },
+  {
+    title: "Video",
+    meta: "WebM · MP4 · GIF",
+    vector: <RenderVector />,
+    body: "Encoded on your own device with WebCodecs — no queue, no upload.",
+  },
+  {
+    title: "Clipboard",
+    meta: "1080px PNG",
+    vector: <ClipboardVector />,
+    body: "Copy straight out of the editor without touching the filesystem.",
+  },
+  {
+    title: "Share link",
+    meta: "View tracking",
+    vector: <ShareVector />,
+    body: "Publish a composition to a public page and watch the views land.",
+  },
+] as const
+
+const FAQS = [
+  {
+    q: "Which use case should I start with?",
+    a: "Whichever one you need this week. Every job on this page runs through the same five steps — import, frame, style, optionally animate, export — so the second visual you make is always faster than the first.",
+  },
+  {
+    q: "Can I keep one look across a whole set?",
+    a: "Yes. Save the treatment as a custom preset and re-apply it, or work in bulk edit mode where multiple canvases sit on one board and can be styled and previewed together before export.",
+  },
+  {
+    q: "Do app store screenshots need specific sizes?",
+    a: "Set the canvas aspect ratio to the one the store expects and export at 4K or 8K width. Device frames are applied non-destructively, so the same capture can be re-framed for a different store listing without redoing the composition.",
+  },
+  {
+    q: "How small can an animated demo get?",
+    a: "GIF and WebM are both bounded by the timeline length and canvas size you choose. Short loops of a few seconds at HD usually land in the low megabytes, which is small enough to autoplay in a README, a changelog, or a launch post.",
+  },
+  {
+    q: "Is any of this paid?",
+    a: "The editor and every export option are free, and no account is needed to make or download a visual. Signing in adds public share links, cloud drafts, and saved presets.",
+  },
+] as const
+
+const outlineCtaClass =
+  "group inline-flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-4 py-2 text-sm font-medium text-primary backdrop-blur-sm transition hover:border-primary/45 hover:text-primary/80"
+
+const linkClass =
+  "font-medium text-primary underline decoration-primary/35 underline-offset-4 transition-colors hover:text-primary/80"
+
+type UseCase = {
+  title: string
+  meta: string
+  vector: ReactNode
+  body: string
+}
+
+function SectionHeader({
+  eyebrow,
+  label,
+  headline,
+  subhead,
+  lead,
+}: {
+  eyebrow: string
+  label: string
+  headline: string
+  subhead: string
+  lead: ReactNode
+}) {
+  return (
+    <div className="grid gap-6 lg:grid-cols-2 lg:gap-16">
+      <div>
+        <span className="font-mono text-[10px] tracking-widest text-primary/80 uppercase">
+          {`// ${eyebrow}`}
+        </span>
+        <h2 className="mt-3 text-2xl font-medium tracking-[-0.025em] sm:text-3xl">
+          {label}
+        </h2>
+      </div>
+      <div className="max-w-xl">
+        <p className="text-2xl leading-[1.2] font-medium tracking-[-0.025em] text-balance sm:text-3xl">
+          {headline}
+          <br />
+          <span className="text-foreground/45">{subhead}</span>
+        </p>
+        <p className="mt-6 text-sm leading-7 text-foreground/58">{lead}</p>
+      </div>
+    </div>
+  )
+}
+
+function CardRow({ cards }: { cards: readonly UseCase[] }) {
+  return (
+    <div className="mt-12 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      {cards.map((card) => (
+        <VectorCard
+          key={card.title}
+          vector={card.vector}
+          meta={card.meta}
+          title={card.title}
+          body={card.body}
+        />
+      ))}
+    </div>
+  )
+}
+
+function Section({ id, children }: { id: string; children: ReactNode }) {
+  return (
+    <section
+      id={id}
+      className="scroll-mt-24 border-t border-border/50 pt-14 first:border-t-0 first:pt-0"
+    >
+      {children}
+    </section>
+  )
+}
+
+export default function UseCasesPage() {
+  const allCases = [...SHIPPING, ...DEVICES, ...EXPLAINING]
+
+  return (
+    <main
+      className="relative isolate min-h-svh bg-background text-foreground"
+      style={
+        {
+          "--rail": "color-mix(in oklch, var(--foreground) 20%, transparent)",
+        } as CSSProperties
+      }
+    >
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: serializeJsonLd(
+            useCasesStructuredData({
+              cases: allCases.map((c) => ({ title: c.title, body: c.body })),
+              faqs: FAQS,
+            })
+          ),
+        }}
+      />
+
+      <div className="pointer-events-none fixed inset-0 z-0">
+        <FlickeringGrid
+          color="rgb(255,255,255)"
+          maxOpacity={0.035}
+          flickerChance={0.08}
+          squareSize={3}
+          gridGap={8}
+          className="h-full w-full"
+        />
+      </div>
+
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <Nav />
+      </div>
+      <DashedH />
+
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <section className="landing-page-in relative flex flex-col items-center overflow-hidden px-5 pt-14 pb-14 text-center sm:px-8 sm:pt-20 sm:pb-20 lg:px-12">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 -z-10 opacity-35"
+            style={{
+              maskImage:
+                "linear-gradient(to top left, black 5%, transparent 62%)",
+              WebkitMaskImage:
+                "linear-gradient(to top left, black 5%, transparent 62%)",
+            }}
+          >
+            <DitherField cell={6} speed={0.35} intensity={0.7} />
+          </div>
+
+          <span
+            style={{ "--landing-rise-duration": "0.6s" } as CSSProperties}
+            className="landing-rise font-mono text-[10px] tracking-[0.28em] text-primary/80 uppercase"
+          >
+            {"// Use cases"}
+          </span>
+          <h1
+            style={
+              {
+                "--landing-rise-from": "12px",
+                "--landing-rise-duration": "0.7s",
+                "--landing-rise-delay": "0.1s",
+              } as CSSProperties
+            }
+            className="landing-rise mt-5 max-w-5xl text-[clamp(1.4rem,0.85rem+3.8vw,1.625rem)] leading-[1.1] font-medium tracking-[-0.035em] text-balance sm:text-5xl sm:leading-[1.06] sm:tracking-[-0.03em] lg:text-[3.75rem]"
+          >
+            <span className="whitespace-nowrap">One editor,</span>
+            <br />
+            <span className="text-primary">a dozen jobs it does well.</span>
+          </h1>
+          <p
+            style={
+              {
+                "--landing-rise-duration": "0.6s",
+                "--landing-rise-delay": "0.3s",
+              } as CSSProperties
+            }
+            className="landing-rise mt-6 max-w-2xl text-[13px] leading-[1.6] text-balance text-foreground/58 sm:text-[15px] sm:leading-relaxed"
+          >
+            Launch posts, store listings, demo clips, changelog images, docs
+            stills, and social proof. Same workflow every time — the only thing
+            that changes is where the file ends up.
+          </p>
+          <div
+            style={
+              {
+                "--landing-rise-duration": "0.6s",
+                "--landing-rise-delay": "0.4s",
+              } as CSSProperties
+            }
+            className="landing-rise mt-9 flex flex-wrap items-center justify-center gap-3"
+          >
+            <Link
+              href="/app"
+              className="group inline-flex items-center gap-2 rounded-md bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition hover:opacity-95"
+            >
+              Start editing
+              <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+            </Link>
+            <a
+              href="https://git.new/Tokokino"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-5 py-2.5 text-sm font-medium text-foreground/70 backdrop-blur-sm transition hover:border-foreground/30 hover:text-foreground"
+            >
+              <StarIcon className="size-3.5 text-yellow-400" />
+              Star on GitHub
+            </a>
+          </div>
+        </section>
+      </div>
+      <DashedH />
+
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <div className="landing-page-in flex flex-col gap-14 px-5 py-14 sm:px-8 sm:py-16 lg:px-12">
+          <Section id="shipping">
+            <SectionHeader
+              eyebrow="Shipping"
+              label="Announcing"
+              headline="Every release needs one image"
+              subhead="that shows the new thing"
+              lead="The visual attached to a launch post or a changelog entry does more work than the copy under it. These are the shapes that job usually takes."
+            />
+            <CardRow cards={SHIPPING} />
+          </Section>
+
+          <Section id="devices">
+            <SectionHeader
+              eyebrow="Listings"
+              label="On device"
+              headline="A screen inside a phone"
+              subhead="reads as a product"
+              lead="Device frames are applied non-destructively, so one capture can be re-framed for a different store listing or a wider layout without rebuilding the composition."
+            />
+            <CardRow cards={DEVICES} />
+          </Section>
+
+          <Section id="explaining">
+            <SectionHeader
+              eyebrow="Teaching"
+              label="Explaining"
+              headline="A screenshot says here it is"
+              subhead="an annotated one says here is why"
+              lead="Marks, labels, and short loops turn a picture of a screen into something a reader can follow. Each layer stays separate, so the argument can change without re-cropping the evidence."
+            />
+            <CardRow cards={EXPLAINING} />
+          </Section>
+
+          <Section id="output">
+            <SectionHeader
+              eyebrow="Output"
+              label="What you walk away with"
+              headline="Every job on this page"
+              subhead="ends in a file or a link"
+              lead="Stills are rasterised from the canvas you have been looking at and video is encoded on your own machine, so whatever you were making arrives without a render queue or an upload."
+            />
+            <CardRow cards={OUTPUT} />
+          </Section>
+
+          <Section id="how">
+            <SectionHeader
+              eyebrow="The method"
+              label="Same five steps"
+              headline="The job changes"
+              subhead="the workflow does not"
+              lead={
+                <>
+                  Import a capture, frame it, style the scene, optionally
+                  animate it, then export. Every visual on this page came out of
+                  that loop. The{" "}
+                  <Link href="/how-it-works" className={linkClass}>
+                    full walkthrough
+                  </Link>{" "}
+                  covers each step, or you can skip it and open the editor.
+                </>
+              }
+            />
+            <div className="mt-12">
+              <HowItWorksFlow />
+            </div>
+
+            <div className="mt-12 flex flex-col items-center gap-5 text-center">
+              <p className="max-w-md text-sm leading-7 text-balance text-foreground/58">
+                Every card above started as a template. Swap your own capture in
+                and the treatment comes with it.
+              </p>
+              <Link href="/showcase" className={outlineCtaClass}>
+                Showcase
+                <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+              </Link>
+            </div>
+          </Section>
+
+          <Section id="faq">
+            <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between md:gap-16">
+              <div className="shrink-0 md:w-64 md:pt-1">
+                <span className="font-mono text-[10px] tracking-widest text-primary/80 uppercase">
+                  {"// FAQ"}
+                </span>
+                <h2 className="mt-3 text-2xl font-medium tracking-[-0.025em] sm:text-3xl">
+                  Questions
+                </h2>
+              </div>
+              <div className="min-w-0 flex-1">
+                <FaqColumn items={FAQS} />
+              </div>
+            </div>
+          </Section>
+        </div>
+      </div>
+
+      <DashedH />
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <FinalCta />
+      </div>
+
+      <DashedH />
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <Footer />
+      </div>
+      <ScrollToTop />
+    </main>
+  )
+}

--- a/components/landing/dither-field.tsx
+++ b/components/landing/dither-field.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+import { cn } from "@/lib/utils"
+
+const BAYER_8x8 = [
+  [0, 32, 8, 40, 2, 34, 10, 42],
+  [48, 16, 56, 24, 50, 18, 58, 26],
+  [12, 44, 4, 36, 14, 46, 6, 38],
+  [60, 28, 52, 20, 62, 30, 54, 22],
+  [3, 35, 11, 43, 1, 33, 9, 41],
+  [51, 19, 59, 27, 49, 17, 57, 25],
+  [15, 47, 7, 39, 13, 45, 5, 37],
+  [63, 31, 55, 23, 61, 29, 53, 21],
+]
+
+const FRAME_MS = 1000 / 20
+
+function readRgb(el: HTMLElement, variable: string): [number, number, number] {
+  const raw = getComputedStyle(el).getPropertyValue(variable).trim()
+  if (!raw) return [233, 57, 84]
+
+  // The palette is authored in oklch, which canvas cannot parse. Painting the
+  // value onto a 1x1 context is the cheapest way to resolve it to sRGB.
+  const probe = document.createElement("canvas")
+  probe.width = 1
+  probe.height = 1
+  const ctx = probe.getContext("2d", { willReadFrequently: true })
+  if (!ctx) return [233, 57, 84]
+  ctx.fillStyle = raw
+  ctx.fillRect(0, 0, 1, 1)
+  const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data
+  return [r, g, b]
+}
+
+/**
+ * Ordered-dither field: a Bayer-thresholded falloff rendered at one pixel per
+ * cell on an offscreen buffer, then scaled up with smoothing off. Drawing the
+ * cells individually would cost tens of thousands of fillRect calls a frame.
+ */
+export function DitherField({
+  className,
+  cell = 6,
+  speed = 0.35,
+  intensity = 1,
+}: {
+  className?: string
+  cell?: number
+  speed?: number
+  intensity?: number
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    const buffer = document.createElement("canvas")
+    const bufferCtx = buffer.getContext("2d")
+    if (!bufferCtx) return
+
+    const [r, g, b] = readRgb(canvas, "--primary")
+    const reduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches
+
+    let width = 0
+    let height = 0
+    let cols = 0
+    let rows = 0
+    let image: ImageData | null = null
+    let frame = 0
+    let last = 0
+
+    const resize = () => {
+      const rect = canvas.getBoundingClientRect()
+      width = Math.max(1, Math.floor(rect.width))
+      height = Math.max(1, Math.floor(rect.height))
+      cols = Math.max(1, Math.ceil(width / cell))
+      rows = Math.max(1, Math.ceil(height / cell))
+      canvas.width = width
+      canvas.height = height
+      buffer.width = cols
+      buffer.height = rows
+      image = bufferCtx.createImageData(cols, rows)
+      ctx.imageSmoothingEnabled = false
+    }
+
+    const paint = (time: number) => {
+      if (!image) return
+      const data = image.data
+      const lastCol = Math.max(1, cols - 1)
+      const lastRow = Math.max(1, rows - 1)
+
+      for (let y = 0; y < rows; y++) {
+        for (let x = 0; x < cols; x++) {
+          // Density grows toward the right edge and the bottom, so the field
+          // reads as a corner bleed rather than a halo around the copy.
+          const corner = Math.max(x / lastCol, y / lastRow)
+          const wave =
+            Math.sin(x * 0.07 + time) * 0.05 + Math.cos(y * 0.09 - time) * 0.05
+          const value = (corner - 0.46) * 1.9 + wave
+
+          const threshold = BAYER_8x8[y & 7][x & 7] / 64
+          const index = (y * cols + x) * 4
+          const on = value > threshold
+
+          data[index] = r
+          data[index + 1] = g
+          data[index + 2] = b
+          data[index + 3] = on ? Math.round(255 * intensity) : 0
+        }
+      }
+
+      bufferCtx.putImageData(image, 0, 0)
+      ctx.clearRect(0, 0, width, height)
+      ctx.imageSmoothingEnabled = false
+      ctx.drawImage(buffer, 0, 0, cols, rows, 0, 0, cols * cell, rows * cell)
+    }
+
+    const tick = (now: number) => {
+      if (now - last >= FRAME_MS) {
+        last = now
+        paint((now / 1000) * speed)
+      }
+      frame = requestAnimationFrame(tick)
+    }
+
+    resize()
+
+    if (reduceMotion) {
+      paint(0)
+    } else {
+      frame = requestAnimationFrame(tick)
+    }
+
+    const observer = new ResizeObserver(() => {
+      resize()
+      paint(reduceMotion ? 0 : (performance.now() / 1000) * speed)
+    })
+    observer.observe(canvas)
+
+    return () => {
+      cancelAnimationFrame(frame)
+      observer.disconnect()
+    }
+  }, [cell, speed, intensity])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      className={cn("pointer-events-none size-full", className)}
+    />
+  )
+}

--- a/components/landing/dither-field.tsx
+++ b/components/landing/dither-field.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
+import { useTheme } from "next-themes"
 
 import { cn } from "@/lib/utils"
 
@@ -51,6 +52,10 @@ export function DitherField({
   intensity?: number
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [isInView, setIsInView] = useState(false)
+  // --primary resolves differently per theme, and the value is read once into
+  // the buffer, so the effect has to re-run when the theme flips.
+  const { resolvedTheme } = useTheme()
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -123,32 +128,42 @@ export function DitherField({
     }
 
     const tick = (now: number) => {
-      if (now - last >= FRAME_MS) {
-        last = now
-        paint((now / 1000) * speed)
-      }
+      if (!isInView) return
       frame = requestAnimationFrame(tick)
+
+      if (now - last < FRAME_MS) return
+      last = now
+      paint((now / 1000) * speed)
     }
 
     resize()
 
     if (reduceMotion) {
       paint(0)
-    } else {
+    } else if (isInView) {
       frame = requestAnimationFrame(tick)
+    } else {
+      paint(0)
     }
 
-    const observer = new ResizeObserver(() => {
+    const resizeObserver = new ResizeObserver(() => {
       resize()
-      paint(reduceMotion ? 0 : (performance.now() / 1000) * speed)
+      paint(reduceMotion || !isInView ? 0 : (performance.now() / 1000) * speed)
     })
-    observer.observe(canvas)
+    resizeObserver.observe(canvas)
+
+    const intersectionObserver = new IntersectionObserver(
+      ([entry]) => setIsInView(entry.isIntersecting),
+      { threshold: 0 }
+    )
+    intersectionObserver.observe(canvas)
 
     return () => {
       cancelAnimationFrame(frame)
-      observer.disconnect()
+      resizeObserver.disconnect()
+      intersectionObserver.disconnect()
     }
-  }, [cell, speed, intensity])
+  }, [cell, speed, intensity, isInView, resolvedTheme])
 
   return (
     <canvas

--- a/components/landing/faq.tsx
+++ b/components/landing/faq.tsx
@@ -9,7 +9,12 @@ import {
 } from "@/components/ui/accordion"
 import { ease } from "@/components/landing/constants"
 
-const faqs = [
+export type FaqItem = {
+  q: string
+  a: string
+}
+
+const faqs: readonly FaqItem[] = [
   {
     q: "Do I need an account to use Tokokino?",
     a: "No account needed to edit and export. You can drop in a capture, style it, animate it, and download a PNG/JPEG/WebP or GIF/WebM right away — no sign-in required. An account (email or Google) is only needed if you want to create public share links or access your share history.",
@@ -64,11 +69,11 @@ const faqs = [
   },
 ]
 
-function FaqColumn({
+export function FaqColumn({
   items,
   offset = 0,
 }: {
-  items: typeof faqs
+  items: readonly FaqItem[]
   offset?: number
 }) {
   return (

--- a/components/landing/footer.tsx
+++ b/components/landing/footer.tsx
@@ -37,7 +37,7 @@ const FOOTER_COLUMNS = [
     links: [
       { label: "Features", href: "#features" },
       { label: "How it works", href: "/how-it-works" },
-      { label: "Use cases", href: "/how-it-works#use-cases" },
+      { label: "Use cases", href: "/use-cases" },
       { label: "FAQ", href: "#faq" },
       { label: "Glossary", href: "/glossary" },
       { label: "Changelog", href: "/changelog" },

--- a/components/landing/footer.tsx
+++ b/components/landing/footer.tsx
@@ -36,7 +36,8 @@ const FOOTER_COLUMNS = [
     title: "Product",
     links: [
       { label: "Features", href: "#features" },
-      { label: "How it works", href: "#how-it-works" },
+      { label: "How it works", href: "/how-it-works" },
+      { label: "Use cases", href: "/how-it-works#use-cases" },
       { label: "FAQ", href: "#faq" },
       { label: "Glossary", href: "/glossary" },
       { label: "Changelog", href: "/changelog" },

--- a/components/landing/how-it-works-flow.tsx
+++ b/components/landing/how-it-works-flow.tsx
@@ -1,0 +1,102 @@
+import { RiArrowDownLine, RiCheckLine } from "@remixicon/react"
+
+const BUILD = [
+  { step: "Capture", detail: "Screenshot, URL, recording, or post" },
+  { step: "Compose", detail: "Device frame, background, depth" },
+  { step: "Context", detail: "Text, marks, and extra shots" },
+] as const
+
+const SHIP = [
+  { step: "Animate", detail: "Timeline clips and easing curves" },
+  { step: "Export", detail: "Stills, video, or a public link" },
+] as const
+
+function Check() {
+  return (
+    <span className="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full bg-accent text-accent-foreground">
+      <RiCheckLine className="size-3" />
+    </span>
+  )
+}
+
+function Row({ step, detail }: { step: string; detail: string }) {
+  return (
+    <li className="flex items-start gap-3">
+      <Check />
+      <span className="text-[13px] leading-5 text-foreground/85">
+        {step}
+        <span className="text-foreground/45"> — {detail}</span>
+      </span>
+    </li>
+  )
+}
+
+function Arrow() {
+  return (
+    <div className="flex justify-center py-4 text-foreground/25">
+      <RiArrowDownLine className="size-4" />
+    </div>
+  )
+}
+
+export function HowItWorksFlow() {
+  return (
+    <div className="grid gap-3 lg:grid-cols-2">
+      <div className="rounded-[14px] border border-border/60 bg-background/40 p-1.5 backdrop-blur-sm">
+        <div className="rounded-[8px] border border-border/40 bg-background/60 px-6 py-10 sm:px-10">
+          <div className="mx-auto max-w-[19rem]">
+            <div className="rounded-md border border-border/50 bg-background/70 px-4 py-3">
+              <p className="font-mono text-[11px] text-foreground/75">
+                screenshot.png
+              </p>
+              <p className="mt-1 text-[12px] text-foreground/45">
+                Dropped on the canvas · 2560 × 1440
+              </p>
+            </div>
+
+            <Arrow />
+
+            <div className="overflow-hidden rounded-md border border-border/50 bg-background/70">
+              <p className="border-b border-border/50 px-4 py-2.5 text-center text-[13px] font-medium text-foreground">
+                Tokokino
+              </p>
+              <ul className="flex flex-col gap-3 px-4 py-4">
+                {BUILD.map((item) => (
+                  <Row key={item.step} {...item} />
+                ))}
+              </ul>
+              <ul className="flex flex-col gap-3 border-t border-border/50 px-4 py-4">
+                {SHIP.map((item) => (
+                  <Row key={item.step} {...item} />
+                ))}
+              </ul>
+            </div>
+
+            <Arrow />
+
+            <div className="rounded-md border border-border/50 bg-background/70 px-4 py-3">
+              <p className="font-mono text-[11px] text-primary">
+                launch-demo.webm
+              </p>
+              <p className="mt-1 text-[12px] text-foreground/45">
+                Encoded on your device · 4K · 2.4 MB
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-[14px] border border-border/60 bg-background/40 p-1.5 backdrop-blur-sm">
+        <div className="flex h-full items-center rounded-[8px] border border-border/40 bg-background/60 px-6 py-12 sm:px-12">
+          <p className="text-xl leading-[1.45] font-medium tracking-[-0.025em] sm:text-2xl">
+            You drop in a capture.
+            <br />
+            Tokokino frames, styles, and animates it.
+            <br />
+            <span className="text-primary">You export the file.</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/landing/how-it-works-vectors.tsx
+++ b/components/landing/how-it-works-vectors.tsx
@@ -553,3 +553,70 @@ export function ShareVector() {
     </Vector>
   )
 }
+
+export function MultiDeviceVector() {
+  return (
+    <Vector>
+      <R x={6} y={32} width={56} height={38} rx={5} />
+      <L x1={2} y1={76} x2={66} y2={76} />
+      <Ghost opacity={0.5}>
+        <R x={70} y={28} width={30} height={46} rx={5} />
+        <L x1={81} y1={69} x2={89} y2={69} />
+      </Ghost>
+      <Ghost opacity={0.35}>
+        <R x={104} y={40} width={13} height={34} rx={4} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function CompareVector() {
+  return (
+    <Vector>
+      <R x={8} y={26} width={44} height={62} rx={6} />
+      <Ghost opacity={0.45}>
+        <L x1={18} y1={44} x2={42} y2={44} />
+        <L x1={18} y1={56} x2={36} y2={56} />
+      </Ghost>
+      <Ghost opacity={0.5}>
+        <R x={68} y={26} width={44} height={62} rx={6} />
+        <L x1={78} y1={44} x2={102} y2={44} />
+        <L x1={78} y1={56} x2={96} y2={56} />
+      </Ghost>
+      <Ghost opacity={0.4}>
+        <L x1={60} y1={16} x2={60} y2={98} />
+      </Ghost>
+      <C cx={60} cy={57} r={7} />
+    </Vector>
+  )
+}
+
+export function AnnounceVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.35}>
+        <R x={8} y={32} width={64} height={52} rx={7} />
+      </Ghost>
+      <R x={20} y={46} width={34} height={24} rx={4} />
+      <Ghost opacity={0.6}>
+        <L x1={82} y1={44} x2={92} y2={34} />
+        <L x1={86} y1={58} x2={100} y2={58} />
+        <L x1={82} y1={72} x2={92} y2={82} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function WalkthroughVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.45}>
+        <P d="M14 94 C 40 94, 44 58, 60 58 S 88 26, 106 26" />
+      </Ghost>
+      <C cx={14} cy={94} r={6} />
+      <C cx={60} cy={58} r={7} />
+      <Dot cx={60} cy={58} r={2.4} />
+      <C cx={106} cy={26} r={6} />
+    </Vector>
+  )
+}

--- a/components/landing/how-it-works-vectors.tsx
+++ b/components/landing/how-it-works-vectors.tsx
@@ -1,0 +1,555 @@
+"use client"
+
+import type { ComponentProps, ReactNode } from "react"
+import { motion, useReducedMotion } from "motion/react"
+
+import { ease } from "@/components/landing/constants"
+
+const container = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.08 } },
+}
+
+const stroke = {
+  hidden: { pathLength: 0, opacity: 0 },
+  visible: {
+    pathLength: 1,
+    opacity: 1,
+    transition: {
+      pathLength: { duration: 0.5, ease },
+      opacity: { duration: 0.15 },
+    },
+  },
+}
+
+const solid = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.15 } },
+}
+
+function Vector({ children }: { children: ReactNode }) {
+  const shouldReduceMotion = useReducedMotion()
+
+  return (
+    <motion.svg
+      viewBox="0 0 120 120"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      variants={container}
+      initial={shouldReduceMotion ? "visible" : "hidden"}
+      whileInView="visible"
+      viewport={{ once: true, amount: 0.6 }}
+      className="size-full text-foreground/70"
+    >
+      {children}
+    </motion.svg>
+  )
+}
+
+function Ghost({
+  children,
+  opacity = 0.3,
+}: {
+  children: ReactNode
+  opacity?: number
+}) {
+  return <g opacity={opacity}>{children}</g>
+}
+
+const P = (props: ComponentProps<typeof motion.path>) => (
+  <motion.path variants={stroke} {...props} />
+)
+const R = (props: ComponentProps<typeof motion.rect>) => (
+  <motion.rect variants={stroke} {...props} />
+)
+const C = (props: ComponentProps<typeof motion.circle>) => (
+  <motion.circle variants={stroke} {...props} />
+)
+const L = (props: ComponentProps<typeof motion.line>) => (
+  <motion.line variants={stroke} {...props} />
+)
+const Dot = (props: ComponentProps<typeof motion.circle>) => (
+  <motion.circle
+    variants={solid}
+    fill="currentColor"
+    stroke="none"
+    {...props}
+  />
+)
+
+function CropMarks({
+  x,
+  y,
+  w,
+  h,
+}: {
+  x: number
+  y: number
+  w: number
+  h: number
+}) {
+  const arm = 4
+  const corners = [
+    [x, y],
+    [x + w, y],
+    [x, y + h],
+    [x + w, y + h],
+  ]
+
+  return (
+    <Ghost opacity={0.55}>
+      {corners.map(([cx, cy]) => (
+        <g key={`${cx}-${cy}`}>
+          <L x1={cx - arm} y1={cy} x2={cx + arm} y2={cy} />
+          <L x1={cx} y1={cy - arm} x2={cx} y2={cy + arm} />
+        </g>
+      ))}
+    </Ghost>
+  )
+}
+
+export function ImportVector() {
+  return (
+    <Vector>
+      <Ghost>
+        <R x={42} y={8} width={36} height={24} rx={4} />
+      </Ghost>
+      <L x1={60} y1={38} x2={60} y2={62} />
+      <P d="M53 55 L60 62 L67 55" />
+      <R x={18} y={70} width={84} height={36} rx={7} />
+    </Vector>
+  )
+}
+
+export function FrameVector() {
+  return (
+    <Vector>
+      <Ghost>
+        <R x={14} y={14} width={92} height={92} rx={16} />
+      </Ghost>
+      <R x={28} y={28} width={64} height={64} rx={10} />
+      <Ghost opacity={0.5}>
+        <R x={44} y={44} width={32} height={32} rx={5} />
+      </Ghost>
+      <CropMarks x={28} y={28} w={64} h={64} />
+    </Vector>
+  )
+}
+
+export function StyleVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.22}>
+        <P d="M6 62 A54 54 0 0 1 114 62" />
+      </Ghost>
+      <Ghost opacity={0.4}>
+        <P d="M14 62 A46 46 0 0 1 106 62" />
+      </Ghost>
+      <P d="M22 62 A38 38 0 0 1 98 62" />
+      <C cx={60} cy={62} r={22} />
+      <Ghost opacity={0.45}>
+        <L x1={10} y1={62} x2={110} y2={62} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function ContextVector() {
+  return (
+    <Vector>
+      <Ghost>
+        <R x={20} y={26} width={72} height={58} rx={7} />
+      </Ghost>
+      <L x1={32} y1={44} x2={70} y2={44} />
+      <L x1={32} y1={56} x2={58} y2={56} />
+      <P d="M100 104 L70 70" />
+      <P d="M70 70 L82 72 M70 70 L72 82" />
+      <Ghost opacity={0.55}>
+        <L x1={80} y1={30} x2={80} y2={40} />
+        <L x1={75} y1={35} x2={85} y2={35} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function ExportVector() {
+  return (
+    <Vector>
+      <Ghost>
+        <R x={22} y={52} width={76} height={54} rx={7} />
+      </Ghost>
+      <L x1={60} y1={78} x2={60} y2={20} />
+      <P d="M47 33 L60 20 L73 33" />
+      <Ghost opacity={0.5}>
+        <L x1={34} y1={92} x2={60} y2={92} />
+        <L x1={70} y1={92} x2={86} y2={92} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function DevicesVector() {
+  return (
+    <Vector>
+      <R x={12} y={30} width={68} height={54} rx={6} />
+      <L x1={12} y1={43} x2={80} y2={43} />
+      <Dot cx={21} cy={37} r={1.7} />
+      <Dot cx={27} cy={37} r={1.7} />
+      <Dot cx={33} cy={37} r={1.7} />
+      <Ghost opacity={0.55}>
+        <R x={84} y={40} width={24} height={48} rx={6} />
+        <L x1={92} y1={47} x2={100} y2={47} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function DepthVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.25}>
+        <R x={14} y={22} width={66} height={48} rx={7} />
+      </Ghost>
+      <Ghost opacity={0.5}>
+        <R x={27} y={35} width={66} height={48} rx={7} />
+      </Ghost>
+      <R x={40} y={48} width={66} height={48} rx={7} />
+    </Vector>
+  )
+}
+
+export function LaunchVector() {
+  return (
+    <Vector>
+      <Ghost>
+        <C cx={60} cy={60} r={30} />
+      </Ghost>
+      <L x1={60} y1={100} x2={60} y2={22} />
+      <P d="M48 34 L60 22 L72 34" />
+      <Ghost opacity={0.5}>
+        <L x1={40} y1={96} x2={46} y2={90} />
+        <L x1={80} y1={96} x2={74} y2={90} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function DemoVector() {
+  return (
+    <Vector>
+      <C cx={64} cy={60} r={26} />
+      <P d="M57 49 L57 71 L77 60 Z" />
+      <Ghost opacity={0.45}>
+        <P d="M30 40 A34 34 0 0 0 30 80" />
+      </Ghost>
+      <Ghost opacity={0.22}>
+        <P d="M18 32 A46 46 0 0 0 18 88" />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function AppStoreVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.4}>
+        <R x={4} y={30} width={30} height={60} rx={6} />
+      </Ghost>
+      <R x={42} y={22} width={36} height={76} rx={7} />
+      <L x1={54} y1={31} x2={66} y2={31} />
+      <Ghost opacity={0.4}>
+        <R x={86} y={30} width={30} height={60} rx={6} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function ChangelogVector() {
+  return (
+    <Vector>
+      <L x1={12} y1={62} x2={108} y2={62} />
+      <Ghost opacity={0.45}>
+        <C cx={30} cy={62} r={6} />
+      </Ghost>
+      <C cx={60} cy={62} r={9} />
+      <Dot cx={60} cy={62} r={2.6} />
+      <Ghost opacity={0.45}>
+        <C cx={90} cy={62} r={6} />
+      </Ghost>
+      <Ghost opacity={0.5}>
+        <L x1={60} y1={40} x2={60} y2={48} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function DocsVector() {
+  return (
+    <Vector>
+      <R x={22} y={16} width={66} height={86} rx={7} />
+      <L x1={34} y1={38} x2={76} y2={38} />
+      <L x1={34} y1={52} x2={76} y2={52} />
+      <Ghost opacity={0.5}>
+        <L x1={34} y1={66} x2={60} y2={66} />
+      </Ghost>
+      <P d="M108 82 L84 54" />
+      <P d="M84 54 L95 57 M84 54 L87 65" />
+    </Vector>
+  )
+}
+
+export function LandingVector() {
+  return (
+    <Vector>
+      <R x={14} y={18} width={92} height={46} rx={7} />
+      <Ghost opacity={0.45}>
+        <R x={14} y={74} width={26} height={28} rx={5} />
+        <R x={47} y={74} width={26} height={28} rx={5} />
+        <R x={80} y={74} width={26} height={28} rx={5} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function SocialVector() {
+  return (
+    <Vector>
+      <R x={16} y={22} width={88} height={56} rx={12} />
+      <P d="M38 78 L34 96 L56 78" />
+      <C cx={38} cy={42} r={8} />
+      <L x1={54} y1={39} x2={88} y2={39} />
+      <Ghost opacity={0.55}>
+        <L x1={54} y1={50} x2={78} y2={50} />
+        <L x1={30} y1={63} x2={88} y2={63} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function DeckVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.25}>
+        <R x={24} y={14} width={84} height={48} rx={6} />
+      </Ghost>
+      <R x={12} y={26} width={84} height={48} rx={6} />
+      <L x1={54} y1={74} x2={54} y2={94} />
+      <Ghost opacity={0.55}>
+        <L x1={34} y1={94} x2={74} y2={94} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function UrlVector() {
+  return (
+    <Vector>
+      <R x={10} y={28} width={100} height={64} rx={8} />
+      <L x1={10} y1={46} x2={110} y2={46} />
+      <Ghost opacity={0.5}>
+        <R x={32} y={32} width={68} height={9} rx={4.5} />
+      </Ghost>
+      <Dot cx={19} cy={37} r={1.8} />
+      <Dot cx={25} cy={37} r={1.8} />
+      <Ghost opacity={0.45}>
+        <L x1={24} y1={62} x2={96} y2={62} />
+        <L x1={24} y1={74} x2={70} y2={74} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function ClipVector() {
+  return (
+    <Vector>
+      <R x={10} y={32} width={100} height={56} rx={8} />
+      <Ghost opacity={0.4}>
+        <L x1={30} y1={32} x2={30} y2={88} />
+        <L x1={90} y1={32} x2={90} y2={88} />
+      </Ghost>
+      <P d="M52 48 L52 72 L74 60 Z" />
+    </Vector>
+  )
+}
+
+export function LinkCardVector() {
+  return (
+    <Vector>
+      <R x={14} y={22} width={92} height={76} rx={9} />
+      <C cx={34} cy={44} r={8} />
+      <Ghost opacity={0.5}>
+        <L x1={50} y1={40} x2={92} y2={40} />
+        <L x1={50} y1={50} x2={76} y2={50} />
+      </Ghost>
+      <R x={32} y={70} width={26} height={12} rx={6} />
+      <Ghost opacity={0.55}>
+        <R x={54} y={70} width={26} height={12} rx={6} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function TextVector() {
+  return (
+    <Vector>
+      <L x1={36} y1={34} x2={84} y2={34} />
+      <L x1={60} y1={34} x2={60} y2={86} />
+      <Ghost opacity={0.35}>
+        <R x={26} y={24} width={68} height={72} rx={2} />
+      </Ghost>
+      <Dot cx={26} cy={24} r={2.4} />
+      <Dot cx={94} cy={24} r={2.4} />
+      <Dot cx={26} cy={96} r={2.4} />
+      <Dot cx={94} cy={96} r={2.4} />
+    </Vector>
+  )
+}
+
+export function ShapesVector() {
+  return (
+    <Vector>
+      <C cx={46} cy={52} r={24} />
+      <Ghost opacity={0.5}>
+        <R x={54} y={44} width={48} height={48} rx={7} />
+      </Ghost>
+      <Ghost opacity={0.35}>
+        <P d="M18 94 L44 94 L31 72 Z" />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function SlotsVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.4}>
+        <g transform="rotate(-13 26 62)">
+          <R x={4} y={44} width={42} height={34} rx={5} />
+        </g>
+        <g transform="rotate(13 94 62)">
+          <R x={74} y={44} width={42} height={34} rx={5} />
+        </g>
+      </Ghost>
+      <R x={32} y={36} width={56} height={44} rx={7} />
+    </Vector>
+  )
+}
+
+export function TimelineVector() {
+  return (
+    <Vector>
+      <R x={8} y={44} width={34} height={18} rx={4} />
+      <Ghost opacity={0.45}>
+        <R x={48} y={44} width={26} height={18} rx={4} />
+        <R x={80} y={44} width={32} height={18} rx={4} />
+      </Ghost>
+      <Ghost opacity={0.4}>
+        <L x1={8} y1={80} x2={112} y2={80} />
+        <L x1={20} y1={84} x2={20} y2={90} />
+        <L x1={44} y1={84} x2={44} y2={90} />
+        <L x1={68} y1={84} x2={68} y2={90} />
+        <L x1={92} y1={84} x2={92} y2={90} />
+      </Ghost>
+      <L x1={62} y1={26} x2={62} y2={92} />
+      <R x={57} y={20} width={10} height={9} rx={2} />
+    </Vector>
+  )
+}
+
+export function EasingVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.35}>
+        <L x1={18} y1={22} x2={18} y2={98} />
+        <L x1={18} y1={98} x2={104} y2={98} />
+      </Ghost>
+      <P d="M18 98 C 40 98, 62 28, 104 28" />
+      <Ghost opacity={0.5}>
+        <L x1={18} y1={98} x2={40} y2={98} />
+        <L x1={104} y1={28} x2={82} y2={28} />
+      </Ghost>
+      <Dot cx={40} cy={98} r={3} />
+      <Dot cx={82} cy={28} r={3} />
+    </Vector>
+  )
+}
+
+export function TargetVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.35}>
+        <R x={22} y={28} width={76} height={60} rx={8} />
+      </Ghost>
+      <C cx={60} cy={58} r={15} />
+      <L x1={60} y1={34} x2={60} y2={42} />
+      <L x1={60} y1={74} x2={60} y2={82} />
+      <L x1={36} y1={58} x2={44} y2={58} />
+      <L x1={76} y1={58} x2={84} y2={58} />
+      <Dot cx={60} cy={58} r={2.8} />
+    </Vector>
+  )
+}
+
+export function TrimVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.35}>
+        <R x={10} y={44} width={100} height={32} rx={5} />
+      </Ghost>
+      <R x={28} y={38} width={7} height={44} rx={3} />
+      <R x={85} y={38} width={7} height={44} rx={3} />
+      <Ghost opacity={0.5}>
+        <L x1={44} y1={54} x2={44} y2={66} />
+        <L x1={54} y1={50} x2={54} y2={70} />
+        <L x1={64} y1={56} x2={64} y2={64} />
+        <L x1={74} y1={49} x2={74} y2={71} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function RenderVector() {
+  return (
+    <Vector>
+      <R x={18} y={24} width={84} height={46} rx={7} />
+      <Ghost opacity={0.4}>
+        <L x1={38} y1={24} x2={38} y2={70} />
+        <L x1={82} y1={24} x2={82} y2={70} />
+      </Ghost>
+      <L x1={60} y1={74} x2={60} y2={100} />
+      <P d="M49 89 L60 100 L71 89" />
+    </Vector>
+  )
+}
+
+export function ClipboardVector() {
+  return (
+    <Vector>
+      <R x={30} y={24} width={60} height={76} rx={8} />
+      <R x={48} y={16} width={24} height={14} rx={4} />
+      <Ghost opacity={0.45}>
+        <L x1={44} y1={54} x2={76} y2={54} />
+        <L x1={44} y1={66} x2={68} y2={66} />
+        <L x1={44} y1={78} x2={72} y2={78} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function ShareVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.45}>
+        <L x1={38} y1={44} x2={80} y2={56} />
+        <L x1={38} y1={78} x2={80} y2={66} />
+      </Ghost>
+      <C cx={30} cy={40} r={9} />
+      <C cx={30} cy={82} r={9} />
+      <C cx={88} cy={61} r={9} />
+    </Vector>
+  )
+}

--- a/components/landing/how-it-works.tsx
+++ b/components/landing/how-it-works.tsx
@@ -1,7 +1,9 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import Link from "next/link"
 import { motion } from "motion/react"
+import { ArrowRight } from "@/components/landing/landing-svgs"
 import { ease } from "@/components/landing/constants"
 import { ShimmerImage } from "@/components/ui/shimmer-image"
 
@@ -100,6 +102,14 @@ export function HowItWorks() {
           mockups, and timeline animations. Click a step to move the spotlight
           over the matching part of the flow.
         </p>
+
+        <Link
+          href="/how-it-works"
+          className="group inline-flex w-fit items-center gap-2 rounded-md border border-border/70 bg-background/40 px-4 py-2 text-sm font-medium text-foreground/80 backdrop-blur-sm transition hover:border-primary/50 hover:text-foreground"
+        >
+          Read the full walkthrough
+          <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+        </Link>
       </motion.div>
 
       <div className="relative overflow-hidden rounded-md border border-border/70 bg-background/55 backdrop-blur-md">

--- a/components/landing/nav.tsx
+++ b/components/landing/nav.tsx
@@ -21,7 +21,7 @@ const links = [
   { label: "Templates", href: "#templates" },
   { label: "Comparison", href: "#comparison" },
   { label: "Use cases", href: "#use-cases" },
-  { label: "How it works", href: "#how-it-works" },
+  { label: "How it works", href: "/how-it-works" },
   { label: "Contact", href: "#contact" },
 ]
 

--- a/components/landing/nav.tsx
+++ b/components/landing/nav.tsx
@@ -20,7 +20,7 @@ const links = [
   { label: "Features", href: "#features" },
   { label: "Templates", href: "#templates" },
   { label: "Comparison", href: "#comparison" },
-  { label: "Use cases", href: "#use-cases" },
+  { label: "Use cases", href: "/use-cases" },
   { label: "How it works", href: "/how-it-works" },
   { label: "Contact", href: "#contact" },
 ]

--- a/components/landing/use-cases-section.tsx
+++ b/components/landing/use-cases-section.tsx
@@ -6,7 +6,9 @@ import {
   RiRocketLine,
   RiWindowLine,
 } from "@remixicon/react"
+import Link from "next/link"
 import { motion } from "motion/react"
+import { ArrowRight } from "@/components/landing/landing-svgs"
 import { ease } from "@/components/landing/constants"
 
 const USE_CASES = [
@@ -90,6 +92,14 @@ export function UseCasesSection() {
               )
             })}
           </div>
+
+          <Link
+            href="/how-it-works#use-cases"
+            className="group inline-flex w-fit items-center gap-2 rounded-md border border-border/70 bg-background/40 px-4 py-2 text-sm font-medium text-foreground/80 backdrop-blur-sm transition hover:border-primary/50 hover:text-foreground"
+          >
+            See every use case
+            <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+          </Link>
         </motion.div>
 
         <div className="grid gap-3 sm:grid-cols-2">

--- a/components/landing/use-cases-section.tsx
+++ b/components/landing/use-cases-section.tsx
@@ -94,7 +94,7 @@ export function UseCasesSection() {
           </div>
 
           <Link
-            href="/how-it-works#use-cases"
+            href="/use-cases"
             className="group inline-flex w-fit items-center gap-2 rounded-md border border-border/70 bg-background/40 px-4 py-2 text-sm font-medium text-foreground/80 backdrop-blur-sm transition hover:border-primary/50 hover:text-foreground"
           >
             See every use case

--- a/components/landing/vector-card.tsx
+++ b/components/landing/vector-card.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react"
+
+export function VectorCard({
+  vector,
+  title,
+  body,
+  meta,
+}: {
+  vector: ReactNode
+  title: string
+  body: string
+  meta?: string
+}) {
+  return (
+    <div className="h-full rounded-[14px] border border-border/60 bg-background/40 p-1.5 backdrop-blur-sm transition-colors hover:border-border/90">
+      <div className="flex h-full flex-col rounded-[8px] border border-border/40 bg-background/60 p-5">
+        <div className="flex h-[8.5rem] shrink-0 items-center justify-center">
+          <div className="aspect-square h-full">{vector}</div>
+        </div>
+        <div className="mt-6 flex flex-col gap-1.5">
+          {meta ? (
+            <span className="font-mono text-[10px] tracking-[0.2em] text-foreground/36 uppercase">
+              {meta}
+            </span>
+          ) : null}
+          <h3 className="text-[14px] font-semibold tracking-tight text-foreground">
+            {title}
+          </h3>
+          <p className="text-[12.5px] leading-5 text-foreground/52">{body}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/seo/how-it-works-structured-data.ts
+++ b/lib/seo/how-it-works-structured-data.ts
@@ -1,0 +1,82 @@
+const SITE_URL = "https://tokokino.com"
+const PAGE_URL = `${SITE_URL}/how-it-works`
+
+type Step = {
+  name: string
+  body: string
+  anchor: string
+}
+
+type Faq = {
+  q: string
+  a: string
+}
+
+export function howItWorksStructuredData({
+  steps,
+  faqs,
+}: {
+  steps: readonly Step[]
+  faqs: readonly Faq[]
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "HowTo",
+        "@id": `${PAGE_URL}/#howto`,
+        name: "How to make a polished product screenshot or animated demo",
+        description:
+          "Bring in a capture, frame it, style the scene, add context, animate the key moments, then export a still or a video — all in the browser.",
+        url: PAGE_URL,
+        totalTime: "PT5M",
+        estimatedCost: {
+          "@type": "MonetaryAmount",
+          currency: "USD",
+          value: "0",
+        },
+        tool: {
+          "@type": "HowToTool",
+          name: "Tokokino",
+        },
+        step: steps.map((step, index) => ({
+          "@type": "HowToStep",
+          position: index + 1,
+          name: step.name,
+          text: step.body,
+          url: `${PAGE_URL}#${step.anchor}`,
+        })),
+      },
+      {
+        "@type": "FAQPage",
+        "@id": `${PAGE_URL}/#faq`,
+        mainEntity: faqs.map((faq) => ({
+          "@type": "Question",
+          name: faq.q,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: faq.a,
+          },
+        })),
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": `${PAGE_URL}/#breadcrumbs`,
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Tokokino",
+            item: SITE_URL,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "How it works",
+            item: PAGE_URL,
+          },
+        ],
+      },
+    ],
+  }
+}

--- a/lib/seo/page-metadata.ts
+++ b/lib/seo/page-metadata.ts
@@ -1,0 +1,46 @@
+import type { Metadata } from "next"
+
+const OG_IMAGE = {
+  url: "/opengraph.png?v=2",
+  width: 1920,
+  height: 1008,
+  alt: "Tokokino screenshot and animated demo editor preview",
+} as const
+
+/**
+ * Next merges metadata shallowly, so a page that sets `openGraph` replaces the
+ * root object outright — including its images. Anything overriding the social
+ * card has to restate every field it still wants.
+ */
+export function pageMetadata({
+  title,
+  description,
+  path,
+  type = "website",
+}: {
+  title: string
+  description: string
+  path: string
+  type?: "website" | "article"
+}): Metadata {
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    openGraph: {
+      title,
+      description,
+      url: path,
+      type,
+      siteName: "Tokokino",
+      locale: "en_US",
+      images: [{ ...OG_IMAGE, type: "image/png" }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [OG_IMAGE],
+    },
+  }
+}

--- a/lib/seo/use-cases-structured-data.ts
+++ b/lib/seo/use-cases-structured-data.ts
@@ -1,0 +1,71 @@
+const SITE_URL = "https://tokokino.com"
+const PAGE_URL = `${SITE_URL}/use-cases`
+
+type UseCase = {
+  title: string
+  body: string
+}
+
+type Faq = {
+  q: string
+  a: string
+}
+
+export function useCasesStructuredData({
+  cases,
+  faqs,
+}: {
+  cases: readonly UseCase[]
+  faqs: readonly Faq[]
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "ItemList",
+        "@id": `${PAGE_URL}/#use-cases`,
+        name: "What people build with Tokokino",
+        description:
+          "Launch posts, app store screenshots, animated product demos, changelog images, documentation stills, landing page visuals, and social proof.",
+        url: PAGE_URL,
+        numberOfItems: cases.length,
+        itemListElement: cases.map((useCase, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          name: useCase.title,
+          description: useCase.body,
+        })),
+      },
+      {
+        "@type": "FAQPage",
+        "@id": `${PAGE_URL}/#faq`,
+        mainEntity: faqs.map((faq) => ({
+          "@type": "Question",
+          name: faq.q,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: faq.a,
+          },
+        })),
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": `${PAGE_URL}/#breadcrumbs`,
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Tokokino",
+            item: SITE_URL,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Use cases",
+            item: PAGE_URL,
+          },
+        ],
+      },
+    ],
+  }
+}


### PR DESCRIPTION
Two new marketing pages targeting the "how it works" and use-case queries the landing anchors were competing for, plus fixes to the social-card metadata across the marketing site.

## `/how-it-works`

A walkthrough of the editor: hero, five step sections (Capture, Compose, Context, Animate, Export), an end-to-end flow diagram, the local-first boundary, and an FAQ.

Each step section pairs a two-column header with a row of four cards, and every card carries a stroke-drawn line-art vector. The flow diagram shows `screenshot.png` → a Tokokino box with the five steps checklisted → `launch-demo.webm`, next to a three-line summary.

## `/use-cases`

Twelve use cases grouped into **Announcing**, **On device**, and **Explaining**, then an **Output** section covering what each job actually ends in — stills, video, clipboard, share link.

Reuses the vector card, section header, and flow diagram from `/how-it-works`; four new vectors cover the cases that had none. The hero carries an ordered-dither field: a Bayer-thresholded falloff rendered one pixel per cell on an offscreen buffer and scaled up with smoothing off, capped at 20fps and masked to a bottom-right bleed. It reads `--primary` by resolving the oklch value through a 1×1 canvas, so it stays theme-correct with no hardcoded hex, and renders a single static frame under `prefers-reduced-motion`.

## SEO fixes

Two of these are pre-existing bugs, not just new-page setup:

- **`/how-it-works` and `/use-cases` advertised the landing page.** Both served the root's `og:title`, `og:description`, and `og:url: https://tokokino.com`, so sharing either showed the wrong page entirely.
- **`/compare/[slug]` had lost its `og:image`.** Next merges metadata shallowly, so that page's `openGraph` block replaced the root's rather than extending it — the comparison pages have been shipping social cards with no image, while `twitter:title`/`twitter:description` still showed the landing copy.

`lib/seo/page-metadata.ts` restates every field a social card needs, and all three routes use it.

- Dropped the `/#how-it-works` and `/#use-cases` sitemap entries — fragments normalise to `/`, so they competed with the dedicated pages at the same 0.8 priority.
- Both pages added to `llms.txt`.
- Structured data: `/how-it-works` serves HowTo (5 steps) + FAQPage (7) + BreadcrumbList; `/use-cases` serves ItemList (12) + FAQPage (5) + BreadcrumbList.

## Design

Everything is built on the existing token set — no new colours, no box-shadows, `--primary` reserved for the single highest-intent action per view. The FAQ accordion is now exported as `FaqColumn` so both pages reuse the landing's, and the `FinalCta` and `FlickeringGrid` come straight from the landing so the pages open the same way it does.

## Also changed

- `/how-it-works` no longer carries a use-cases section — it duplicated the whole of the new page. It links across instead. **The `/how-it-works#use-cases` anchor no longer exists**; nothing in the repo points at it, but any external link would now land at the top of the page.
- Nav, footer, sitemap, and the landing's own sections link to both new pages.

## Verification

`pnpm typecheck`, `pnpm lint:strict`, and `oxfmt` all clean. Every marketing route returns 200; social tags, canonicals, sitemap, and structured data checked against the rendered HTML.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds dedicated `/how-it-works` and `/use-cases` marketing routes, with reusable visual components, structured data, navigation updates, and complete per-page social metadata.
- Adds walkthrough and use-case content with reusable vector cards, flow diagrams, FAQ sections, and animated artwork.
- Adds HowTo, ItemList, FAQ, and breadcrumb structured data.
- Centralizes canonical, Open Graph, and Twitter metadata and restores comparison-page social images.
- Updates the sitemap, `llms.txt`, landing links, navigation, and footer for the new routes.

<h3>Confidence Score: 4/5</h3>

The theme-dependent dither color should be refreshed before merging; its offscreen animation cost is also worth addressing.

Theme toggling leaves the newly added hero canvas rendering a stale primary color because its RGB value is captured only at mount, while the same component also keeps repainting after it scrolls out of view.

**Files Needing Attention:** components/landing/dither-field.tsx

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/landing/dither-field.tsx | Adds the ordered-dither canvas, but its captured theme color becomes stale after theme changes and its animation continues while offscreen. |
| app/how-it-works/page.tsx | Adds the complete walkthrough page with metadata, structured data, reusable cards, FAQ content, and cross-page navigation. |
| app/use-cases/page.tsx | Adds the use-cases page and mounts the new dither effect; the page composition and structured-data wiring are otherwise coherent. |
| lib/seo/page-metadata.ts | Centralizes complete canonical and social-card metadata, relying correctly on the root metadata base for absolute URL resolution. |
| lib/seo/how-it-works-structured-data.ts | Generates consistent HowTo, FAQPage, and BreadcrumbList structured data from page-owned content. |
| lib/seo/use-cases-structured-data.ts | Generates ItemList, FAQPage, and BreadcrumbList structured data for the new use-cases route. |
| components/landing/nav.tsx | Replaces landing-only use-case and walkthrough anchors with dedicated route links while preserving established fragment rewriting. |
| app/compare/[slug]/page.tsx | Adopts the shared metadata helper to restore complete Open Graph and Twitter cards for comparison pages. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20shivabhattacharjee%2Ftokokino%20PR%20%2371%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=shivabhattacharjee%2Ftokokino&pr=71&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acomponents%2Flanding%2Fdither-field.tsx%3A66%0A**Theme%20color%20remains%20stale**%0A%0AWhen%20a%20user%20toggles%20the%20theme%20on%20%60%2Fuse-cases%60%2C%20%60readRgb%60%20is%20not%20called%20again%2C%20so%20the%20canvas%20retains%20the%20previous%20%60--primary%60%20color%20while%20the%20surrounding%20token-based%20elements%20adopt%20the%20new%20theme.%0A%0A%23%23%23%20Issue%202%0Acomponents%2Flanding%2Fdither-field.tsx%3A125-131%0A**Offscreen%20animation%20keeps%20repainting**%0A%0AAfter%20the%20hero%20scrolls%20out%20of%20view%2C%20this%20callback%20continues%20rebuilding%20and%20drawing%20the%20dither%20buffer%20at%20up%20to%2020%20frames%20per%20second.%20Add%20visibility%20gating%20like%20the%20sibling%20%60FlickeringGrid%60%20to%20avoid%20unnecessary%20CPU%20and%20battery%20use.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=shivabhattacharjee%2Ftokokino&pr=71&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
components/landing/dither-field.tsx:66
**Theme color remains stale**

When a user toggles the theme on `/use-cases`, `readRgb` is not called again, so the canvas retains the previous `--primary` color while the surrounding token-based elements adopt the new theme.

### Issue 2
components/landing/dither-field.tsx:125-131
**Offscreen animation keeps repainting**

After the hero scrolls out of view, this callback continues rebuilding and drawing the dither buffer at up to 20 frames per second. Add visibility gating like the sibling `FlickeringGrid` to avoid unnecessary CPU and battery use.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(marketing): add /use-cases page and..."](https://github.com/shivabhattacharjee/tokokino/commit/954cbd537d388ad58d35f0ef451cf610ec8045bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57875010)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated “How it works” and “Use cases” landing pages with walkthroughs, FAQs, workflows, and calls to action.
  * Added animated illustrations, workflow visuals, and a dither-field background effect.
  * Added navigation and footer links to the new pages.
* **SEO**
  * Improved page metadata, canonical URLs, sitemap entries, and structured search data.
* **Accessibility**
  * Added reduced-motion support for animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->