### PR TITLE
Rebuild the about page, share one index across doc pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -94,7 +94,7 @@ const linkClass =
   "font-medium text-primary underline decoration-primary/35 underline-offset-4 transition-colors hover:text-primary/80"
 
 const solidCtaClass =
-  "group inline-flex w-fit items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-95"
+  "group inline-flex w-fit items-center gap-2 rounded-md border border-transparent bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-95"
 
 const outlineCtaClass =
   "group inline-flex w-fit items-center gap-2 rounded-md border border-border/70 bg-background/40 px-4 py-2 text-sm font-medium text-foreground/80 backdrop-blur-sm transition hover:border-primary/45 hover:text-foreground"

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,123 +1,543 @@
 import type { Metadata } from "next"
+import type { CSSProperties, ReactNode } from "react"
 import Link from "next/link"
 
-import { DocPage } from "@/components/landing/doc-page"
+import {
+  AboutBannerVector,
+  BoundaryVector,
+  BrowserVector,
+  DeviceStoreVector,
+  MotionVector,
+  OpenSourceVector,
+  SoloVector,
+  PresetVector,
+  ServerVector,
+} from "@/components/landing/about-vectors"
+import { DashedH } from "@/components/landing/dashed-h"
+import { DitherField } from "@/components/landing/dither-field"
+import { FinalCta } from "@/components/landing/final-cta"
+import { Footer } from "@/components/landing/footer"
+import { FlickeringGrid } from "@/components/ui/flickering-grid"
+import { ArrowRight, StarIcon } from "@/components/landing/landing-svgs"
+import { Nav } from "@/components/landing/nav"
+import { RAIL_V_STYLE } from "@/components/landing/rail-styles"
+import { ScrollToTop } from "@/components/landing/scroll-to-top"
+import { VectorCard } from "@/components/landing/vector-card"
+import { aboutStructuredData } from "@/lib/seo/about-structured-data"
+import { pageMetadata } from "@/lib/seo/page-metadata"
+import { serializeJsonLd } from "@/lib/seo/tokokino-structured-data"
 
-export const metadata: Metadata = {
-  title: "About Tokokino",
+export const metadata: Metadata = pageMetadata({
+  title: "About Tokokino — a local-first editor for product visuals",
   description:
-    "Learn why Tokokino exists, how its local-first editor works, and how the open-source project is maintained.",
+    "Why Tokokino exists, where the work actually runs, the decisions that shape the product, and who maintains the open-source project.",
+  path: "/about",
+  type: "article",
+})
+
+const CONTENT_WIDTH =
+  "mx-auto max-w-[76rem] w-[calc(100%-1rem)] sm:w-[calc(100%-2rem)] md:w-[calc(100%-3rem)] lg:w-[calc(100%-4rem)] xl:w-full"
+
+const PIPELINE = ["Capture", "Compose", "Context", "Animate", "Export"] as const
+
+const PRINCIPLES = [
+  {
+    title: "Local-first by default",
+    body: "Editing, rasterising, and video encoding run in your browser. Nothing is uploaded because you opened it.",
+  },
+  {
+    title: "One canvas for stills and motion",
+    body: "A demo is the composition you already made, moving. The timeline sits on the same canvas as the still.",
+  },
+  {
+    title: "Presets over repetition",
+    body: "A look you liked once should be a click on the next shot, not a rebuild in a general design file.",
+  },
+  {
+    title: "Open enough to be read",
+    body: "The source is public under AGPL-3.0, so the privacy boundary can be checked rather than trusted.",
+  },
+  {
+    title: "Small on purpose",
+    body: "This is screenshot-led product communication. Illustration and long-form video belong to other tools.",
+  },
+] as const
+
+const BOUNDARY = [
+  {
+    title: "In your browser",
+    vector: <BrowserVector />,
+    meta: "Editing · Export",
+    body: "The canvas, every still raster, and video encoding through WebCodecs — all on your own machine.",
+  },
+  {
+    title: "On your device",
+    vector: <DeviceStoreVector />,
+    meta: "Drafts · Offline",
+    body: "Work in progress is stored locally, and the editor can be installed to keep working with no network.",
+  },
+  {
+    title: "On the server, when asked",
+    vector: <ServerVector />,
+    meta: "Explicit calls",
+    body: "Capturing a URL, fetching a social post, syncing a cloud draft, publishing a share link. Nothing implicit.",
+  },
+  {
+    title: "Never by default",
+    vector: <BoundaryVector />,
+    meta: "Source captures",
+    body: "The file you dropped on the canvas stays with you. Sharing sends the rendered result, not the source.",
+  },
+] as const
+
+const linkClass =
+  "font-medium text-primary underline decoration-primary/35 underline-offset-4 transition-colors hover:text-primary/80"
+
+const solidCtaClass =
+  "group inline-flex w-fit items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-95"
+
+const outlineCtaClass =
+  "group inline-flex w-fit items-center gap-2 rounded-md border border-border/70 bg-background/40 px-4 py-2 text-sm font-medium text-foreground/80 backdrop-blur-sm transition hover:border-primary/45 hover:text-foreground"
+
+const FACTS = [
+  { label: "Maintainer", value: "Shiva Bhattacharjee" },
+  { label: "Based in", value: "Guwahati, India" },
+  { label: "License", value: "AGPL-3.0" },
+  { label: "Company", value: "None" },
+] as const
+
+function SectionHeader({
+  eyebrow,
+  label,
+  headline,
+  subhead,
+  lead,
+}: {
+  eyebrow: string
+  label: string
+  headline: string
+  subhead: string
+  lead: ReactNode
+}) {
+  return (
+    <div className="grid gap-6 lg:grid-cols-2 lg:gap-16">
+      <div>
+        <span className="font-mono text-[10px] tracking-widest text-primary/80 uppercase">
+          {`// ${eyebrow}`}
+        </span>
+        <h2 className="mt-3 text-2xl font-medium tracking-[-0.025em] sm:text-3xl">
+          {label}
+        </h2>
+      </div>
+      <div className="max-w-xl">
+        <p className="text-2xl leading-[1.2] font-medium tracking-[-0.025em] text-balance sm:text-3xl">
+          {headline}
+          <br />
+          <span className="text-foreground/45">{subhead}</span>
+        </p>
+        <div className="mt-6 text-sm leading-7 text-foreground/58">{lead}</div>
+      </div>
+    </div>
+  )
 }
 
-const sections = [
-  {
-    title: "A focused tool for product visuals",
-    body: (
-      <>
-        Tokokino exists to shorten the distance between a raw product capture
-        and a visual that is ready for a launch, changelog, help article,
-        presentation, or social post. Instead of rebuilding the same frame,
-        background, spacing, and annotation treatment in a general design suite,
-        you can start with a screenshot or recording and work inside an editor
-        built around that material. Device mockups, browser frames, multi-shot
-        layouts, reusable presets, and high-resolution exports are part of the
-        same workflow.
-      </>
-    ),
-  },
-  {
-    title: "Local-first by design",
-    body: (
-      <>
-        The interactive editor runs primarily in your browser. Ordinary edits
-        and exports do not require an account, and source captures are not
-        uploaded merely because you opened them in the canvas. Server-backed
-        features are explicit: signing in can enable cloud drafts, and creating
-        a public share sends the rendered result needed for that link. This
-        boundary keeps quick, private editing simple while still making
-        collaboration available when you choose it.
-      </>
-    ),
-  },
-  {
-    title: "Still images and motion in one editor",
-    body: (
-      <>
-        Tokokino handles polished PNG, JPEG, and WebP compositions as well as
-        short animated demos. A timeline can animate canvas effects and
-        transitions, while video and GIF inputs can be cropped, trimmed, and
-        combined with the same framing and backdrop tools used for stills. The
-        goal is not to replace a full illustration or long-form video suite; it
-        is to make screenshot-led product communication faster and more
-        consistent.
-      </>
-    ),
-  },
-  {
-    title: "An independent open-source project",
-    body: (
-      <>
-        Tokokino is an independent personal project maintained by Shiva
-        Bhattacharjee from Guwahati, Assam, India. It is not presented as a
-        registered company. The source is published under the AGPL-3.0 license,
-        so people can inspect how the product works, report problems, propose
-        improvements, and self-host it subject to the license. Product updates
-        are documented in the changelog, and public development happens through
-        the project repository.
-      </>
-    ),
-  },
-]
+function Section({ id, children }: { id: string; children: ReactNode }) {
+  return (
+    <section
+      id={id}
+      className="scroll-mt-24 border-t border-border/50 pt-14 first:border-t-0 first:pt-0"
+    >
+      {children}
+    </section>
+  )
+}
 
 export default function AboutPage() {
   return (
-    <DocPage
-      eyebrow="About"
-      title="A smaller, sharper way to present product work."
-      summary="Tokokino is an open-source, local-first editor for polished screenshots, mockups, social visuals, and short animated product demos."
+    <main
+      className="relative isolate min-h-svh bg-background text-foreground"
+      style={
+        {
+          "--rail": "color-mix(in oklch, var(--foreground) 20%, transparent)",
+        } as CSSProperties
+      }
     >
-      <article className="max-w-3xl">
-        <div className="grid gap-px overflow-hidden rounded-md border border-border/60 bg-border/60 sm:grid-cols-2">
-          {sections.map((section) => (
-            <section
-              key={section.title}
-              className="bg-background/80 p-6 sm:p-7"
-            >
-              <h2 className="text-base font-medium tracking-tight sm:text-lg">
-                {section.title}
-              </h2>
-              <p className="mt-4 text-sm leading-7 text-foreground/58">
-                {section.body}
-              </p>
-            </section>
-          ))}
-        </div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: serializeJsonLd(
+            aboutStructuredData({ principles: PRINCIPLES })
+          ),
+        }}
+      />
 
-        <div className="mt-10 border-t border-border/50 pt-8 text-sm leading-7 text-foreground/58">
-          Ready to make something? Open the{" "}
-          <Link
-            href="/app"
-            className="font-medium text-primary underline decoration-primary/35 underline-offset-4 transition-colors hover:text-primary/80"
+      <div className="pointer-events-none fixed inset-0 z-0">
+        <FlickeringGrid
+          color="rgb(255,255,255)"
+          maxOpacity={0.035}
+          flickerChance={0.08}
+          squareSize={3}
+          gridGap={8}
+          className="h-full w-full"
+        />
+      </div>
+
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <Nav />
+      </div>
+      <DashedH />
+
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <section className="landing-page-in relative flex flex-col items-center overflow-hidden px-5 pt-14 pb-14 text-center sm:px-8 sm:pt-20 sm:pb-20 lg:px-12">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 -z-10 opacity-35"
+            style={{
+              maskImage:
+                "linear-gradient(to top left, black 5%, transparent 62%)",
+              WebkitMaskImage:
+                "linear-gradient(to top left, black 5%, transparent 62%)",
+            }}
           >
-            editor
-          </Link>
-          , browse the{" "}
-          <Link
-            href="/showcase"
-            className="font-medium text-primary underline decoration-primary/35 underline-offset-4 transition-colors hover:text-primary/80"
+            <DitherField cell={6} speed={0.35} intensity={0.7} />
+          </div>
+
+          <span
+            style={{ "--landing-rise-duration": "0.6s" } as CSSProperties}
+            className="landing-rise font-mono text-[10px] tracking-[0.28em] text-primary/80 uppercase"
           >
-            template showcase
-          </Link>
-          , or visit the{" "}
-          <Link
-            href="/contact"
-            className="font-medium text-primary underline decoration-primary/35 underline-offset-4 transition-colors hover:text-primary/80"
+            {"// About"}
+          </span>
+          <h1
+            style={
+              {
+                "--landing-rise-from": "12px",
+                "--landing-rise-duration": "0.7s",
+                "--landing-rise-delay": "0.1s",
+              } as CSSProperties
+            }
+            className="landing-rise mt-5 max-w-5xl text-[clamp(1.4rem,0.85rem+3.8vw,1.625rem)] leading-[1.1] font-medium tracking-[-0.035em] text-balance sm:text-5xl sm:leading-[1.06] sm:tracking-[-0.03em] lg:text-[3.75rem]"
           >
-            contact page
-          </Link>{" "}
-          if you need help or want to contribute.
+            <span className="whitespace-nowrap">One small editor for</span>
+            <br />
+            <span className="text-primary">the visuals a product needs.</span>
+          </h1>
+          <p
+            style={
+              {
+                "--landing-rise-duration": "0.6s",
+                "--landing-rise-delay": "0.3s",
+              } as CSSProperties
+            }
+            className="landing-rise mt-6 max-w-xl text-[13px] leading-[1.6] text-balance text-foreground/58 sm:text-[15px] sm:leading-relaxed"
+          >
+            Tokokino is an open-source, local-first editor for polished
+            screenshots, mockups, social visuals, and short animated product
+            demos. It is an independent project, maintained by one person.
+          </p>
+          <div
+            style={
+              {
+                "--landing-rise-duration": "0.6s",
+                "--landing-rise-delay": "0.4s",
+              } as CSSProperties
+            }
+            className="landing-rise mt-9 flex flex-wrap items-center justify-center gap-3"
+          >
+            <Link
+              href="/app"
+              className="group inline-flex items-center gap-2 rounded-md bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition hover:opacity-95"
+            >
+              Start editing
+              <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+            </Link>
+            <a
+              href="https://git.new/Tokokino"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-5 py-2.5 text-sm font-medium text-foreground/70 backdrop-blur-sm transition hover:border-foreground/30 hover:text-foreground"
+            >
+              <StarIcon className="size-3.5 text-yellow-400" />
+              Star on GitHub
+            </a>
+          </div>
+        </section>
+      </div>
+      <DashedH />
+
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <div className="landing-page-in flex flex-col gap-14 px-5 py-14 sm:px-8 sm:py-16 lg:px-12">
+          <Section id="mission">
+            <SectionHeader
+              eyebrow="Mission"
+              label="Why does it exist?"
+              headline="visual = fn(capture)"
+              subhead="Raw material in, something shippable out"
+              lead={
+                <>
+                  <p>
+                    Product work rarely starts as a tidy image. It starts as a
+                    screenshot at an awkward resolution, a recording that runs
+                    too long, or a page that only exists behind a login. The
+                    distance between that and something you would put on a
+                    launch post is mostly repetition: frame it, pad it, choose a
+                    background, point at the part that matters, export it at the
+                    right size.
+                  </p>
+                  <p className="mt-4">
+                    Tokokino exists to make that distance short and repeatable.
+                    Instead of rebuilding the same treatment in a general design
+                    suite, you start from the capture and work in an editor
+                    built around it — device mockups, browser chrome, multi-shot
+                    layouts, reusable presets, and high-resolution exports are
+                    all the same workflow.
+                  </p>
+                </>
+              }
+            />
+
+            <div className="mt-12 rounded-[14px] border border-border/60 bg-background/40 p-1.5 backdrop-blur-sm">
+              <div className="rounded-[8px] border border-border/40 bg-background/60 px-4 py-8 sm:px-10 sm:py-10">
+                <div className="mx-auto aspect-[16/5] w-full max-w-4xl">
+                  <AboutBannerVector />
+                </div>
+                <div className="mx-auto mt-8 flex max-w-3xl flex-wrap items-center justify-center gap-x-6 gap-y-2">
+                  {PIPELINE.map((step, index) => (
+                    <span
+                      key={step}
+                      className="flex items-center gap-2 font-mono text-[10px] tracking-[0.24em] text-foreground/40 uppercase"
+                    >
+                      <span className="text-primary/70">0{index + 1}</span>
+                      {step}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </Section>
+
+          <Section id="principles">
+            <SectionHeader
+              eyebrow="How it is built"
+              label="Principles"
+              headline="Five decisions"
+              subhead="that shape everything else"
+              lead="None of these are neutral. Each one closes off features that a bigger product would ship, and that is the point — the tool stays small enough to stay fast."
+            />
+
+            <ol className="mt-12 border-t border-border/50">
+              {PRINCIPLES.map((principle, index) => (
+                <li
+                  key={principle.title}
+                  className="grid gap-2 border-b border-border/50 py-5 md:grid-cols-[3rem_minmax(0,1fr)_minmax(0,1.15fr)] md:items-baseline md:gap-6"
+                >
+                  <span className="font-mono text-[11px] text-primary/70 tabular-nums">
+                    0{index + 1}
+                  </span>
+                  <h3 className="text-[15px] font-medium tracking-tight text-foreground">
+                    {principle.title}
+                  </h3>
+                  <p className="text-[13px] leading-6 text-foreground/52">
+                    {principle.body}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          </Section>
+
+          <Section id="local-first">
+            <SectionHeader
+              eyebrow="Local-first"
+              label="Where the work happens"
+              headline="Opening a capture"
+              subhead="does not upload it"
+              lead={
+                <>
+                  The interactive editor runs in your browser. Ordinary edits
+                  and exports need no account, and server-backed features are
+                  always explicit — signing in enables cloud drafts, and
+                  publishing a share link sends the rendered result that link
+                  needs. The boundary keeps quick, private editing simple while
+                  leaving collaboration available when you choose it. It is also
+                  written down in the{" "}
+                  <Link href="/privacy" className={linkClass}>
+                    privacy policy
+                  </Link>{" "}
+                  and readable in the source.
+                </>
+              }
+            />
+
+            <div className="mt-12 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              {BOUNDARY.map((card) => (
+                <VectorCard
+                  key={card.title}
+                  vector={card.vector}
+                  meta={card.meta}
+                  title={card.title}
+                  body={card.body}
+                />
+              ))}
+            </div>
+          </Section>
+
+          <Section id="motion">
+            <SectionHeader
+              eyebrow="Scope"
+              label="Stills and motion"
+              headline="One editor for the picture"
+              subhead="and for the picture moving"
+              lead="Tokokino handles polished PNG, JPEG, and WebP compositions as well as short animated demos. A per-canvas timeline animates the canvas itself — zoom, tilt, lighting, backgrounds, filters — while video and GIF inputs crop, trim, and mute alongside the framing and backdrop tools used for stills. It is not trying to replace an illustration suite or a long-form video editor."
+            />
+
+            <div className="mt-12 grid gap-3 sm:grid-cols-2">
+              <VectorCard
+                vector={<MotionVector />}
+                meta="Timeline · WebM · GIF"
+                title="Motion on the same canvas"
+                body="Clips own the properties you changed while they were selected, and the encode runs on your device."
+              />
+              <VectorCard
+                vector={<PresetVector />}
+                meta="Templates · Presets"
+                title="A look you can re-apply"
+                body="Save a finished treatment once and put it on the next twelve captures without rebuilding it."
+              />
+            </div>
+          </Section>
+
+          <Section id="open-source">
+            <SectionHeader
+              eyebrow="Open source"
+              label="How it is maintained"
+              headline="Published under AGPL-3.0"
+              subhead="so it can be inspected, not just used"
+              lead={
+                <>
+                  The source is public, so people can read how the product
+                  works, report problems, propose improvements, and self-host it
+                  subject to the license. Development happens in the open, and
+                  every release is written up in the{" "}
+                  <Link href="/changelog" className={linkClass}>
+                    changelog
+                  </Link>
+                  .
+                </>
+              }
+            />
+
+            <div className="mt-12 grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
+              <VectorCard
+                vector={<OpenSourceVector />}
+                meta="AGPL-3.0"
+                title="Built in the open"
+                body="Issues, pull requests, and the whole editor history live in the public repository."
+              />
+
+              <div className="h-full rounded-[14px] border border-border/60 bg-background/40 p-1.5 backdrop-blur-sm">
+                <div className="flex h-full flex-col justify-between rounded-[8px] border border-border/40 bg-background/60 p-6">
+                  <div className="flex flex-col gap-3">
+                    <span className="font-mono text-[10px] tracking-[0.2em] text-foreground/36 uppercase">
+                      Get involved
+                    </span>
+                    <p className="text-sm leading-7 text-foreground/58">
+                      Bug reports and feature requests are the fastest way to
+                      change what ships next. If something in the editor gets in
+                      your way, it is worth an issue.
+                    </p>
+                  </div>
+                  <div className="mt-8 flex flex-wrap gap-3">
+                    <a
+                      href="https://git.new/Tokokino"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={solidCtaClass}
+                    >
+                      Browse the source
+                      <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+                    </a>
+                    <Link href="/changelog" className={outlineCtaClass}>
+                      Read the changelog
+                      <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </Section>
+
+          <Section id="maintainer">
+            <SectionHeader
+              eyebrow="Who"
+              label="The person behind it"
+              headline="An independent project"
+              subhead="not a registered company"
+              lead={
+                <>
+                  There is no team behind Tokokino and no company attached to
+                  it, which is why the roadmap stays narrow and the tool keeps
+                  doing one job. Questions, bugs, and ideas all reach the same
+                  inbox — the{" "}
+                  <Link href="/contact" className={linkClass}>
+                    contact page
+                  </Link>{" "}
+                  is the shortest route.
+                </>
+              }
+            />
+
+            <div className="mt-12 grid gap-3 sm:grid-cols-2 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.6fr)]">
+              <VectorCard
+                vector={<SoloVector />}
+                meta="One maintainer"
+                title="No team, no committee"
+                body="No investors and no roadmap by consensus — just a changelog that says what shipped."
+              />
+
+              <div className="h-full rounded-[14px] border border-border/60 bg-background/40 p-1.5 backdrop-blur-sm">
+                <div className="flex h-full flex-col justify-between rounded-[8px] border border-border/40 bg-background/60 p-6">
+                  <dl className="grid gap-px overflow-hidden rounded-md border border-border/50 bg-border/45">
+                    {FACTS.map((fact) => (
+                      <div
+                        key={fact.label}
+                        className="grid items-baseline gap-1 bg-background/70 px-4 py-3 sm:grid-cols-[minmax(0,8rem)_minmax(0,1fr)] sm:gap-4"
+                      >
+                        <dt className="font-mono text-[10px] tracking-[0.2em] text-foreground/36 uppercase">
+                          {fact.label}
+                        </dt>
+                        <dd className="text-[13px] font-medium text-foreground">
+                          {fact.value}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                  <div className="mt-6 flex flex-wrap gap-3">
+                    <Link href="/contact" className={solidCtaClass}>
+                      Get in touch
+                      <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+                    </Link>
+                    <Link href="/showcase" className={outlineCtaClass}>
+                      See the showcase
+                      <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </Section>
         </div>
-      </article>
-    </DocPage>
+      </div>
+
+      <DashedH />
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <FinalCta />
+      </div>
+
+      <DashedH />
+      <div className={`relative ${CONTENT_WIDTH}`} style={RAIL_V_STYLE}>
+        <Footer />
+      </div>
+      <ScrollToTop />
+    </main>
   )
 }

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -2,12 +2,11 @@ import type { Metadata } from "next"
 import type { CSSProperties } from "react"
 
 import { DashedH } from "@/components/landing/dashed-h"
+import { DocIndex, type DocIndexItem } from "@/components/landing/doc-index"
 import { Footer } from "@/components/landing/footer"
 import { Nav } from "@/components/landing/nav"
 import { RAIL_V_STYLE } from "@/components/landing/rail-styles"
 import { ScrollToTop } from "@/components/landing/scroll-to-top"
-
-import { ChangelogIndex, type ChangelogIndexItem } from "./changelog-index"
 
 const CONTENT_WIDTH =
   "mx-auto max-w-[76rem] w-[calc(100%-1rem)] sm:w-[calc(100%-2rem)] md:w-[calc(100%-3rem)] lg:w-[calc(100%-4rem)] xl:w-full"
@@ -366,7 +365,7 @@ const releases: Release[] = [
 ]
 
 export default function ChangelogPage() {
-  const indexItems: ChangelogIndexItem[] = releases.map((release) => ({
+  const indexItems: DocIndexItem[] = releases.map((release) => ({
     id: release.id,
     label: `v${release.version}`,
   }))
@@ -401,7 +400,7 @@ export default function ChangelogPage() {
 
           <div className="mt-8 grid gap-10 sm:mt-10 md:grid-cols-[11rem_1fr] md:gap-8 lg:grid-cols-[13rem_1fr] lg:gap-12 xl:grid-cols-[14rem_1fr]">
             <aside className="hidden md:block">
-              <ChangelogIndex items={indexItems} />
+              <DocIndex items={indexItems} />
             </aside>
 
             <div className="min-w-0 space-y-14">

--- a/app/glossary/glossary-index.tsx
+++ b/app/glossary/glossary-index.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 
+import { useActiveSection } from "@/hooks/use-active-section"
 import { cn } from "@/lib/utils"
 
 type GlossaryIndexItem = {
@@ -10,60 +11,16 @@ type GlossaryIndexItem = {
 }
 
 export function GlossaryIndex({ items }: { items: GlossaryIndexItem[] }) {
-  const [activeId, setActiveId] = React.useState(items[0]?.id ?? "")
-
-  React.useEffect(() => {
-    if (!items.length) return
-
-    const sectionElements = items
-      .map((item) => document.getElementById(item.id))
-      .filter((element): element is HTMLElement => Boolean(element))
-
-    const syncActiveSection = () => {
-      const nearPageBottom =
-        window.innerHeight + window.scrollY >=
-        document.documentElement.scrollHeight - 24
-
-      if (nearPageBottom) {
-        const lastSection = sectionElements.at(-1)
-        if (lastSection) {
-          setActiveId(lastSection.id)
-        }
-        return
-      }
-
-      const anchorLine = window.innerHeight * 0.4
-      const current =
-        sectionElements.findLast(
-          (section) => section.getBoundingClientRect().top <= anchorLine
-        ) ?? sectionElements[0]
-
-      if (current) setActiveId(current.id)
-    }
-
-    const observer = new IntersectionObserver(syncActiveSection, {
-      rootMargin: "-15% 0px -60% 0px",
-      threshold: [0, 0.1, 0.35, 0.6],
-    })
-
-    sectionElements.forEach((section) => observer.observe(section))
-    syncActiveSection()
-    window.addEventListener("scroll", syncActiveSection, { passive: true })
-    window.addEventListener("resize", syncActiveSection)
-
-    return () => {
-      observer.disconnect()
-      window.removeEventListener("scroll", syncActiveSection)
-      window.removeEventListener("resize", syncActiveSection)
-    }
-  }, [items])
+  const [activeId, setActiveId] = useActiveSection(
+    React.useMemo(() => items.map((item) => item.id), [items])
+  )
 
   return (
     <div className="sticky top-8">
       <p className="font-mono text-[10px] tracking-widest text-primary/80 uppercase">
         {"// Letters"}
       </p>
-      <div className="mt-4 grid grid-cols-5 gap-1">
+      <div className="mt-4 grid max-w-[13rem] grid-cols-5 gap-1">
         {items.map((item) => {
           const isActive = activeId === item.id
 

--- a/components/landing/about-vectors.tsx
+++ b/components/landing/about-vectors.tsx
@@ -1,0 +1,395 @@
+"use client"
+
+import type { ComponentProps, ReactNode } from "react"
+import { motion, useReducedMotion } from "motion/react"
+
+import { ease } from "@/components/landing/constants"
+
+const container = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.08 } },
+}
+
+const stroke = {
+  hidden: { pathLength: 0, opacity: 0 },
+  visible: {
+    pathLength: 1,
+    opacity: 1,
+    transition: {
+      pathLength: { duration: 0.5, ease },
+      opacity: { duration: 0.15 },
+    },
+  },
+}
+
+const solid = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.15 } },
+}
+
+function Vector({
+  children,
+  viewBox = "0 0 120 120",
+}: {
+  children: ReactNode
+  viewBox?: string
+}) {
+  const shouldReduceMotion = useReducedMotion()
+
+  return (
+    <motion.svg
+      viewBox={viewBox}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      variants={container}
+      initial={shouldReduceMotion ? "visible" : "hidden"}
+      whileInView="visible"
+      viewport={{ once: true, amount: 0.6 }}
+      className="size-full text-foreground/70"
+    >
+      {children}
+    </motion.svg>
+  )
+}
+
+function Ghost({
+  children,
+  opacity = 0.3,
+}: {
+  children: ReactNode
+  opacity?: number
+}) {
+  return <g opacity={opacity}>{children}</g>
+}
+
+const P = (props: ComponentProps<typeof motion.path>) => (
+  <motion.path variants={stroke} {...props} />
+)
+const R = (props: ComponentProps<typeof motion.rect>) => (
+  <motion.rect variants={stroke} {...props} />
+)
+const C = (props: ComponentProps<typeof motion.circle>) => (
+  <motion.circle variants={stroke} {...props} />
+)
+const L = (props: ComponentProps<typeof motion.line>) => (
+  <motion.line variants={stroke} {...props} />
+)
+const Dot = (props: ComponentProps<typeof motion.circle>) => (
+  <motion.circle
+    variants={solid}
+    fill="currentColor"
+    stroke="none"
+    {...props}
+  />
+)
+const AccentP = (props: ComponentProps<typeof motion.path>) => (
+  <motion.path className="text-primary/75" variants={stroke} {...props} />
+)
+const AccentR = (props: ComponentProps<typeof motion.rect>) => (
+  <motion.rect className="text-primary/75" variants={stroke} {...props} />
+)
+const AccentL = (props: ComponentProps<typeof motion.line>) => (
+  <motion.line className="text-primary/75" variants={stroke} {...props} />
+)
+const AccentDashed = (props: ComponentProps<typeof motion.path>) => (
+  <motion.path className="text-primary/75" variants={solid} {...props} />
+)
+const AccentDot = (props: ComponentProps<typeof motion.circle>) => (
+  <motion.circle
+    className="text-primary/75"
+    variants={solid}
+    fill="currentColor"
+    stroke="none"
+    {...props}
+  />
+)
+
+function CropMarks({
+  x,
+  y,
+  w,
+  h,
+  arm = 4,
+}: {
+  x: number
+  y: number
+  w: number
+  h: number
+  arm?: number
+}) {
+  const corners = [
+    [x, y],
+    [x + w, y],
+    [x, y + h],
+    [x + w, y + h],
+  ]
+
+  return (
+    <Ghost opacity={0.75}>
+      {corners.map(([cx, cy]) => (
+        <g key={`${cx}-${cy}`}>
+          <AccentL x1={cx - arm} y1={cy} x2={cx + arm} y2={cy} />
+          <AccentL x1={cx} y1={cy - arm} x2={cx} y2={cy + arm} />
+        </g>
+      ))}
+    </Ghost>
+  )
+}
+
+export function BrowserVector() {
+  return (
+    <Vector>
+      <R x={12} y={26} width={96} height={68} rx={8} />
+      <L x1={12} y1={42} x2={108} y2={42} />
+      <Dot cx={21} cy={34} r={1.7} />
+      <Dot cx={27} cy={34} r={1.7} />
+      <AccentDot cx={33} cy={34} r={1.7} />
+      <AccentR x={30} y={54} width={60} height={30} rx={5} />
+      <Ghost opacity={0.5}>
+        <L x1={44} y1={34} x2={96} y2={34} />
+      </Ghost>
+      <CropMarks x={30} y={54} w={60} h={30} arm={3} />
+    </Vector>
+  )
+}
+
+export function DeviceStoreVector() {
+  return (
+    <Vector>
+      <R x={18} y={22} width={84} height={54} rx={7} />
+      <Ghost opacity={0.5}>
+        <L x1={32} y1={40} x2={74} y2={40} />
+        <L x1={32} y1={52} x2={58} y2={52} />
+      </Ghost>
+      <P d="M34 88 H86" />
+      <Ghost opacity={0.45}>
+        <P d="M60 76 V88" />
+      </Ghost>
+      <AccentP d="M46 100 A14 14 0 0 1 74 100" />
+      <AccentDot cx={60} cy={100} r={2.4} />
+    </Vector>
+  )
+}
+
+export function ServerVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.32}>
+        <R x={16} y={20} width={88} height={22} rx={6} />
+      </Ghost>
+      <R x={16} y={50} width={88} height={22} rx={6} />
+      <Ghost opacity={0.32}>
+        <R x={16} y={80} width={88} height={22} rx={6} />
+      </Ghost>
+      <AccentDot cx={28} cy={61} r={2.4} />
+      <Ghost opacity={0.5}>
+        <L x1={40} y1={61} x2={78} y2={61} />
+      </Ghost>
+      <AccentP d="M92 55 L98 61 L92 67" />
+    </Vector>
+  )
+}
+
+export function BoundaryVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.3}>
+        <P d="M42 32 A12 12 0 0 1 66 28 A10 10 0 0 1 78 40 H46 A8 8 0 0 1 42 32 Z" />
+      </Ghost>
+      <AccentP d="M55 45 L65 55 M65 45 L55 55" />
+      {/* 96 units = 10 dashes of 6 + 9 gaps of 4, so neither end is clipped. */}
+      <AccentDashed d="M12 62 H108" strokeDasharray="6 4" />
+      <P d="M60 74 V66 M55.5 70.5 L60 66 L64.5 70.5" />
+      <R x={24} y={76} width={72} height={32} rx={6} />
+      <Ghost opacity={0.5}>
+        <L x1={36} y1={88} x2={72} y2={88} />
+        <L x1={36} y1={98} x2={58} y2={98} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function MotionVector() {
+  return (
+    <Vector>
+      <R x={14} y={16} width={92} height={54} rx={8} />
+      <AccentP d="M58 32 L58 54 L78 43 Z" />
+      <Ghost opacity={0.45}>
+        <P d="M48 30 A18 18 0 0 0 48 56" />
+      </Ghost>
+      <Ghost opacity={0.3}>
+        <P d="M42 24 A24 24 0 0 0 42 62" />
+      </Ghost>
+      <Ghost opacity={0.18}>
+        <P d="M36 20 A30 30 0 0 0 36 66" />
+      </Ghost>
+      <L x1={14} y1={92} x2={106} y2={92} />
+      <AccentR x={22} y={84} width={38} height={16} rx={4} />
+      <Ghost opacity={0.45}>
+        <R x={66} y={84} width={26} height={16} rx={4} />
+      </Ghost>
+      <Ghost opacity={0.5}>
+        {[14, 37, 60, 83, 106].map((x) => (
+          <L key={x} x1={x} y1={104} x2={x} y2={110} />
+        ))}
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function OpenSourceVector() {
+  return (
+    <Vector>
+      <L x1={38} y1={16} x2={38} y2={104} />
+      <C cx={38} cy={26} r={5} />
+      <AccentDot cx={38} cy={26} r={2.2} />
+      <C cx={38} cy={60} r={5} />
+      <C cx={38} cy={98} r={5} />
+      <AccentP d="M38 44 C 62 44, 78 44, 78 30" />
+      <AccentP d="M38 76 C 58 76, 72 76, 72 90" />
+      <C cx={78} cy={24} r={5} className="text-primary/75" />
+      <Ghost opacity={0.5}>
+        <C cx={72} cy={96} r={5} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function SoloVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.18}>
+        <C cx={60} cy={60} r={44} />
+      </Ghost>
+      <Ghost opacity={0.3}>
+        <C cx={60} cy={60} r={32} />
+      </Ghost>
+      <C cx={60} cy={60} r={20} />
+      <AccentDot cx={60} cy={60} r={4} />
+      <Ghost opacity={0.5}>
+        <L x1={60} y1={8} x2={60} y2={20} />
+        <L x1={60} y1={100} x2={60} y2={112} />
+        <L x1={8} y1={60} x2={20} y2={60} />
+        <L x1={100} y1={60} x2={112} y2={60} />
+      </Ghost>
+    </Vector>
+  )
+}
+
+export function PresetVector() {
+  return (
+    <Vector>
+      <Ghost opacity={0.28}>
+        <R x={16} y={18} width={40} height={30} rx={5} />
+      </Ghost>
+      <AccentR x={16} y={58} width={40} height={30} rx={5} />
+      <R x={70} y={18} width={34} height={30} rx={5} />
+      <R x={70} y={58} width={34} height={30} rx={5} />
+      <Ghost opacity={0.5}>
+        <P d="M60 33 H66" />
+        <P d="M60 73 H66" />
+      </Ghost>
+      <AccentP d="M36 48 V58 M31 53 L36 58 L41 53" />
+    </Vector>
+  )
+}
+
+export function AboutBannerVector() {
+  const shouldReduceMotion = useReducedMotion()
+
+  return (
+    <Vector viewBox="0 0 640 200">
+      <Ghost opacity={0.25}>
+        <R x={28} y={54} width={76} height={54} rx={7} />
+      </Ghost>
+      <Ghost opacity={0.45}>
+        <R x={36} y={64} width={76} height={54} rx={7} />
+      </Ghost>
+      <R x={44} y={74} width={76} height={54} rx={7} />
+      <AccentR x={56} y={90} width={16} height={16} rx={4} />
+      <Ghost opacity={0.5}>
+        <L x1={80} y1={94} x2={108} y2={94} />
+        <L x1={80} y1={104} x2={100} y2={104} />
+      </Ghost>
+
+      <Ghost opacity={0.55}>
+        <L x1={120} y1={101} x2={232} y2={101} />
+      </Ghost>
+      <AccentP d="M226 96 L232 101 L226 106" />
+
+      <R x={232} y={36} width={200} height={130} rx={14} />
+      <Dot cx={246} cy={47} r={2} />
+      <Dot cx={254} cy={47} r={2} />
+      <AccentDot cx={262} cy={47} r={2} />
+      <AccentR x={258} y={58} width={148} height={86} rx={9} />
+      <CropMarks x={258} y={58} w={148} h={86} arm={6} />
+      <Ghost opacity={0.5}>
+        <L x1={276} y1={86} x2={344} y2={86} />
+        <L x1={276} y1={100} x2={324} y2={100} />
+      </Ghost>
+      <Ghost opacity={0.4}>
+        <L x1={276} y1={124} x2={388} y2={124} />
+      </Ghost>
+
+      <Ghost opacity={0.55}>
+        <L x1={432} y1={101} x2={460} y2={101} />
+        <P d="M460 101 C 478 101, 478 62, 496 62" />
+        <L x1={460} y1={101} x2={496} y2={101} />
+        <P d="M460 101 C 478 101, 478 140, 496 140" />
+      </Ghost>
+
+      <R x={496} y={47} width={112} height={30} rx={8} />
+      <AccentR x={508} y={55} width={14} height={14} rx={3} />
+      <Ghost opacity={0.45}>
+        <L x1={532} y1={58} x2={584} y2={58} />
+        <L x1={532} y1={66} x2={562} y2={66} />
+      </Ghost>
+
+      <R x={496} y={86} width={112} height={30} rx={8} />
+      <AccentP d="M509 94 L509 108 L521 101 Z" />
+      <Ghost opacity={0.45}>
+        <L x1={532} y1={97} x2={584} y2={97} />
+        <L x1={532} y1={105} x2={562} y2={105} />
+      </Ghost>
+
+      <R x={496} y={125} width={112} height={30} rx={8} />
+      <AccentP d="M509 147 V139 H517 M513 143 L523 133 M517 133 H523 V139" />
+      <Ghost opacity={0.45}>
+        <L x1={532} y1={136} x2={584} y2={136} />
+        <L x1={532} y1={144} x2={562} y2={144} />
+      </Ghost>
+
+      {shouldReduceMotion ? null : (
+        <motion.g variants={solid}>
+          <circle r={2.6} className="fill-primary" stroke="none">
+            <animateMotion
+              dur="3.6s"
+              repeatCount="indefinite"
+              path="M120 101 H232"
+              keyPoints="0;1"
+              keyTimes="0;1"
+              calcMode="spline"
+              keySplines="0.42 0 0.58 1"
+            />
+          </circle>
+          <circle r={2.6} className="fill-primary" stroke="none">
+            <animateMotion
+              dur="3.6s"
+              begin="1.2s"
+              repeatCount="indefinite"
+              path="M436 101 H496"
+              keyPoints="0;1"
+              keyTimes="0;1"
+              calcMode="spline"
+              keySplines="0.42 0 0.58 1"
+            />
+          </circle>
+        </motion.g>
+      )}
+    </Vector>
+  )
+}

--- a/components/landing/doc-index.tsx
+++ b/components/landing/doc-index.tsx
@@ -2,7 +2,8 @@
 
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { LineNav, type LineNavItem } from "@/components/line-nav"
+import { useActiveSection } from "@/hooks/use-active-section"
 
 export type DocIndexItem = {
   id: string
@@ -10,86 +11,28 @@ export type DocIndexItem = {
 }
 
 export function DocIndex({ items }: { items: DocIndexItem[] }) {
-  const [activeId, setActiveId] = React.useState(items[0]?.id ?? "")
+  const [activeId, setActiveId] = useActiveSection(
+    React.useMemo(() => items.map((item) => item.id), [items])
+  )
 
-  React.useEffect(() => {
-    if (!items.length) return
-
-    const sectionElements = items
-      .map((item) => document.getElementById(item.id))
-      .filter((element): element is HTMLElement => Boolean(element))
-
-    const syncActiveSection = () => {
-      const nearPageBottom =
-        window.innerHeight + window.scrollY >=
-        document.documentElement.scrollHeight - 24
-
-      if (nearPageBottom) {
-        const lastSection = sectionElements.at(-1)
-        if (lastSection) {
-          setActiveId(lastSection.id)
-        }
-        return
-      }
-
-      const anchorLine = window.innerHeight * 0.4
-      const current =
-        sectionElements.findLast(
-          (section) => section.getBoundingClientRect().top <= anchorLine
-        ) ?? sectionElements[0]
-
-      if (current) setActiveId(current.id)
-    }
-
-    const observer = new IntersectionObserver(syncActiveSection, {
-      rootMargin: "-15% 0px -60% 0px",
-      threshold: [0, 0.1, 0.35, 0.6],
-    })
-
-    sectionElements.forEach((section) => observer.observe(section))
-    syncActiveSection()
-    window.addEventListener("scroll", syncActiveSection, { passive: true })
-    window.addEventListener("resize", syncActiveSection)
-
-    return () => {
-      observer.disconnect()
-      window.removeEventListener("scroll", syncActiveSection)
-      window.removeEventListener("resize", syncActiveSection)
-    }
-  }, [items])
+  const navItems = React.useMemo<LineNavItem[]>(
+    () =>
+      items.map((item) => ({
+        title: item.label,
+        href: `#${item.id}`,
+      })),
+    [items]
+  )
 
   return (
-    <nav className="sticky top-8 flex flex-col gap-2.5 py-1">
-      {items.map((item) => {
-        const isActive = activeId === item.id
-
-        return (
-          <a
-            key={item.id}
-            href={`#${item.id}`}
-            aria-current={isActive ? "location" : undefined}
-            onClick={() => setActiveId(item.id)}
-            className="group flex items-start gap-3"
-          >
-            <span
-              aria-hidden
-              className={cn(
-                "mt-[0.6rem] h-px w-6 shrink-0 bg-primary/30 transition-[width,background-color]",
-                isActive && "w-10 bg-primary",
-                !isActive && "group-hover:bg-primary"
-              )}
-            />
-            <span
-              className={cn(
-                "text-sm leading-6 text-muted-foreground transition-colors group-hover:text-primary",
-                isActive && "text-primary"
-              )}
-            >
-              {item.label}
-            </span>
-          </a>
-        )
-      })}
-    </nav>
+    <div className="sticky top-8">
+      <LineNav
+        className="w-full"
+        items={navItems}
+        activeHref={`#${activeId}`}
+        scrollActiveIntoView={false}
+        onItemClick={(item) => setActiveId(item.href.slice(1))}
+      />
+    </div>
   )
 }

--- a/components/landing/doc-page.tsx
+++ b/components/landing/doc-page.tsx
@@ -53,7 +53,7 @@ export function DocPage({
           <div
             className={
               index
-                ? "mt-8 grid gap-10 sm:mt-10 md:grid-cols-[13rem_1fr] md:gap-8 lg:grid-cols-[15rem_1fr] lg:gap-12"
+                ? "mt-8 grid gap-10 sm:mt-10 md:grid-cols-[15rem_1fr] md:gap-8 lg:grid-cols-[17rem_1fr] lg:gap-12"
                 : "mt-8 sm:mt-10"
             }
           >

--- a/hooks/use-active-section.ts
+++ b/hooks/use-active-section.ts
@@ -2,30 +2,20 @@
 
 import * as React from "react"
 
-import { LineNav, type LineNavItem } from "@/components/line-nav"
-
-export type ChangelogIndexItem = {
-  id: string
-  label: string
-}
-
-export function ChangelogIndex({ items }: { items: ChangelogIndexItem[] }) {
-  const navItems = React.useMemo<LineNavItem[]>(
-    () =>
-      items.map((item) => ({
-        title: item.label,
-        href: `#${item.id}`,
-      })),
-    [items]
-  )
-
-  const [activeHref, setActiveHref] = React.useState(navItems[0]?.href ?? "")
+/**
+ * Tracks which of the given section ids is the one currently being read, and
+ * returns it alongside a setter so a click can claim it before the scroll lands.
+ */
+export function useActiveSection(ids: string[]) {
+  const [activeId, setActiveId] = React.useState(ids[0] ?? "")
+  const idsKey = ids.join("|")
 
   React.useEffect(() => {
-    if (!items.length) return
+    const sectionIds = idsKey ? idsKey.split("|") : []
+    if (!sectionIds.length) return
 
-    const sectionElements = items
-      .map((item) => document.getElementById(item.id))
+    const sectionElements = sectionIds
+      .map((id) => document.getElementById(id))
       .filter((element): element is HTMLElement => Boolean(element))
 
     const syncActiveSection = () => {
@@ -36,7 +26,7 @@ export function ChangelogIndex({ items }: { items: ChangelogIndexItem[] }) {
       if (nearPageBottom) {
         const lastSection = sectionElements.at(-1)
         if (lastSection) {
-          setActiveHref(`#${lastSection.id}`)
+          setActiveId(lastSection.id)
         }
         return
       }
@@ -47,7 +37,7 @@ export function ChangelogIndex({ items }: { items: ChangelogIndexItem[] }) {
           (section) => section.getBoundingClientRect().top <= anchorLine
         ) ?? sectionElements[0]
 
-      if (current) setActiveHref(`#${current.id}`)
+      if (current) setActiveId(current.id)
     }
 
     const observer = new IntersectionObserver(syncActiveSection, {
@@ -65,17 +55,7 @@ export function ChangelogIndex({ items }: { items: ChangelogIndexItem[] }) {
       window.removeEventListener("scroll", syncActiveSection)
       window.removeEventListener("resize", syncActiveSection)
     }
-  }, [items])
+  }, [idsKey])
 
-  return (
-    <div className="sticky top-8">
-      <LineNav
-        className="w-full"
-        items={navItems}
-        activeHref={activeHref}
-        scrollActiveIntoView={false}
-        onItemClick={(item) => setActiveHref(item.href)}
-      />
-    </div>
-  )
+  return [activeId, setActiveId] as const
 }

--- a/lib/seo/about-structured-data.ts
+++ b/lib/seo/about-structured-data.ts
@@ -1,0 +1,63 @@
+const SITE_URL = "https://tokokino.com"
+const PAGE_URL = `${SITE_URL}/about`
+
+type Principle = {
+  title: string
+  body: string
+}
+
+export function aboutStructuredData({
+  principles,
+}: {
+  principles: readonly Principle[]
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "AboutPage",
+        "@id": `${PAGE_URL}/#about`,
+        name: "About Tokokino",
+        description:
+          "Why Tokokino exists, how its local-first editor draws the line between the browser and the server, and how the open-source project is maintained.",
+        url: PAGE_URL,
+        isPartOf: { "@id": `${SITE_URL}/#website` },
+        about: { "@id": `${SITE_URL}/#software-application` },
+        publisher: { "@id": `${SITE_URL}/#organization` },
+      },
+      {
+        "@type": "Person",
+        "@id": `${SITE_URL}/#maintainer`,
+        name: "Shiva Bhattacharjee",
+        url: "https://github.com/ShivaBhattacharjee",
+        jobTitle: "Maintainer",
+        homeLocation: {
+          "@type": "Place",
+          address: {
+            "@type": "PostalAddress",
+            addressLocality: "Guwahati",
+            addressRegion: "Assam",
+            addressCountry: "IN",
+          },
+        },
+        sameAs: [
+          "https://github.com/ShivaBhattacharjee",
+          "https://x.com/sh17va",
+        ],
+      },
+      {
+        "@type": "ItemList",
+        "@id": `${PAGE_URL}/#principles`,
+        name: "How Tokokino is built",
+        url: PAGE_URL,
+        numberOfItems: principles.length,
+        itemListElement: principles.map((principle, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          name: principle.title,
+          description: principle.body,
+        })),
+      },
+    ],
+  }
+}


### PR DESCRIPTION
## About page

Replaces the four-paragraph `DocPage` layout with a full marketing page, structured like `/how-it-works` and `/use-cases`:

- **Hero** — `// About` eyebrow, two-line headline with the strawberry accent on the second line, dither field, Start editing / Star on GitHub.
- **Mission** — label-left / content-right split with `visual = fn(capture)` as the headline, then the "why does it exist?" prose.
- **Pipeline banner** — a wide animated SVG (source stack → canvas → still/video/link outputs) with `01 Capture · 02 Compose · 03 Context · 04 Animate · 05 Export` beneath it.
- **Principles** — numbered `01–05` rows for the five decisions that keep the tool small.
- **Where the work happens** — four vector cards spelling out the local-first boundary: in your browser, on your device, on the server when asked, never by default.
- **Scope**, **open source**, and **maintainer** sections, then the usual final CTA and footer.

### Vectors

`components/landing/about-vectors.tsx` adds eight square vectors plus the banner, using the same primitives as `how-it-works-vectors` — `pathLength` stroke-draw on `whileInView` with a staggered container, ghost/accent layers, `useReducedMotion` short-circuit. The banner's two flow dots run on SMIL `animateMotion` and are not rendered when reduced motion is on. The dashed boundary line spans exactly 96 units against a `6 4` pattern so neither end is clipped, and it uses an opacity variant rather than `pathLength`, which would have fought the dashes through `stroke-dasharray`.

### SEO

`lib/seo/about-structured-data.ts` emits `AboutPage` + `Person` (maintainer) + an `ItemList` of the principles.

## Doc page index

The changelog rail and the legal/developer page index were separate components with the same scroll-spy copy-pasted three times. `DocIndex` now renders the same `LineNav` the changelog used, and the spy moved into `hooks/use-active-section.ts`, so `/privacy`, `/terms`, `/dpa`, and `/developers` pick up the animated rail with no page-level changes. `app/changelog/changelog-index.tsx` is deleted; the glossary keeps its letter-grid UI and just uses the hook. The doc index column was widened to `15rem`/`17rem` because labels like "Security Incident Notification" would otherwise run into the content column.

## Checks

`pnpm typecheck`, `pnpm lint:strict`, `pnpm format`, and `pnpm test` (1545 tests) all pass.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR rebuilds `/about` as a full marketing page with animated vectors and structured data, and consolidates documentation-page scroll spying around a shared hook and `LineNav`.

- Adds the new About page sections, local-first messaging, CTAs, vectors, and JSON-LD.
- Reuses `DocIndex` across changelog, legal, and developer pages.
- Extracts active-section tracking for both document and glossary indexes.
- Widens document index columns for longer section labels.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after addressing the non-blocking About-page icon sizing inconsistency.

The shared navigation refactor preserves current hash and scroll-spy behavior, and the new marketing and structured-data code has no identified blocking defect; only the repository-specific icon sizing convention is violated.

**Files Needing Attention:** app/about/page.tsx

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/about/page.tsx | Replaces the compact document layout with a complete marketing page; one icon uses a size utility that violates the repository’s required icon convention. |
| components/landing/about-vectors.tsx | Adds reusable animated SVG illustrations with reduced-motion handling and no identified functional defect. |
| hooks/use-active-section.ts | Extracts the existing scroll-spy behavior into a shared hook; current callers use stable, delimiter-safe section IDs. |
| components/landing/doc-index.tsx | Adapts document index entries to LineNav while preserving fragment navigation and active-section updates. |
| app/changelog/page.tsx | Replaces the changelog-specific index with the shared DocIndex without changing release section identifiers. |
| app/glossary/glossary-index.tsx | Reuses the shared active-section hook while retaining the glossary-specific letter-grid interface. |
| components/landing/doc-page.tsx | Widens indexed document layouts to accommodate longer navigation labels. |
| lib/seo/about-structured-data.ts | Adds AboutPage, maintainer Person, and principles ItemList structured data with consistent site entity references. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20shivabhattacharjee%2Ftokokino%20PR%20%2372%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=shivabhattacharjee%2Ftokokino&pr=72&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapp%2Fabout%2Fpage.tsx%3A260%0A**Inconsistent%20CTA%20icon%20sizing**%0A%0AThe%20new%20GitHub%20CTA%20uses%20%60size-3.5%60%20for%20%60StarIcon%60%20instead%20of%20the%20repository-required%20%60size-4%60%20icon%20pattern%2C%20making%20its%20sizing%20inconsistent%20with%20the%20standard%20icon%20treatment.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CStarIcon%20className%3D%22size-4%20text-yellow-400%22%20%2F%3E%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=shivabhattacharjee%2Ftokokino&pr=72&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
app/about/page.tsx:260
**Inconsistent CTA icon sizing**

The new GitHub CTA uses `size-3.5` for `StarIcon` instead of the repository-required `size-4` icon pattern, making its sizing inconsistent with the standard icon treatment.

```suggestion
              <StarIcon className="size-4 text-yellow-400" />
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(marketing): rebuild the about page"](https://github.com/shivabhattacharjee/tokokino/commit/8eb4686bcc4e2ccf656ab6f21cb053d6f43f1cc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58579750)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/shivabhattacharjee/tokokino/blob/main/CLAUDE.md))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a redesigned About page with product details, mission, principles, privacy boundaries, supported media, licensing, open-source information, and maintainer details.
  - Added animated visual illustrations, calls to action, footer navigation, and scroll-to-top controls.
  - Improved search-engine and social sharing metadata for the About page.

- **Enhancements**
  - Standardized section navigation across documentation, glossary, and changelog pages.
  - Improved active-section tracking and documentation layout spacing.
  - Added reduced-motion support for animated visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->