### PR TITLE
fix: optimise Safari ASCII rendering and editor controls

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -472,6 +472,35 @@
   .tool-cluster {
     @apply flex items-center gap-0.5 rounded-md border border-border/60 bg-secondary/60 p-1;
   }
+
+  /*
+   * Solid strawberry actions share the same dimensional surface as animate
+   * timeline clips: a soft highlight at the top and a darker lower edge.
+   * Keep this scoped to interactive controls so primary progress bars,
+   * selection marks, and other status UI retain their flat fill.
+  */
+  .strawberry-button,
+  :is(button, a, [role="button"]).bg-primary:not(
+      .strawberry-button-exempt
+    ) {
+    background-color: var(--primary);
+    background-image: linear-gradient(
+      to bottom,
+      color-mix(in oklab, var(--primary) 92%, white),
+      color-mix(in oklab, var(--primary) 92%, black)
+    );
+  }
+
+  .strawberry-button:hover,
+  :is(button, a, [role="button"]).bg-primary:not(
+      .strawberry-button-exempt
+    ):hover {
+    background-image: linear-gradient(
+      to bottom,
+      color-mix(in oklab, var(--primary) 88%, white),
+      color-mix(in oklab, var(--primary) 88%, black)
+    );
+  }
 }
 
 @layer base {

--- a/components/editor/canvas/ascii-backdrop.tsx
+++ b/components/editor/canvas/ascii-backdrop.tsx
@@ -6,18 +6,17 @@ import {
   ASCII_FONT_FAMILY,
   asciiGridSize,
   asciiPlateColor,
-  asciiRunGeometry,
   getAsciiResolutionPreview,
   gridFromImageData,
+  isWebKitEngine,
   monospaceAdvanceRatio,
   sampleBackgroundPixels,
   subscribeAsciiResolutionPreview,
   type AsciiGrid,
 } from "@/lib/editor/ascii-backdrop"
+import { backgroundCss } from "@/lib/editor/css-utils"
 import type { BackdropAscii, Background } from "@/lib/editor/state-types"
 import { useCanvasScopeId, useCanvasSourceId } from "@/lib/editor/store"
-
-type Segment = { text: string; color: string; start: number }
 
 function escapeSvg(value: string): string {
   return value
@@ -28,84 +27,108 @@ function escapeSvg(value: string): string {
 }
 
 /**
- * Merge neighbouring cells that quantized to the same colour so a coloured grid
- * renders as a few hundred spans instead of one per character.
+ * Package only the glyph alpha as an SVG mask. Source-coloured ASCII used to
+ * emit one SVG <text> per colour run; a detailed 200-column background could
+ * therefore emit roughly 12,000 text nodes. The mask always has one node per
+ * row and lets the original background supply the ink. Chromium can composite
+ * it live; WebKit keeps it hidden until export and uses the flat canvas below.
  */
-function rowSegments(grid: AsciiGrid, row: number): Segment[] {
-  const segments: Segment[] = []
-  const start = row * grid.cols
-  for (let i = 0; i < grid.cols; i++) {
-    const color = grid.colors[start + i]
-    const char = grid.chars[start + i]
-    const last = segments[segments.length - 1]
-    if (last && last.color === color) last.text += char
-    else segments.push({ text: char, color, start: i })
-  }
-  return segments
-}
-
-/**
- * Package the glyph tree as one SVG image resource. Keeping the thousands of
- * coloured text runs out of the live DOM lets WebKit cache/composite the layer
- * as a single image while the screenshot moves, without sacrificing vector text
- * when html-to-image captures a high-resolution export.
- */
-function asciiSvgDataUrl({
+function asciiGlyphMaskUrl({
   grid,
   width,
   height,
-  cellWidth,
   cellHeight,
   fontSize,
-  ascii,
 }: {
   grid: AsciiGrid
   width: number
   height: number
-  cellWidth: number
   cellHeight: number
   fontSize: number
-  ascii: BackdropAscii
 }): string | null {
   if (!(width > 0) || !(height > 0) || !(fontSize > 0)) return null
 
-  const runs: string[] = []
+  const rows: string[] = []
   for (let row = 0; row < grid.rows; row++) {
     const y = (row + 0.5) * cellHeight
-    if (!ascii.colored) {
-      const text = grid.chars.slice(row * grid.cols, (row + 1) * grid.cols)
-      const geometry = asciiRunGeometry(0, text.length, cellWidth)
-      runs.push(
-        `<text x="${geometry.x}" y="${y}" textLength="${geometry.width}" lengthAdjust="spacingAndGlyphs" dominant-baseline="central" fill="${escapeSvg(ascii.color)}" xml:space="preserve">${escapeSvg(text)}</text>`
-      )
-      continue
-    }
-
-    for (const segment of rowSegments(grid, row)) {
-      const geometry = asciiRunGeometry(
-        segment.start,
-        segment.text.length,
-        cellWidth
-      )
-      runs.push(
-        `<text x="${geometry.x}" y="${y}" textLength="${geometry.width}" lengthAdjust="spacingAndGlyphs" dominant-baseline="central" fill="${escapeSvg(segment.color)}" xml:space="preserve">${escapeSvg(segment.text)}</text>`
-      )
-    }
+    const text = grid.chars.slice(row * grid.cols, (row + 1) * grid.cols)
+    rows.push(
+      `<text x="0" y="${y}" textLength="${width}" lengthAdjust="spacingAndGlyphs" dominant-baseline="central" fill="white" xml:space="preserve">${escapeSvg(text)}</text>`
+    )
   }
 
   const svg =
     `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" ` +
-    `font-family="${escapeSvg(ASCII_FONT_FAMILY)}" font-size="${fontSize}" style="font-variant-ligatures:none;overflow:hidden">${runs.join("")}</svg>`
+    `font-family="${escapeSvg(ASCII_FONT_FAMILY)}" font-size="${fontSize}" style="font-variant-ligatures:none;overflow:hidden">${rows.join("")}</svg>`
   return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+}
+
+/**
+ * Paint a screen-resolution ASCII texture once and hand WebKit one flat canvas
+ * layer to composite. Safari repeatedly re-rasterizes the equivalent CSS/SVG
+ * mask while the editor moves, which becomes dramatically slower at 120 Hz.
+ */
+function paintAsciiRasterPreview(
+  canvas: HTMLCanvasElement,
+  grid: AsciiGrid,
+  pixels: Uint8ClampedArray,
+  width: number,
+  height: number,
+  fontSize: number,
+  ascii: BackdropAscii
+): void {
+  if (!(width > 0) || !(height > 0) || !(fontSize > 0)) return
+
+  const pixelRatio = Math.max(1, Math.min(2, window.devicePixelRatio || 1))
+  const outputWidth = Math.max(1, Math.round(width * pixelRatio))
+  const outputHeight = Math.max(1, Math.round(height * pixelRatio))
+  if (canvas.width !== outputWidth) canvas.width = outputWidth
+  if (canvas.height !== outputHeight) canvas.height = outputHeight
+
+  const ctx = canvas.getContext("2d")
+  if (!ctx) return
+  ctx.clearRect(0, 0, outputWidth, outputHeight)
+  ctx.fillStyle = "#fff"
+  ctx.font = `${fontSize * pixelRatio}px ${ASCII_FONT_FAMILY}`
+  ctx.textBaseline = "middle"
+
+  const cellHeight = outputHeight / grid.rows
+  for (let row = 0; row < grid.rows; row++) {
+    const text = grid.chars.slice(row * grid.cols, (row + 1) * grid.cols)
+    const measuredWidth = ctx.measureText(text).width
+    ctx.save()
+    ctx.translate(0, (row + 0.5) * cellHeight)
+    if (measuredWidth > 0) ctx.scale(outputWidth / measuredWidth, 1)
+    ctx.fillText(text, 0, 0)
+    ctx.restore()
+  }
+
+  ctx.globalCompositeOperation = "source-in"
+  if (ascii.colored && pixels.length >= grid.cols * grid.rows * 4) {
+    const colors = document.createElement("canvas")
+    colors.width = grid.cols
+    colors.height = grid.rows
+    const colorsCtx = colors.getContext("2d")
+    if (colorsCtx) {
+      const image = colorsCtx.createImageData(grid.cols, grid.rows)
+      image.data.set(pixels.subarray(0, image.data.length))
+      colorsCtx.putImageData(image, 0, 0)
+      ctx.imageSmoothingEnabled = false
+      ctx.drawImage(colors, 0, 0, outputWidth, outputHeight)
+    }
+  } else {
+    ctx.fillStyle = ascii.color
+    ctx.fillRect(0, 0, outputWidth, outputHeight)
+  }
+  ctx.globalCompositeOperation = "source-over"
 }
 
 /**
  * Renders the canvas background as ASCII characters.
  *
- * The glyphs live in an SVG-backed image rather than a `<canvas>` because export
- * rasterizes the DOM at up to 8K — a canvas would be captured at its own
- * (screen-sized) resolution and upscaled into mush, while the SVG re-renders
- * sharply at any pixel ratio without thousands of live DOM nodes.
+ * Chromium previews the vector mask directly. WebKit previews a flat canvas
+ * because its live SVG-mask compositor stalls badly at high refresh rates; the
+ * hidden vector layer is restored in the export clone so 8K output stays sharp.
  */
 function AsciiBackdropImpl({
   background,
@@ -126,6 +149,8 @@ function AsciiBackdropImpl({
   const hostRef = React.useRef<HTMLDivElement>(null)
   const scopeId = useCanvasScopeId()
   const sourceCanvasId = useCanvasSourceId()
+  const rasterRef = React.useRef<HTMLCanvasElement>(null)
+  const useRasterPreview = React.useMemo(() => isWebKitEngine(), [])
   // Preset thumbnails mount under a synthetic scope id but mirror a real
   // canvas, so they read the source canvas's preview and track the drag too.
   const previewCanvasId = sourceCanvasId ?? scopeId
@@ -173,7 +198,9 @@ function AsciiBackdropImpl({
     let cancelled = false
     sampleBackgroundPixels(background, cols, rows)
       .then((data) => {
-        if (!cancelled && data) setSample({ pixels: data, cols, rows })
+        if (!cancelled && data) {
+          setSample({ pixels: data, cols, rows })
+        }
       })
       .catch(() => {
         // Keep the last good sample — a failed resample must not blank the
@@ -193,9 +220,11 @@ function AsciiBackdropImpl({
     return gridFromImageData(sample.pixels, sample.cols, sample.rows, {
       charset: ascii.charset,
       inverted: ascii.inverted,
-      colored: ascii.colored,
+      // The render layer supplies source colour. Avoid allocating/quantizing
+      // one CSS colour string per cell just to discard it.
+      colored: false,
     })
-  }, [ascii.charset, ascii.colored, ascii.inverted, sample])
+  }, [ascii.charset, ascii.inverted, sample])
 
   const plate = React.useMemo(() => {
     if (!sample || sample.rows < 1) return undefined
@@ -210,18 +239,49 @@ function AsciiBackdropImpl({
   const fontSize = cellWidth / monospaceAdvanceRatio()
   const userOpacity = (ascii.opacity ?? 100) / 100
   const committedOpacity = `var(--bd-ascii-opacity, ${userOpacity})`
-  const glyphImageUrl = React.useMemo(() => {
+  const glyphMaskUrl = React.useMemo(() => {
     if (!grid) return null
-    return asciiSvgDataUrl({
+    return asciiGlyphMaskUrl({
       grid,
       width: size.width,
       height: size.height,
-      cellWidth,
       cellHeight,
       fontSize,
-      ascii,
     })
-  }, [ascii, cellHeight, cellWidth, fontSize, grid, size.height, size.width])
+  }, [cellHeight, fontSize, grid, size.height, size.width])
+
+  const glyphStyle = React.useMemo<React.CSSProperties>(() => {
+    if (!glyphMaskUrl) return {}
+    const ink = ascii.colored
+      ? backgroundCss(background)
+      : { background: ascii.color }
+    const mask = `url("${glyphMaskUrl}")`
+    return {
+      ...ink,
+      maskImage: mask,
+      WebkitMaskImage: mask,
+      maskPosition: "0 0",
+      WebkitMaskPosition: "0 0",
+      maskRepeat: "no-repeat",
+      WebkitMaskRepeat: "no-repeat",
+      maskSize: "100% 100%",
+      WebkitMaskSize: "100% 100%",
+    }
+  }, [ascii.color, ascii.colored, background, glyphMaskUrl])
+
+  React.useEffect(() => {
+    const canvas = rasterRef.current
+    if (!useRasterPreview || !canvas || !grid || !sample) return
+    paintAsciiRasterPreview(
+      canvas,
+      grid,
+      sample.pixels,
+      size.width,
+      size.height,
+      fontSize,
+      ascii
+    )
+  }, [ascii, fontSize, grid, sample, size.height, size.width, useRasterPreview])
 
   return (
     <div
@@ -236,27 +296,35 @@ function AsciiBackdropImpl({
         className="absolute inset-0"
         style={{
           background: plate,
-          filter: `${filter ?? "brightness(1)"} opacity(${committedOpacity})`,
+          filter,
+          opacity: committedOpacity as React.CSSProperties["opacity"],
         }}
       >
-        {glyphImageUrl ? (
-          // A runtime-generated SVG data URL that export reads back off the
-          // DOM; next/image cannot optimize it and its wrapper breaks capture.
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
+        {useRasterPreview ? (
+          <canvas
+            ref={rasterRef}
+            aria-hidden
+            data-export-hidden="true"
+            className="absolute inset-0 block size-full"
+          />
+        ) : null}
+        {glyphMaskUrl ? (
+          <div
             aria-hidden
             data-export-ascii-glyphs="true"
-            src={glyphImageUrl}
-            alt=""
-            draggable={false}
-            width={size.width}
-            height={size.height}
+            data-export-ascii-vector="true"
+            data-bg-source-url={
+              ascii.colored &&
+              background.type === "image" &&
+              background.sourceUrl &&
+              background.sourceUrl !== background.value
+                ? background.sourceUrl
+                : undefined
+            }
+            className="absolute inset-0"
             style={{
-              display: "block",
-              width: size.width,
-              height: size.height,
-              maxWidth: "none",
-              overflow: "hidden",
+              ...glyphStyle,
+              display: useRasterPreview ? "none" : undefined,
             }}
           />
         ) : null}

--- a/components/editor/editor-app.tsx
+++ b/components/editor/editor-app.tsx
@@ -124,7 +124,7 @@ function EditorLayout() {
                   setIsPreviewAutoScroll(false)
                   setSettingsOpen(false)
                 }}
-                className="h-10 cursor-pointer border border-foreground/15 bg-background/80 px-4 text-foreground shadow-xl backdrop-blur-md hover:bg-background/95"
+                className="strawberry-button-exempt h-10 cursor-pointer border border-foreground/15 bg-background/80 px-4 text-foreground shadow-xl backdrop-blur-md hover:bg-background/95"
               >
                 <RiEyeLine className="mr-2 size-4" />
                 Exit Preview

--- a/components/editor/inspector/backdrop-section.tsx
+++ b/components/editor/inspector/backdrop-section.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/editor/css-utils"
 import {
   DEFAULT_BACKDROP_ASCII,
+  isWebKitEngine,
   resolveBackdropAscii,
   setAsciiResolutionPreview,
 } from "@/lib/editor/ascii-backdrop"
@@ -120,9 +121,13 @@ export function BackdropSection({
     [setPreviewVar]
   )
   // ASCII resolution can't preview through a CSS var: the glyph grid has to be
-  // resampled to change, so the drag feeds the renderer a resolution instead.
+  // resampled to change. Safari took ~45ms per image readback at 200 columns,
+  // so repeating it for every pointermove blocks the main thread. WebKit keeps
+  // the slider/value responsive and performs the real resample once on commit;
+  // Chromium keeps the live grid preview that it can render cheaply.
   const previewAsciiResolution = React.useCallback(
     (resolution: number | null) => {
+      if (resolution !== null && isWebKitEngine()) return
       setAsciiResolutionPreview(activeCanvasId, resolution)
     },
     [activeCanvasId]

--- a/components/editor/inspector/background-section-parts/image-background-panel.tsx
+++ b/components/editor/inspector/background-section-parts/image-background-panel.tsx
@@ -158,7 +158,7 @@ export function ImageBackgroundPanel({
             <Button
               variant="default"
               size="sm"
-              className="h-9 flex-1 cursor-pointer gap-2 bg-[#9BCD64] text-[#10220e] hover:bg-[#8ec25a]"
+              className="strawberry-button-exempt h-9 flex-1 cursor-pointer gap-2 bg-[#9BCD64] text-[#10220e] hover:bg-[#8ec25a]"
             >
               <RiUnsplashLine className="size-4" />
               <span className="text-[11px] font-medium">Unsplash</span>

--- a/components/editor/mobile-controls/history-button.tsx
+++ b/components/editor/mobile-controls/history-button.tsx
@@ -50,7 +50,7 @@ export function MobileHistoryButton({
             className={cn(
               "flex shrink-0 cursor-pointer flex-col items-center gap-1 rounded-md border px-3 py-1.5 text-[11px] font-medium transition-colors",
               open
-                ? "border-[#ff5a6f] bg-[#ff5a6f] text-white"
+                ? "border-primary bg-primary text-white"
                 : "border-transparent text-foreground/60 hover:bg-[#cfe5b8]/20 hover:text-foreground dark:hover:bg-[#cfe5b8]/10"
             )}
           >

--- a/components/editor/mobile-controls/index.tsx
+++ b/components/editor/mobile-controls/index.tsx
@@ -551,7 +551,7 @@ export function MobileControls({
                 className={cn(
                   "flex shrink-0 cursor-pointer flex-col items-center gap-1 rounded-md border px-3 py-1.5 text-[11px] font-medium transition-colors",
                   isActive
-                    ? "border-[#ff5a6f] bg-[#ff5a6f] text-white"
+                    ? "border-primary bg-primary text-white"
                     : "border-transparent text-foreground/60 hover:bg-[#cfe5b8]/20 hover:text-foreground dark:hover:bg-[#cfe5b8]/10"
                 )}
               >
@@ -584,7 +584,7 @@ export function MobileControls({
                 className={cn(
                   "flex size-10 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors",
                   penButtonActive
-                    ? "bg-[#ff5a6f] text-white"
+                    ? "bg-primary text-white"
                     : "bg-secondary/50 text-foreground/70 hover:text-foreground"
                 )}
               >

--- a/components/editor/top-bar/export-controls.tsx
+++ b/components/editor/top-bar/export-controls.tsx
@@ -964,7 +964,7 @@ export function ExportControls({
         onCancel={cancelAnimExport}
       />
 
-      <div className="flex h-8 items-stretch overflow-hidden rounded-md bg-primary text-white shadow-sm transition-all hover:shadow-md">
+      <div className="strawberry-button flex h-8 items-stretch overflow-hidden rounded-md bg-primary text-white shadow-sm transition-all hover:shadow-md">
         <Tooltip>
           <TooltipTrigger asChild>
             <button

--- a/components/editor/top-bar/index.tsx
+++ b/components/editor/top-bar/index.tsx
@@ -1338,7 +1338,6 @@ export function TopBar() {
       <div className="hidden min-w-0 flex-1 items-center justify-center gap-1.5 md:flex">
         <div className="tool-cluster hidden xl:flex">
           <OpenControls
-            currentDraftName={currentDraft?.name ?? null}
             isOffline={offlineShell !== null}
             isSavingOffline={isStoringOffline}
             onNewProject={() => setShowNewAlert(true)}

--- a/components/editor/top-bar/open-controls.tsx
+++ b/components/editor/top-bar/open-controls.tsx
@@ -19,14 +19,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
 
 export function OpenControls({
-  currentDraftName,
   isOffline = false,
   isSavingOffline = false,
   onNewProject,
@@ -35,7 +29,8 @@ export function OpenControls({
   onOpenProject,
   onToggleOffline,
 }: {
-  currentDraftName: string | null
+  /** Retained for compatibility; File no longer surfaces a hover tooltip. */
+  currentDraftName?: string | null
   /** The editor is already stored on this device. */
   isOffline?: boolean
   /** The shell is being cached — the item stays put but locks. */
@@ -48,34 +43,26 @@ export function OpenControls({
   onToggleOffline?: () => void
 }) {
   const [open, setOpen] = React.useState(false)
-  const [tooltipOpen, setTooltipOpen] = React.useState(false)
   const triggerRef = React.useRef<HTMLButtonElement | null>(null)
 
   return (
     <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
-      <Tooltip open={open ? false : tooltipOpen} onOpenChange={setTooltipOpen}>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <Button
-              ref={triggerRef}
-              variant="outline"
-              size="lg"
-              onMouseEnter={() => setOpen(true)}
-              onPointerDown={(event) => {
-                if (open && event.pointerType === "mouse") {
-                  event.preventDefault()
-                }
-              }}
-            >
-              <RiFolderOpenLine />
-              <span className="hidden xl:inline">File</span>
-            </Button>
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {currentDraftName ? `Editing ${currentDraftName}` : "File"}
-        </TooltipContent>
-      </Tooltip>
+      <DropdownMenuTrigger asChild>
+        <Button
+          ref={triggerRef}
+          variant="outline"
+          size="lg"
+          onMouseEnter={() => setOpen(true)}
+          onPointerDown={(event) => {
+            if (open && event.pointerType === "mouse") {
+              event.preventDefault()
+            }
+          }}
+        >
+          <RiFolderOpenLine />
+          <span className="hidden xl:inline">File</span>
+        </Button>
+      </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
         className="w-52"

--- a/components/editor/top-bar/open-project-dialog.tsx
+++ b/components/editor/top-bar/open-project-dialog.tsx
@@ -324,7 +324,7 @@ function ProjectTypeRail({
       <div className="border-t border-border/50 pt-3 sm:mt-auto">
         <Button
           type="button"
-          className="h-9 w-full gap-1.5 border border-green-600/25 bg-green-600/15 text-[12px] text-green-700 hover:bg-green-600/25 hover:text-green-800 dark:border-green-500/30 dark:bg-green-600/20 dark:text-green-400 dark:hover:bg-green-600/30 dark:hover:text-green-300"
+          className="strawberry-button-exempt h-9 w-full gap-1.5 border border-green-600/25 bg-green-600/15 text-[12px] text-green-700 hover:bg-green-600/25 hover:text-green-800 dark:border-green-500/30 dark:bg-green-600/20 dark:text-green-400 dark:hover:bg-green-600/30 dark:hover:text-green-300"
           onClick={onCreateNew}
         >
           <RiAddLine className="size-4" />

--- a/components/editor/top-bar/save-controls.tsx
+++ b/components/editor/top-bar/save-controls.tsx
@@ -15,11 +15,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
 import { Button } from "@/components/ui/button"
 import type { CurrentDraftInfo } from "@/lib/editor/store"
 import { SaveActionRow } from "./ui"
@@ -39,7 +34,6 @@ function saveCopy(
       draftDescription: currentDraft
         ? "Update this project and timeline so you can resume later."
         : "Save the project and timeline so you can resume editing later.",
-      tooltip: "Save animation",
     }
   }
   return {
@@ -52,7 +46,6 @@ function saveCopy(
     draftDescription: currentDraft
       ? "Update this project so you can resume later."
       : "Save the project so you can resume editing later.",
-    tooltip: "Save project",
   }
 }
 
@@ -74,35 +67,26 @@ export function SaveControls({
   onSaveAsDraft: () => void
 }) {
   const copy = saveCopy(isAnimateMode, currentDraft)
-  // Keep the tooltip controlled for its whole lifetime (own hover state) and
-  // force it shut while the popover is open — flipping between a boolean and
-  // undefined would make Radix warn about switching controlled/uncontrolled.
-  const [tooltipOpen, setTooltipOpen] = React.useState(false)
   const triggerRef = React.useRef<HTMLButtonElement | null>(null)
 
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
-      <Tooltip open={open ? false : tooltipOpen} onOpenChange={setTooltipOpen}>
-        <TooltipTrigger asChild>
-          <PopoverTrigger asChild>
-            <Button
-              ref={triggerRef}
-              variant="outline"
-              size="lg"
-              onMouseEnter={() => onOpenChange(true)}
-              onPointerDown={(event) => {
-                if (open && event.pointerType === "mouse") {
-                  event.preventDefault()
-                }
-              }}
-            >
-              <RiSaveLine />
-              <span className="hidden xl:inline">Save</span>
-            </Button>
-          </PopoverTrigger>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">{copy.tooltip}</TooltipContent>
-      </Tooltip>
+      <PopoverTrigger asChild>
+        <Button
+          ref={triggerRef}
+          variant="outline"
+          size="lg"
+          onMouseEnter={() => onOpenChange(true)}
+          onPointerDown={(event) => {
+            if (open && event.pointerType === "mouse") {
+              event.preventDefault()
+            }
+          }}
+        >
+          <RiSaveLine />
+          <span className="hidden xl:inline">Save</span>
+        </Button>
+      </PopoverTrigger>
       <PopoverContent
         align="center"
         sideOffset={12}

--- a/components/editor/top-bar/ui.tsx
+++ b/components/editor/top-bar/ui.tsx
@@ -46,14 +46,14 @@ export function SegmentedRow({
                 opt.disabled
                   ? "cursor-not-allowed text-muted-foreground/40"
                   : active
-                    ? "cursor-pointer text-foreground"
+                    ? "cursor-pointer text-primary-foreground"
                     : "cursor-pointer text-muted-foreground hover:text-foreground"
               )}
             >
               {active && !opt.disabled ? (
                 <motion.span
                   layoutId={`segmented-pill-${options.map((o) => o.value).join("-")}`}
-                  className="absolute inset-0 rounded-full bg-background shadow-sm ring-1 ring-border/60"
+                  className="strawberry-button absolute inset-0 rounded-full shadow-sm ring-1 ring-primary/40"
                   transition={{ type: "spring", stiffness: 420, damping: 34 }}
                 />
               ) : null}

--- a/lib/editor/ascii-backdrop.ts
+++ b/lib/editor/ascii-backdrop.ts
@@ -44,6 +44,21 @@ export function normalizeAsciiResolution(raw: number): number {
 }
 
 /**
+ * WebKit pays tens of milliseconds for each image-background canvas readback.
+ * Desktop Chromium UAs also contain "AppleWebKit", so exclude the engines that
+ * only carry the compatibility token. iOS browsers intentionally stay on the
+ * WebKit path because Apple requires them to use WebKit underneath.
+ */
+export function isWebKitEngine(
+  userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent
+): boolean {
+  return (
+    userAgent.includes("AppleWebKit/") &&
+    !/(?:Chrome|Chromium|Edg|OPR)\//.test(userAgent)
+  )
+}
+
+/**
  * The resolution a slider drag is currently showing, per canvas.
  *
  * The grid is resampled for real on every step instead of scaling the painted

--- a/lib/editor/export-clone.ts
+++ b/lib/editor/export-clone.ts
@@ -43,6 +43,7 @@ function makeExportStyle(scopeId: string, neutralizePortraitFx = false) {
       transition: none !important;
     }
     ${scope} [data-export-hidden="true"] { display: none !important; }
+    ${scope} [data-export-ascii-vector="true"] { display: block !important; }
     ${scope} [data-selection-border="true"] {
       outline: none !important;
       border: none !important;

--- a/tests/components/editor/ascii-backdrop.test.tsx
+++ b/tests/components/editor/ascii-backdrop.test.tsx
@@ -6,13 +6,15 @@ vi.mock("@/lib/editor/ascii-backdrop", async (importOriginal) => {
   const actual = await importOriginal<typeof AsciiBackdropModule>()
   return {
     ...actual,
+    isWebKitEngine: vi.fn(() => false),
     sampleBackgroundPixels: vi.fn(
       async (_background: unknown, cols: number, rows: number) => {
         const data = new Uint8ClampedArray(cols * rows * 4)
         for (let i = 0; i < data.length; i += 4) {
-          data[i] = 255
-          data[i + 1] = 255
-          data[i + 2] = 255
+          const even = (i / 4) % 2 === 0
+          data[i] = even ? 255 : 0
+          data[i + 1] = 0
+          data[i + 2] = even ? 0 : 255
           data[i + 3] = 255
         }
         return data
@@ -24,6 +26,7 @@ vi.mock("@/lib/editor/ascii-backdrop", async (importOriginal) => {
 import { AsciiBackdrop } from "@/components/editor/canvas/ascii-backdrop"
 import {
   DEFAULT_BACKDROP_ASCII,
+  isWebKitEngine,
   setAsciiResolutionPreview,
 } from "@/lib/editor/ascii-backdrop"
 import { CanvasScope } from "@/lib/editor/store"
@@ -39,8 +42,9 @@ class FakeResizeObserver {
   disconnect() {}
 }
 
-function parseGlyphSvg(image: HTMLImageElement | null): Document {
-  const source = image?.getAttribute("src") ?? ""
+function parseGlyphSvg(glyphs: HTMLElement | null): Document {
+  const mask = glyphs?.style.maskImage ?? ""
+  const source = mask.match(/url\(["']?(data:[^)"']+)["']?\)/)?.[1] ?? ""
   const encodedSvg = source.slice(source.indexOf(",") + 1)
   return new DOMParser().parseFromString(
     decodeURIComponent(encodedSvg),
@@ -52,13 +56,15 @@ function nextFrame(): Promise<void> {
   return new Promise((resolve) => requestAnimationFrame(() => resolve()))
 }
 
-describe("AsciiBackdrop SVG image", () => {
+describe("AsciiBackdrop SVG mask", () => {
   afterEach(() => {
     resize = null
+    vi.mocked(isWebKitEngine).mockReturnValue(false)
     vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 
-  it("renders fixed-cell rows inside one SVG-backed image", async () => {
+  it("renders fixed-cell rows inside one row-bounded SVG mask", async () => {
     vi.stubGlobal("ResizeObserver", FakeResizeObserver)
     const { container } = render(
       <AsciiBackdrop
@@ -84,17 +90,13 @@ describe("AsciiBackdrop SVG image", () => {
       )
     })
 
-    const image = container.querySelector<HTMLImageElement>(
-      'img[data-export-ascii-glyphs="true"]'
+    const glyphs = container.querySelector<HTMLElement>(
+      '[data-export-ascii-glyphs="true"]'
     )
-    expect(image).not.toBeNull()
+    expect(glyphs).not.toBeNull()
     expect(container.querySelector("svg")).toBeNull()
-    // The plane is always exactly canvas-sized: nothing scales a stale grid.
-    expect(image?.style.width).toBe("200px")
-    expect(image?.style.height).toBe("100px")
-    expect(image?.style.transform).toBe("")
 
-    const svgDocument = parseGlyphSvg(image)
+    const svgDocument = parseGlyphSvg(glyphs)
     const svg = svgDocument.documentElement
     const rows = Array.from(svgDocument.querySelectorAll("text"))
     expect(svg.getAttribute("viewBox")).toBe("0 0 200 100")
@@ -104,6 +106,99 @@ describe("AsciiBackdrop SVG image", () => {
       expect(row.getAttribute("textLength")).toBe("200")
       expect(row.getAttribute("lengthAdjust")).toBe("spacingAndGlyphs")
     }
+  })
+
+  it("keeps source-coloured 200-column grids to one SVG node per row", async () => {
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver)
+    const { container } = render(
+      <AsciiBackdrop
+        background={{ type: "gradient", value: "linear-gradient(red, blue)" }}
+        ascii={{
+          ...DEFAULT_BACKDROP_ASCII,
+          enabled: true,
+          resolution: 200,
+          colored: true,
+        }}
+      />
+    )
+
+    await act(async () => {
+      resize?.(
+        [
+          {
+            contentRect: { width: 1600, height: 900 },
+          } as ResizeObserverEntry,
+        ],
+        {} as ResizeObserver
+      )
+    })
+
+    const glyphs = container.querySelector<HTMLElement>(
+      '[data-export-ascii-glyphs="true"]'
+    )
+    const svgDocument = parseGlyphSvg(glyphs)
+    expect(svgDocument.querySelectorAll("text")).toHaveLength(56)
+    expect(glyphs?.style.background).toContain("linear-gradient")
+    expect(glyphs?.style.webkitMaskImage).toBe(glyphs?.style.maskImage)
+  })
+
+  it("uses a flat canvas preview on WebKit and keeps the vector layer for export", async () => {
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver)
+    vi.mocked(isWebKitEngine).mockReturnValue(true)
+    const context = {
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      fillText: vi.fn(),
+      measureText: vi.fn(() => ({ width: 200 })),
+      save: vi.fn(),
+      restore: vi.fn(),
+      translate: vi.fn(),
+      scale: vi.fn(),
+      drawImage: vi.fn(),
+      createImageData: vi.fn((width: number, height: number) => ({
+        data: new Uint8ClampedArray(width * height * 4),
+      })),
+      putImageData: vi.fn(),
+    }
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      context as never
+    )
+
+    const { container } = render(
+      <AsciiBackdrop
+        background={{ type: "gradient", value: "linear-gradient(red, blue)" }}
+        ascii={{
+          ...DEFAULT_BACKDROP_ASCII,
+          enabled: true,
+          resolution: 200,
+          colored: true,
+        }}
+      />
+    )
+
+    await act(async () => {
+      resize?.(
+        [
+          {
+            contentRect: { width: 1600, height: 900 },
+          } as ResizeObserverEntry,
+        ],
+        {} as ResizeObserver
+      )
+    })
+
+    const raster = container.querySelector<HTMLCanvasElement>(
+      'canvas[data-export-hidden="true"]'
+    )
+    const vector = container.querySelector<HTMLElement>(
+      '[data-export-ascii-vector="true"]'
+    )
+    expect(raster).not.toBeNull()
+    expect(raster?.width).toBe(1600)
+    expect(raster?.height).toBe(900)
+    expect(vector?.style.display).toBe("none")
+    expect(context.fillText).toHaveBeenCalledTimes(56)
+    expect(context.drawImage).toHaveBeenCalledOnce()
   })
 
   it("resamples the grid at the resolution a drag is previewing", async () => {
@@ -131,9 +226,7 @@ describe("AsciiBackdrop SVG image", () => {
     })
 
     const glyphs = () =>
-      container.querySelector<HTMLImageElement>(
-        'img[data-export-ascii-glyphs="true"]'
-      )
+      container.querySelector<HTMLElement>('[data-export-ascii-glyphs="true"]')
     expect(parseGlyphSvg(glyphs()).querySelectorAll("text")).toHaveLength(5)
 
     // Twice the columns is twice the rows — a real resample, not a scaled grid,
@@ -147,7 +240,6 @@ describe("AsciiBackdrop SVG image", () => {
     expect(previewed.documentElement.getAttribute("viewBox")).toBe(
       "0 0 200 100"
     )
-    expect(glyphs()?.style.width).toBe("200px")
 
     await act(async () => {
       setAsciiResolutionPreview("canvas-1", null)

--- a/tests/lib/editor/ascii-backdrop.test.ts
+++ b/tests/lib/editor/ascii-backdrop.test.ts
@@ -18,6 +18,7 @@ import {
   getAsciiResolutionPreview,
   gridFromImageData,
   isAsciiBackdropActive,
+  isWebKitEngine,
   normalizeAsciiOpacity,
   resolveBackdropAscii,
   sampleBackgroundPixels,
@@ -196,6 +197,24 @@ describe("ascii backdrop layout", () => {
 })
 
 describe("ascii backdrop state", () => {
+  it("identifies WebKit without mistaking desktop Chromium compatibility tokens", () => {
+    expect(
+      isWebKitEngine(
+        "Mozilla/5.0 AppleWebKit/605.1.15 Version/26.6.2 Safari/605.1.15"
+      )
+    ).toBe(true)
+    expect(
+      isWebKitEngine(
+        "Mozilla/5.0 AppleWebKit/605.1.15 CriOS/140.0 Mobile/15E148 Safari/604.1"
+      )
+    ).toBe(true)
+    expect(
+      isWebKitEngine(
+        "Mozilla/5.0 AppleWebKit/537.36 Chrome/140.0.0.0 Safari/537.36"
+      )
+    ).toBe(false)
+  })
+
   it("fills missing fields from the defaults on legacy drafts", () => {
     expect(resolveBackdropAscii(undefined)).toEqual(DEFAULT_BACKDROP_ASCII)
     expect(


### PR DESCRIPTION
## Summary
- render Safari ASCII previews as a flat canvas while retaining vector layers for sharp exports
- avoid live WebKit resampling during resolution drags and bound vector masks to one node per row
- include the existing strawberry button, top-bar, and mobile control styling updates
- add WebKit detection and ASCII renderer regression coverage

## Verification
- pnpm typecheck
- pnpm test (192 files, 1557 tests)
- targeted ESLint checks
- Safari profiling: p95 frame time improved from 105 ms to 18 ms at 200 columns

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR optimizes ASCII rendering in WebKit while preserving vector layers for high-resolution exports, and refreshes several editor-control styles.
- Uses a flat canvas for WebKit previews and a row-bounded SVG mask elsewhere.
- Defers WebKit resolution resampling until slider changes are committed.
- Restores hidden vector ASCII layers in export clones.
- Adds WebKit detection and renderer regression coverage.
- Updates primary action, mobile-control, top-bar, and segmented-control styling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The changed WebKit preview, vector export, opacity, masking, and engine-detection paths retain their required rendering contracts, and the investigated edge cases did not establish a reachable failure.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/editor/canvas/ascii-backdrop.tsx | Replaces color-run SVG rendering with a row-bounded glyph mask and adds a WebKit-only raster preview while retaining vector export output. |
| lib/editor/ascii-backdrop.ts | Adds WebKit engine detection that excludes desktop Chromium compatibility tokens while retaining the iOS WebKit path. |
| lib/editor/export-clone.ts | Forces the vector ASCII layer to become visible in export clones after hiding the live WebKit raster layer. |
| components/editor/inspector/backdrop-section.tsx | Suppresses expensive live ASCII-resolution resampling on WebKit while preserving committed updates. |
| app/globals.css | Adds scoped strawberry-gradient styling for primary interactive controls with explicit exemptions for custom-colored actions. |
| tests/components/editor/ascii-backdrop.test.tsx | Covers row-bounded masks, colored rendering, WebKit raster previews, retained vector layers, and resolution resampling. |
| tests/lib/editor/ascii-backdrop.test.ts | Adds regression coverage for Safari, iOS WebKit, and desktop Chromium user-agent detection. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: optimise safari ascii and editor co..."](https://github.com/shivabhattacharjee/tokokino/commit/5ec5388835b710bd907d32eabf4532a57297e370) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60108280)</sub>

<!-- /greptile_comment -->