### PR TITLE
Add Contact and Stack shadows and two border colours

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,7 +361,7 @@ BackdropPattern = { ids: number[], intensity, thickness, color }
 ### Shadows
 
 ```ts
-ShadowType = "none"|"drop"|"soft"|"hard"|"glow"|"float"|"linear"
+ShadowType = "none"|"drop"|"soft"|"hard"|"glow"|"float"|"linear"|"contact"|"stack"
 Shadow = { type, intensity, lightSource, color }
 ```
 

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -62,7 +62,7 @@ function card(key: FeatureKey, meta: string, vector: ReactNode): FeatureCard {
 const FRAME_AND_STYLE = [
   card("01", "Phones · Desktop", <DeviceFramesVector />),
   card("02", "Sampled colour", <AutoPalettesVector />),
-  card("03", "6 shadow types", <ShadowsEffectsVector />),
+  card("03", "8 shadow types", <ShadowsEffectsVector />),
   card("17", "6 portrait modes", <DepthFocusVector />),
 ] as const
 

--- a/components/editor/inspector/border-section.tsx
+++ b/components/editor/inspector/border-section.tsx
@@ -18,7 +18,11 @@ const BORDER_PRESETS = [
   "#cfe5b8", // matcha mist
   "#0f172a", // ink
   "#ffffff", // white
+  "#7c9cf0", // blueberry
+  "#f3c969", // honey
 ]
+
+const PRESET_SLOTS = 8
 
 const DEFAULT_BORDER_COLOR = BORDER_PRESETS[0]
 
@@ -166,10 +170,13 @@ export function BorderSection() {
         ]
       : [...BORDER_PRESETS]
 
-  while (presets.length < 6) {
-    presets.push(BORDER_PRESETS[presets.length])
+  for (const fallback of BORDER_PRESETS) {
+    if (presets.length >= PRESET_SLOTS) break
+    if (!presets.includes(fallback.toLowerCase())) {
+      presets.push(fallback.toLowerCase())
+    }
   }
-  const finalPresets = presets.slice(0, 6)
+  const finalPresets = presets.slice(0, PRESET_SLOTS)
 
   const isCustom =
     enabled &&

--- a/components/editor/inspector/shadow-section.tsx
+++ b/components/editor/inspector/shadow-section.tsx
@@ -15,6 +15,7 @@ import {
   SHADOW_PREVIEW_VAR,
   shadowCss,
   shadowDropFilterCss,
+  shadowLightOffset,
 } from "@/lib/editor/css-utils"
 import { cn } from "@/lib/utils"
 
@@ -387,6 +388,17 @@ export function ShadowSection() {
         lightSource: "2-0",
       })
       return
+    }
+    // Stack derives all three offsets from the light direction, so a light with
+    // no direction collapses them onto each other and renders as one blurred
+    // halo instead of the stepped cast the picker shows. Seed a diagonal, but
+    // only from dead centre — a direction the user chose is theirs to keep.
+    if (nextType === "stack") {
+      const { dx, dy } = shadowLightOffset(shadow.lightSource)
+      if (dx === 0 && dy === 0) {
+        applyShadow({ ...shadow, type: nextType, lightSource: "1-1" })
+        return
+      }
     }
     applyShadow({ ...shadow, type: nextType })
   }

--- a/components/editor/inspector/shadow-section.tsx
+++ b/components/editor/inspector/shadow-section.tsx
@@ -483,6 +483,34 @@ export function ShadowSection() {
       ),
     },
     {
+      id: "contact" as const,
+      label: "Contact",
+      icon: (
+        <div className={cn("size-full rounded-sm px-3 pt-2 pb-5", thumbBg)}>
+          <div
+            className={cn(
+              "size-full shadow-[0_3px_6px_-2px_rgba(0,0,0,0.55),0_8px_16px_-5px_rgba(0,0,0,0.35)] dark:shadow-[0_3px_6px_-2px_rgba(255,255,255,0.55),0_8px_16px_-5px_rgba(255,255,255,0.35)]",
+              thumbCard
+            )}
+          />
+        </div>
+      ),
+    },
+    {
+      id: "stack" as const,
+      label: "Stack",
+      icon: (
+        <div className={cn("size-full rounded-sm p-3 pr-5 pb-5", thumbBg)}>
+          <div
+            className={cn(
+              "size-full shadow-[3px_3px_1px_0_rgba(0,0,0,0.5),6px_6px_1px_0_rgba(0,0,0,0.32),9px_9px_1px_0_rgba(0,0,0,0.18)] dark:shadow-[3px_3px_1px_0_rgba(255,255,255,0.5),6px_6px_1px_0_rgba(255,255,255,0.32),9px_9px_1px_0_rgba(255,255,255,0.18)]",
+              thumbCard
+            )}
+          />
+        </div>
+      ),
+    },
+    {
       id: "linear" as const,
       label: "Linear",
       icon: (

--- a/components/landing/constants.ts
+++ b/components/landing/constants.ts
@@ -24,7 +24,7 @@ export const FEATURES = [
   {
     k: "03",
     t: "Shadows & effects",
-    d: "6 shadow types — Drop, Soft, Hard, Glow, Float, Linear — with intensity and custom color.",
+    d: "8 shadow types — Drop, Soft, Hard, Glow, Float, Linear, Contact, Stack — with intensity and custom color.",
     tone: "primary" as const,
   },
   {

--- a/lib/editor/animation-export/video-media/frame-canvas-utils.ts
+++ b/lib/editor/animation-export/video-media/frame-canvas-utils.ts
@@ -111,21 +111,49 @@ export function nonBlackPct(canvas: HTMLCanvasElement): number {
  * the texture — the video then ran to the very edge of the plate instead of
  * sitting inside it.
  */
+/** Colour functions removed so their commas and numbers can't be misread. */
+function withoutColorFunctions(source: string): string {
+  return source.replace(/(rgba?|hsla?|color)\([^)]*\)/g, " ")
+}
+
+/** The comma-separated layers of a `box-shadow`. */
+function shadowLayerSegments(source: string): string[] {
+  if (!source || source === "none") return []
+  return withoutColorFunctions(source).split(",")
+}
+
+/**
+ * Each `drop-shadow()` in a filter chain, separately.
+ *
+ * Chained drop-shadows are separated by SPACES, not commas, so splitting the
+ * filter on commas returns the whole chain as one segment — and reading the
+ * first four lengths off that then mixes the first layer's offsets with the
+ * second layer's. A multi-layer shadow (contact, linear, float, or any
+ * cross-blend) reserved margin for a layer that doesn't exist and clipped the
+ * one that reaches furthest.
+ */
+function dropShadowSegments(source: string): string[] {
+  if (!source || source === "none") return []
+  return Array.from(
+    withoutColorFunctions(source).matchAll(/drop-shadow\(([^)]*)\)/g),
+    (m) => m[1]
+  )
+}
+
 export function shadowExtentPx(el: HTMLElement): number {
   const cs = getComputedStyle(el)
   let max = 0
-  for (const source of [cs.boxShadow, cs.filter]) {
-    if (!source || source === "none") continue
-    const cleaned = source.replace(/(rgba?|hsla?|color)\([^)]*\)/g, " ")
-    for (const part of cleaned.split(",")) {
-      const nums = (part.match(/-?\d+(?:\.\d+)?(?=px)/g) ?? []).map(Number)
-      if (nums.length === 0) continue
-      const [dx = 0, dy = 0, blur = 0, spread = 0] = nums
-      max = Math.max(
-        max,
-        Math.abs(dx) + Math.abs(dy) + Math.abs(blur) + Math.abs(spread)
-      )
-    }
+  for (const part of [
+    ...shadowLayerSegments(cs.boxShadow),
+    ...dropShadowSegments(cs.filter),
+  ]) {
+    const nums = (part.match(/-?\d+(?:\.\d+)?(?=px)/g) ?? []).map(Number)
+    if (nums.length === 0) continue
+    const [dx = 0, dy = 0, blur = 0, spread = 0] = nums
+    max = Math.max(
+      max,
+      Math.abs(dx) + Math.abs(dy) + Math.abs(blur) + Math.abs(spread)
+    )
   }
 
   const outlineWidth = parseFloat(cs.outlineWidth) || 0

--- a/lib/editor/animation-playback.ts
+++ b/lib/editor/animation-playback.ts
@@ -403,6 +403,23 @@ function parseLightSource(ls: string): { r: number; c: number } {
 }
 
 /**
+ * The colour a `from` → `to` shadow blend renders at progress p. Two visible
+ * shadows CROSS-FADE their colours, so recolouring one (or easing a coloured
+ * keyframe back to a differently coloured base) slides through the mix instead
+ * of snapping to the destination on the first tick. A shadow that renders
+ * nothing has no colour to contribute — it borrows the visible side's, so a
+ * reveal or a retract only moves alpha rather than dragging the hue toward
+ * whatever colour the inert shadow happens to carry.
+ */
+function shadowColorBetween(from: Shadow, to: Shadow, p: number): string {
+  const fromVisible = !shadowInvisible(from)
+  const toVisible = !shadowInvisible(to)
+  if (fromVisible && toVisible) return lerpHexColor(from.color, to.color, p)
+  if (toVisible) return to.color
+  return from.color
+}
+
+/**
  * Shadow at progress p, animating `from` → `to`. Intensity eases from whatever
  * the previous keyframe actually rendered, so back-to-back shadow keyframes stay
  * CONTINUOUS: a drop shadow morphing into a soft one keeps its weight instead of
@@ -422,6 +439,7 @@ export function shadowBetween(from: Shadow, to: Shadow, p: number): Shadow {
   const fromLs = sameType ? parseLightSource(from.lightSource) : toLs
   return {
     ...to,
+    color: shadowColorBetween(from, to, p),
     intensity: lerp(fromIntensity, to.intensity, p),
     lightSource: `${lerp(fromLs.r, toLs.r, p)}-${lerp(fromLs.c, toLs.c, p)}`,
   }

--- a/lib/editor/apply-animation-frame.ts
+++ b/lib/editor/apply-animation-frame.ts
@@ -128,6 +128,13 @@ import type {
   Tilt,
 } from "@/lib/editor/state-types"
 
+/**
+ * A filter list can't contain `none` — one invalidates the whole declaration,
+ * taking the colour grade chained beside it down too. So a frame with no shadow
+ * publishes a no-op filter function instead of `none`.
+ */
+const NO_SHADOW_FILTER = "opacity(1)"
+
 const INVISIBLE_SHADOW: Shadow = {
   type: "none",
   intensity: 0,
@@ -762,7 +769,7 @@ export function applyAnimationFrameAtTime({
         .filter((v): v is string => Boolean(v))
         .join(" ")
       setVar(mainScopeEl, SHADOW_PREVIEW_VAR, box || "none")
-      setVar(mainScopeEl, SHADOW_FILTER_PREVIEW_VAR, filter || "none")
+      setVar(mainScopeEl, SHADOW_FILTER_PREVIEW_VAR, filter || NO_SHADOW_FILTER)
     } else {
       setVar(mainScopeEl, SHADOW_PREVIEW_VAR, null)
       setVar(mainScopeEl, SHADOW_FILTER_PREVIEW_VAR, null)
@@ -1154,7 +1161,7 @@ export function applyAnimationFrameAtTime({
         .filter((v): v is string => Boolean(v))
         .join(" ")
       setVar(slotEl, SHADOW_PREVIEW_VAR, box || "none")
-      setVar(slotEl, SHADOW_FILTER_PREVIEW_VAR, filter || "none")
+      setVar(slotEl, SHADOW_FILTER_PREVIEW_VAR, filter || NO_SHADOW_FILTER)
     } else {
       setVar(slotEl, SHADOW_PREVIEW_VAR, null)
       setVar(slotEl, SHADOW_FILTER_PREVIEW_VAR, null)

--- a/lib/editor/css-utils.ts
+++ b/lib/editor/css-utils.ts
@@ -516,7 +516,21 @@ export function borderOffsetCss(border: Border): string {
 export function shadowDropFilterCss(shadow: Shadow): string | undefined {
   const css = shadowCss(shadow)
   if (!css) return undefined
-  const parts = splitTopLevelCommas(css)
+  return boxShadowToDropFilterCss(css)
+}
+
+/**
+ * A `box-shadow` value as the equivalent chain of `drop-shadow()` filters.
+ *
+ * Takes the CSS rather than a `Shadow` so it can convert a value already
+ * resolved by the engine — the export clone reads `getComputedStyle` and has no
+ * `Shadow` object to hand.
+ */
+export function boxShadowToDropFilterCss(
+  boxShadow: string
+): string | undefined {
+  if (!boxShadow || boxShadow === "none") return undefined
+  const parts = splitTopLevelCommas(boxShadow)
     .map(boxShadowSegmentToDropShadow)
     .filter((v): v is string => Boolean(v))
   return parts.length ? parts.join(" ") : undefined
@@ -561,14 +575,19 @@ function boxShadowSegmentToDropShadow(segment: string): string | null {
 
   // Filter out "inset" — drop-shadow doesn't support it.
   const filtered = tokens.filter((t) => t.toLowerCase() !== "inset")
-  // Color is the last token that isn't a length.
+  // Authored box-shadows put the colour last, but a COMPUTED one puts it first,
+  // and the export clone converts computed values — so sort by what each token
+  // is rather than by where it sits. Nothing but a length can look like one:
+  // every colour form is either a keyword, a hash, or a parenthesised function
+  // the tokenizer above keeps whole.
   const lengthRe = /^-?\d+(\.\d+)?(px|em|rem|%)?$/
   const lengths: string[] = []
-  let color = ""
+  const colorParts: string[] = []
   for (const tok of filtered) {
-    if (lengthRe.test(tok) && !color) lengths.push(tok)
-    else color = color ? `${color} ${tok}` : tok
+    if (lengthRe.test(tok)) lengths.push(tok)
+    else colorParts.push(tok)
   }
+  const color = colorParts.join(" ")
   if (lengths.length < 2) return null
   const [dx, dy, blurRaw, spreadRaw] = lengths
   const blur = parseFloat(blurRaw ?? "0")

--- a/lib/editor/css-utils.ts
+++ b/lib/editor/css-utils.ts
@@ -359,6 +359,13 @@ function shadowRgba(color: string, opacity: number): string {
   return `rgba(${r}, ${g}, ${b}, ${opacity.toFixed(3)})`
 }
 
+function shadowLightOffset(lightSource: string): { dx: number; dy: number } {
+  if (lightSource === "center") return { dx: 0, dy: 0 }
+  const [r, c] = lightSource.split("-").map(Number)
+  if (!Number.isFinite(r) || !Number.isFinite(c)) return { dx: 0, dy: 0 }
+  return { dx: -(c - 2), dy: -(r - 2) }
+}
+
 export function shadowCss(shadow: Shadow): string | undefined {
   if (shadow.type === "none" || shadow.intensity <= 0) return undefined
   const intensity = shadow.intensity / 100
@@ -372,15 +379,7 @@ export function shadowCss(shadow: Shadow): string | undefined {
   }
 
   if (shadow.type === "soft") {
-    let dx = 0,
-      dy = 0
-    if (shadow.lightSource !== "center") {
-      const [r, c] = shadow.lightSource.split("-").map(Number)
-      if (Number.isFinite(r) && Number.isFinite(c)) {
-        dx = -(c - 2)
-        dy = -(r - 2)
-      }
-    }
+    const { dx, dy } = shadowLightOffset(shadow.lightSource)
     const unit = intensity * 10
     const blur = 40 + intensity * 80
     const spread = intensity * 4
@@ -389,15 +388,7 @@ export function shadowCss(shadow: Shadow): string | undefined {
   }
 
   if (shadow.type === "hard") {
-    let dx = 0,
-      dy = 0
-    if (shadow.lightSource !== "center") {
-      const [r, c] = shadow.lightSource.split("-").map(Number)
-      if (Number.isFinite(r) && Number.isFinite(c)) {
-        dx = -(c - 2)
-        dy = -(r - 2)
-      }
-    }
+    const { dx, dy } = shadowLightOffset(shadow.lightSource)
     const unit = intensity * 12
     const opacity = 0.25 + intensity * 0.45
     return `${(dx * unit).toFixed(1)}px ${(dy * unit).toFixed(1)}px 0px 0px ${shadowRgba(color, opacity)}`
@@ -413,16 +404,34 @@ export function shadowCss(shadow: Shadow): string | undefined {
     return `0 ${dy1.toFixed(1)}px ${blur1.toFixed(1)}px 0px ${shadowRgba(color, opacity1)}, 0 ${dy2.toFixed(1)}px ${blur2.toFixed(1)}px 0px ${shadowRgba(color, opacity2)}`
   }
 
+  // Contact and Stack size EVERY dimension off intensity — offset, blur and
+  // alpha all reach 0 together — so an animated reveal grows out of nothing
+  // instead of popping in at a visible offset, and the release mirrors it.
+  if (shadow.type === "contact") {
+    const { dx, dy } = shadowLightOffset(shadow.lightSource)
+    const unit = intensity * 5
+    const near = `${(dx * unit * 0.4).toFixed(1)}px ${(dy * unit * 0.4).toFixed(1)}px ${(intensity * 12).toFixed(1)}px ${(intensity * -3).toFixed(1)}px ${shadowRgba(color, intensity * 0.7)}`
+    const far = `${(dx * unit).toFixed(1)}px ${(dy * unit).toFixed(1)}px ${(intensity * 38).toFixed(1)}px ${(intensity * -9).toFixed(1)}px ${shadowRgba(color, intensity * 0.4)}`
+    return `${near}, ${far}`
+  }
+
+  if (shadow.type === "stack") {
+    const { dx, dy } = shadowLightOffset(shadow.lightSource)
+    const step = intensity * 9
+    // A zero-blur edge snaps to whole pixels, so a stack sliding out one
+    // fractional step per frame visibly stutters — 2px of blur is invisible at
+    // rest and enough to keep the travel continuous.
+    const blur = intensity * 2
+    return [0.62, 0.4, 0.22]
+      .map((alpha, i) => {
+        const distance = step * (i + 1)
+        return `${(dx * distance).toFixed(1)}px ${(dy * distance).toFixed(1)}px ${blur.toFixed(1)}px 0px ${shadowRgba(color, intensity * alpha)}`
+      })
+      .join(", ")
+  }
+
   if (shadow.type === "linear") {
-    let dx = 0,
-      dy = 0
-    if (shadow.lightSource !== "center") {
-      const [r, c] = shadow.lightSource.split("-").map(Number)
-      if (Number.isFinite(r) && Number.isFinite(c)) {
-        dx = -(c - 2)
-        dy = -(r - 2)
-      }
-    }
+    const { dx, dy } = shadowLightOffset(shadow.lightSource)
     const unit = intensity * 12
     const opacity1 = 0.1 + intensity * 0.15
     const opacity2 = 0.08 + intensity * 0.12
@@ -431,15 +440,7 @@ export function shadowCss(shadow: Shadow): string | undefined {
     return `${(dx * unit * 0.5).toFixed(1)}px ${(dy * unit * 0.5).toFixed(1)}px ${(10 + intensity * 15).toFixed(1)}px 0px ${shadowRgba(color, opacity1)}, ${(dx * unit * 1.2).toFixed(1)}px ${(dy * unit * 1.2).toFixed(1)}px ${(25 + intensity * 35).toFixed(1)}px 0px ${shadowRgba(color, opacity2)}, ${(dx * unit * 2.2).toFixed(1)}px ${(dy * unit * 2.2).toFixed(1)}px ${(45 + intensity * 65).toFixed(1)}px 0px ${shadowRgba(color, opacity3)}, ${(dx * unit * 3.5).toFixed(1)}px ${(dy * unit * 3.5).toFixed(1)}px ${(70 + intensity * 100).toFixed(1)}px 0px ${shadowRgba(color, opacity4)}`
   }
 
-  let dx = 0,
-    dy = 0
-  if (shadow.lightSource !== "center") {
-    const [r, c] = shadow.lightSource.split("-").map(Number)
-    if (Number.isFinite(r) && Number.isFinite(c)) {
-      dx = -(c - 2)
-      dy = -(r - 2)
-    }
-  }
+  const { dx, dy } = shadowLightOffset(shadow.lightSource)
   const unit = intensity * 16
   const blur = 20 + intensity * 60
   const spread = -2

--- a/lib/editor/css-utils.ts
+++ b/lib/editor/css-utils.ts
@@ -359,7 +359,11 @@ function shadowRgba(color: string, opacity: number): string {
   return `rgba(${r}, ${g}, ${b}, ${opacity.toFixed(3)})`
 }
 
-function shadowLightOffset(lightSource: string): { dx: number; dy: number } {
+/** Light direction as a unit offset; "center" and the middle cell are both 0,0. */
+export function shadowLightOffset(lightSource: string): {
+  dx: number
+  dy: number
+} {
   if (lightSource === "center") return { dx: 0, dy: 0 }
   const [r, c] = lightSource.split("-").map(Number)
   if (!Number.isFinite(r) || !Number.isFinite(c)) return { dx: 0, dy: 0 }
@@ -570,8 +574,14 @@ function boxShadowSegmentToDropShadow(segment: string): string | null {
   const blur = parseFloat(blurRaw ?? "0")
   const spread = parseFloat(spreadRaw ?? "0")
   // Fold spread into blur as an approximation (drop-shadow has no spread).
-  const effectiveBlur = Math.max(0, blur + Math.max(0, spread) * 2)
-  return `drop-shadow(${dx} ${dy} ${effectiveBlur}px ${color})`
+  // A NEGATIVE spread insets the shadow rect, so it has to shrink the blur —
+  // discarding it made the tight casts (drop, contact) export softer and wider
+  // than they render on canvas. It folds at 1x, which matches the extent the
+  // box-shadow actually covers; positive spread keeps its historic 2x.
+  const effectiveBlur = Math.max(0, blur + (spread > 0 ? spread * 2 : spread))
+  // Rounded because the fold is float arithmetic on already-rounded lengths,
+  // and 5.3999999999999995px in a filter chain helps nobody.
+  return `drop-shadow(${dx} ${dy} ${Number(effectiveBlur.toFixed(2))}px ${color})`
 }
 
 export function backgroundCss(bg: Background): React.CSSProperties {

--- a/lib/editor/export-animation-capture.ts
+++ b/lib/editor/export-animation-capture.ts
@@ -24,6 +24,7 @@ import {
   exportScaleStyle,
   rasterizeNodeToCanvas,
 } from "./export-raster"
+import { isRasterEssentiallyEmpty, settleDelayMs } from "./export-settle"
 
 /**
  * Prepare an offscreen clone of the canvas for repeated frame capture (used by
@@ -49,11 +50,51 @@ export type AnimationCapture = {
 }
 
 /**
+ * How many times to re-raster an ASCII glyph tree that came back blank. The
+ * glyphs are painted entirely through a data-URI SVG mask, which is exactly the
+ * subresource WebKit will report as loaded before it has decoded — so the first
+ * raster can be empty even though the layer renders perfectly on screen.
+ */
+const ASCII_RASTER_MAX_ATTEMPTS = 6
+
+/**
+ * Rasterize one ASCII glyph tree, retrying while the result is blank.
+ *
+ * Returns null if every attempt came back empty, which leaves the caller with
+ * the original glyph DOM — slower to capture, but it still paints, and the
+ * per-frame capture has its own WebKit warm-up. Flattening a blank raster in
+ * would delete the ASCII treatment from every frame of the export.
+ */
+async function rasterizeAsciiGlyphs(
+  glyphTree: HTMLElement,
+  width: number,
+  height: number,
+  pixelRatio: number
+): Promise<HTMLCanvasElement | null> {
+  const outWidth = Math.max(1, Math.round(width * pixelRatio))
+  const outHeight = Math.max(1, Math.round(height * pixelRatio))
+  for (let attempt = 1; attempt <= ASCII_RASTER_MAX_ATTEMPTS; attempt++) {
+    const raster = await rasterizeNodeToCanvas(
+      glyphTree,
+      { cacheBust: false },
+      width,
+      height,
+      outWidth,
+      outHeight
+    )
+    if (!isRasterEssentiallyEmpty(raster)) return raster
+    if (supportsObjectViewBox()) return null
+    await new Promise((resolve) => setTimeout(resolve, settleDelayMs(attempt)))
+  }
+  return null
+}
+
+/**
  * Replace each ASCII glyph tree in an animation clone with one transparent,
  * output-resolution PNG. The outer ASCII layer stays in the DOM so its plate,
  * filter, user opacity, and timeline crossfade keep their original geometry.
  */
-async function flattenAnimationAsciiLayers(
+export async function flattenAnimationAsciiLayers(
   node: HTMLElement,
   renderedWidth: number,
   outputWidth: number
@@ -70,14 +111,13 @@ async function flattenAnimationAsciiLayers(
     const { width, height } = size
 
     try {
-      const raster = await rasterizeNodeToCanvas(
+      const raster = await rasterizeAsciiGlyphs(
         glyphTree,
-        { cacheBust: false },
         width,
         height,
-        Math.max(1, Math.round(width * pixelRatio)),
-        Math.max(1, Math.round(height * pixelRatio))
+        pixelRatio
       )
+      if (!raster) continue
       const dataUrl = await readBlobAsDataUrl(
         await canvasToBlob(raster, "image/png")
       )

--- a/lib/editor/export-clone.ts
+++ b/lib/editor/export-clone.ts
@@ -3,6 +3,7 @@ import {
   flattenGlassChromeRing,
   neutralizeUnsupportedExportBackdropFilters,
 } from "./export-glass"
+import { redirectBoxShadowToFilter } from "./export-shadow-filter"
 
 const WATERMARK_PREFIX = "Designed by"
 const WATERMARK_APP_NAME = "Tokokino"
@@ -164,8 +165,9 @@ export function prepareExportNode(
   }
   wrapper.appendChild(node)
   document.body.appendChild(wrapper)
-  // Reads computed styles, so it needs the clone laid out in the document.
+  // Both read computed styles, so they need the clone laid out in the document.
   flattenGlassChromeRing(node)
+  redirectBoxShadowToFilter(node)
 
   return {
     node,

--- a/lib/editor/export-shadow-filter.ts
+++ b/lib/editor/export-shadow-filter.ts
@@ -1,0 +1,49 @@
+import { supportsObjectViewBox } from "./crop-utils"
+import {
+  boxShadowToDropFilterCss,
+  SHADOW_FILTER_PREVIEW_VAR,
+} from "./css-utils"
+
+/**
+ * Re-express a frameless screenshot's `box-shadow` as a `drop-shadow()` chain
+ * in the export clone, on the engines that need it.
+ *
+ * WebKit rasterizes a `<foreignObject>` without painting the box-shadow on the
+ * screenshot, so a frameless canvas exported from Safari came out with no
+ * shadow at all while the live editor showed it. Framed screenshots were never
+ * affected: they carry `data-editor-shadow-filter-target` and already render
+ * their shadow through the filter chain, which WebKit does raster.
+ *
+ * The element keeps reading {@link SHADOW_FILTER_PREVIEW_VAR}, so an animated
+ * shadow still updates per frame — only the property carrying it changes. The
+ * converted committed value becomes the var's fallback, which is what shows
+ * before the first frame's vars land and on a still export.
+ *
+ * A drop-shadow follows the painted alpha rather than the border box, so a
+ * `contain`-fitted image with transparent letterboxing casts from the picture
+ * instead of the box. That is the same trade every framed export already makes,
+ * and it beats no shadow.
+ */
+export function redirectBoxShadowToFilter(node: HTMLElement): void {
+  if (supportsObjectViewBox()) return
+
+  const targets = node.querySelectorAll<HTMLElement>(
+    "[data-editor-shadow-box-target]"
+  )
+  for (const el of targets) {
+    const computed = getComputedStyle(el)
+    const dropShadow = boxShadowToDropFilterCss(computed.boxShadow)
+    if (!dropShadow) continue
+
+    // Read the filter off the inline style, not the computed one: the inline
+    // value is still the unresolved `var(...)` the grade sliders and the
+    // animation frame write through, and baking the resolved value would
+    // freeze the colour grade on whatever this instant happened to be.
+    const existingFilter = el.style.filter
+    const shadowLeg = `var(${SHADOW_FILTER_PREVIEW_VAR}, ${dropShadow})`
+    el.style.boxShadow = "none"
+    el.style.filter = existingFilter
+      ? `${existingFilter} ${shadowLeg}`
+      : shadowLeg
+  }
+}

--- a/lib/editor/state-types.ts
+++ b/lib/editor/state-types.ts
@@ -105,6 +105,8 @@ export type ShadowType =
   | "glow"
   | "float"
   | "linear"
+  | "contact"
+  | "stack"
 
 export type Shadow = {
   type: ShadowType

--- a/tests/components/editor/border-section.test.tsx
+++ b/tests/components/editor/border-section.test.tsx
@@ -223,11 +223,11 @@ describe("BorderSection", () => {
     expect(frost.querySelector(".text-primary")).toBeNull()
   })
 
-  it("passes six presets and the current color to the color grid", () => {
+  it("passes eight presets and the current color to the color grid", () => {
     render(<BorderSection />)
     expect(screen.getByTestId("color-grid")).toBeInTheDocument()
     const props = store.colorGridProps!
-    expect((props.presets as string[]).length).toBe(6)
+    expect((props.presets as string[]).length).toBe(8)
     expect(props.selected).toBe("#f08a9a")
   })
 

--- a/tests/components/editor/shadow-section.test.tsx
+++ b/tests/components/editor/shadow-section.test.tsx
@@ -108,6 +108,30 @@ describe("ShadowSection", () => {
     })
   })
 
+  it("Stack preset seeds a diagonal light so its layers step apart", async () => {
+    // Every Stack offset is derived from the light direction, so the centre
+    // cell would stack all three layers on the same spot — a blurred halo, not
+    // the stepped cast the picker shows.
+    const user = userEvent.setup()
+    render(<ShadowSection />)
+
+    await user.click(screen.getByRole("button", { name: "Stack" }))
+
+    const patch = store.applyStyle.mock.calls[0][0] as { shadow: Shadow }
+    expect(patch.shadow).toMatchObject({ type: "stack", lightSource: "1-1" })
+  })
+
+  it("Stack preset keeps a light direction the user already chose", async () => {
+    store.shadow = { ...store.shadow, lightSource: "0-4" }
+    const user = userEvent.setup()
+    render(<ShadowSection />)
+
+    await user.click(screen.getByRole("button", { name: "Stack" }))
+
+    const patch = store.applyStyle.mock.calls[0][0] as { shadow: Shadow }
+    expect(patch.shadow.lightSource).toBe("0-4")
+  })
+
   it("commits an intensity edit through applyStyle", async () => {
     const user = userEvent.setup()
     render(<ShadowSection />)

--- a/tests/lib/editor/animation-playback.test.ts
+++ b/tests/lib/editor/animation-playback.test.ts
@@ -677,6 +677,34 @@ describe("sampleShadowLayers", () => {
     expect(sampleShadowLayers([frame(soft)], 2000, none)![0].intensity).toBe(0)
   })
 
+  it("cross-fades the colour when releasing to a differently coloured rest", () => {
+    // Same type, both visible: the release used to take the rest colour on its
+    // first tick, so a green shadow turned black and only THEN faded out.
+    const green: Shadow = { ...soft, color: "#00ff00" }
+    const blackRest: Shadow = { ...soft, intensity: 40 }
+    const start = sampleShadowLayers([frame(green)], 1000, blackRest)!
+    expect(start[0].color).toBe("#00ff00")
+    const mid = sampleShadowLayers([frame(green)], 1500, blackRest)!
+    expect(mid[0].color).toBe("#008000")
+    const end = sampleShadowLayers([frame(green)], 2000, blackRest)!
+    expect(end[0].color).toBe("#000000")
+  })
+
+  it("keeps its own colour retracting to an invisible rest", () => {
+    // Nothing to blend toward — an inert shadow's colour must not drag the hue.
+    const green: Shadow = { ...soft, color: "#00ff00" }
+    const mid = sampleShadowLayers([frame(green)], 1500, none)!
+    expect(mid[0].color).toBe("#00ff00")
+    expect(mid[0].intensity).toBeCloseTo(40, 5)
+  })
+
+  it("reveals straight into its own colour from an invisible rest", () => {
+    const green: Shadow = { ...soft, color: "#00ff00" }
+    expect(sampleShadowLayers([frame(green)], 0, none)![0].color).toBe(
+      "#00ff00"
+    )
+  })
+
   it("cross-blends back when rest is a different visible shadow", () => {
     const mid = sampleShadowLayers([frame(soft)], 1500, glow)!
     expect(mid.map((s) => s.type)).toEqual(["soft", "glow"])

--- a/tests/lib/editor/ascii-export-flatten.test.ts
+++ b/tests/lib/editor/ascii-export-flatten.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+/**
+ * The ASCII glyph layer paints entirely through a data-URI SVG mask, and WebKit
+ * reports such a subresource loaded before it has decoded — so the flatten pass
+ * can rasterize a blank canvas. Since the flatten REPLACES the glyph DOM, taking
+ * a blank raster deletes the ASCII treatment from every frame of the export.
+ */
+
+const rasterizeNodeToCanvas = vi.fn<() => Promise<HTMLCanvasElement>>()
+const isRasterEssentiallyEmpty = vi.fn<() => boolean>()
+const supportsObjectViewBox = vi.fn<() => boolean>()
+
+vi.mock("@/lib/editor/export-raster", () => ({
+  rasterizeNodeToCanvas: () => rasterizeNodeToCanvas(),
+  canvasToBlob: async () => new Blob(),
+  exportScaleStyle: () => ({}),
+}))
+
+vi.mock("@/lib/editor/export-settle", () => ({
+  isRasterEssentiallyEmpty: () => isRasterEssentiallyEmpty(),
+  settleDelayMs: () => 0,
+}))
+
+vi.mock("@/lib/editor/crop-utils", () => ({
+  supportsObjectViewBox: () => supportsObjectViewBox(),
+}))
+
+vi.mock("@/lib/editor/export-embed", () => ({
+  readBlobAsDataUrl: async () => "data:image/png;base64,AAAA",
+  waitForImageElement: async () => undefined,
+  embedCloneImages: async () => undefined,
+  embedCloneBackgroundImages: async () => undefined,
+}))
+
+vi.mock("@/lib/editor/export-dom", () => ({
+  exportElementLayoutSize: () => ({ width: 800, height: 600 }),
+  filterExportHidden: () => true,
+  findCanvasElement: () => null,
+  getCanvasLayoutDims: () => null,
+}))
+
+const { flattenAnimationAsciiLayers } =
+  await import("@/lib/editor/export-animation-capture")
+
+function nodeWithGlyphTree() {
+  const node = document.createElement("div")
+  node.innerHTML = `<div data-export-ascii-glyphs="true"></div>`
+  return node
+}
+
+const glyphTreeOf = (node: HTMLElement) =>
+  node.querySelector('[data-export-ascii-glyphs="true"]')
+
+describe("flattenAnimationAsciiLayers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rasterizeNodeToCanvas.mockResolvedValue(document.createElement("canvas"))
+    supportsObjectViewBox.mockReturnValue(false)
+  })
+
+  it("flattens a glyph tree whose raster painted", async () => {
+    isRasterEssentiallyEmpty.mockReturnValue(false)
+    const node = nodeWithGlyphTree()
+    await flattenAnimationAsciiLayers(node, 800, 1600)
+    expect(rasterizeNodeToCanvas).toHaveBeenCalledTimes(1)
+    expect(glyphTreeOf(node)).toBeNull()
+    expect(node.querySelector("img")).not.toBeNull()
+  })
+
+  it("retries a blank raster and flattens the attempt that paints", async () => {
+    isRasterEssentiallyEmpty
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false)
+    const node = nodeWithGlyphTree()
+    await flattenAnimationAsciiLayers(node, 800, 1600)
+    expect(rasterizeNodeToCanvas).toHaveBeenCalledTimes(3)
+    expect(node.querySelector("img")).not.toBeNull()
+  })
+
+  it("keeps the glyph DOM when every raster comes back blank", async () => {
+    isRasterEssentiallyEmpty.mockReturnValue(true)
+    const node = nodeWithGlyphTree()
+    await flattenAnimationAsciiLayers(node, 800, 1600)
+    // The layer still paints through the per-frame capture, which has its own
+    // WebKit warm-up. An <img> here would be a blank hole in every frame.
+    expect(glyphTreeOf(node)).not.toBeNull()
+    expect(node.querySelector("img")).toBeNull()
+  })
+
+  it("does not spend WebKit's retry budget on Chromium", async () => {
+    isRasterEssentiallyEmpty.mockReturnValue(true)
+    supportsObjectViewBox.mockReturnValue(true)
+    const node = nodeWithGlyphTree()
+    await flattenAnimationAsciiLayers(node, 800, 1600)
+    expect(rasterizeNodeToCanvas).toHaveBeenCalledTimes(1)
+    expect(glyphTreeOf(node)).not.toBeNull()
+  })
+})

--- a/tests/lib/editor/export-shadow-filter.test.ts
+++ b/tests/lib/editor/export-shadow-filter.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+/**
+ * WebKit rasterizes a foreignObject without painting the screenshot's
+ * box-shadow, so a frameless canvas exported from Safari lost its shadow while
+ * the live editor showed it. The export clone re-expresses it as the
+ * drop-shadow chain WebKit does raster.
+ */
+
+const supportsObjectViewBox = vi.fn<() => boolean>()
+
+vi.mock("@/lib/editor/crop-utils", () => ({
+  supportsObjectViewBox: () => supportsObjectViewBox(),
+}))
+
+const { redirectBoxShadowToFilter } =
+  await import("@/lib/editor/export-shadow-filter")
+
+/** jsdom returns inline styles from getComputedStyle, which is all we need. */
+function cloneWith(style: Partial<CSSStyleDeclaration>): HTMLElement {
+  const node = document.createElement("div")
+  const target = document.createElement("img")
+  target.setAttribute("data-editor-shadow-box-target", "")
+  Object.assign(target.style, style)
+  node.appendChild(target)
+  document.body.appendChild(node)
+  return node
+}
+
+const targetOf = (node: HTMLElement) =>
+  node.querySelector<HTMLElement>("[data-editor-shadow-box-target]")!
+
+describe("redirectBoxShadowToFilter", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    supportsObjectViewBox.mockReturnValue(false)
+  })
+
+  it("moves the shadow onto the filter chain on WebKit", () => {
+    const node = cloneWith({
+      boxShadow: "rgba(95, 137, 122, 0.247) 7.2px 7.2px 0.8px 0px",
+    })
+    redirectBoxShadowToFilter(node)
+
+    const el = targetOf(node)
+    expect(el.style.boxShadow).toBe("none")
+    expect(el.style.filter).toContain("--editor-shadow-filter-preview")
+    expect(el.style.filter).toContain("drop-shadow(7.2px 7.2px 0.8px")
+  })
+
+  it("keeps every layer of a multi-layer shadow", () => {
+    const node = cloneWith({
+      boxShadow:
+        "rgba(0, 0, 0, 0.6) 7.2px 7.2px 0.8px 0px, rgba(0, 0, 0, 0.4) 14.4px 14.4px 0.8px 0px, rgba(0, 0, 0, 0.2) 21.6px 21.6px 0.8px 0px",
+    })
+    redirectBoxShadowToFilter(node)
+
+    expect(targetOf(node).style.filter.match(/drop-shadow\(/g)).toHaveLength(3)
+  })
+
+  it("preserves the colour grade already on the filter", () => {
+    const node = cloneWith({
+      boxShadow: "rgba(0, 0, 0, 0.5) 4px 4px 8px 0px",
+      filter: "var(--editor-media-fx, brightness(1.1))",
+    })
+    redirectBoxShadowToFilter(node)
+
+    const filter = targetOf(node).style.filter
+    expect(filter.startsWith("var(--editor-media-fx, brightness(1.1))")).toBe(
+      true
+    )
+    expect(filter).toContain("drop-shadow(")
+  })
+
+  it("leaves Chromium's box-shadow alone", () => {
+    supportsObjectViewBox.mockReturnValue(true)
+    const node = cloneWith({
+      boxShadow: "rgba(0, 0, 0, 0.5) 4px 4px 8px 0px",
+    })
+    redirectBoxShadowToFilter(node)
+
+    expect(targetOf(node).style.boxShadow).not.toBe("none")
+    expect(targetOf(node).style.filter).toBe("")
+  })
+
+  it("does nothing when the screenshot has no shadow", () => {
+    const node = cloneWith({ filter: "brightness(1.1)" })
+    redirectBoxShadowToFilter(node)
+
+    // A var() leg with an empty fallback would invalidate the whole chain and
+    // take the colour grade down with it.
+    expect(targetOf(node).style.filter).toBe("brightness(1.1)")
+  })
+})

--- a/tests/lib/editor/shadow-css.test.ts
+++ b/tests/lib/editor/shadow-css.test.ts
@@ -113,3 +113,42 @@ describe("webkit export paths", () => {
     }
   })
 })
+
+describe("chained drop-shadow extent", () => {
+  it("reserves margin for the layer that reaches furthest, not the first", () => {
+    // Chained drop-shadows are space-separated, so reading four lengths off the
+    // whole chain mixed layer 1's offsets with layer 2's and under-reserved.
+    const el = document.createElement("div")
+    el.style.filter =
+      "drop-shadow(-4px 4px 6px rgba(0, 0, 0, 0.7)) " +
+      "drop-shadow(-10px 10px 29px rgba(0, 0, 0, 0.4))"
+    expect(shadowExtentPx(el)).toBe(49)
+  })
+
+  it("still measures the widest box-shadow layer", () => {
+    const el = document.createElement("div")
+    el.style.boxShadow =
+      "-18px 18px 2px 0px rgba(0, 0, 0, 0.62), -54px 54px 2px 0px rgba(0, 0, 0, 0.22)"
+    expect(shadowExtentPx(el)).toBe(110)
+  })
+})
+
+describe("negative spread in the drop-shadow conversion", () => {
+  it("shrinks the blur by the inset instead of discarding it", () => {
+    // Contact at 60%: near blur 7.2 inset 1.8, far blur 22.8 inset 5.4 — each
+    // covers blur-minus-inset past the box edge, which is what the filter has
+    // to reproduce. Discarding the inset exported both layers too wide.
+    const filter = shadowDropFilterCss(shadow({ type: "contact" }))!
+    const blurs = Array.from(
+      filter.matchAll(/drop-shadow\(\S+ \S+ ([\d.]+)px/g),
+      (m) => parseFloat(m[1])
+    )
+    expect(blurs).toEqual([5.4, 17.4])
+  })
+
+  it("keeps the historic 2x fold for positive spread", () => {
+    // glow and soft rely on it — only the negative branch changed.
+    const glow = shadow({ type: "glow", intensity: 100, lightSource: "center" })
+    expect(shadowDropFilterCss(glow)!).toContain("136px")
+  })
+})

--- a/tests/lib/editor/shadow-css.test.ts
+++ b/tests/lib/editor/shadow-css.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 
-import { shadowCss, shadowDropFilterCss } from "@/lib/editor/css-utils"
+import {
+  boxShadowToDropFilterCss,
+  shadowCss,
+  shadowDropFilterCss,
+} from "@/lib/editor/css-utils"
 import { shadowBetween } from "@/lib/editor/animation-playback"
 import { shadowExtentPx } from "@/lib/editor/animation-export/video-media/frame-canvas-utils"
 import type { Shadow, ShadowType } from "@/lib/editor/state-types"
@@ -150,5 +154,29 @@ describe("negative spread in the drop-shadow conversion", () => {
     // glow and soft rely on it — only the negative branch changed.
     const glow = shadow({ type: "glow", intensity: 100, lightSource: "center" })
     expect(shadowDropFilterCss(glow)!).toContain("136px")
+  })
+})
+
+describe("converting a computed box-shadow", () => {
+  it("reads a colour-first computed value, not just authored order", () => {
+    // getComputedStyle emits the colour FIRST; the authored form puts it last.
+    const computed = "rgba(95, 137, 122, 0.247) 7.2px 7.2px 0.8px 0px"
+    expect(boxShadowToDropFilterCss(computed)).toBe(
+      "drop-shadow(7.2px 7.2px 0.8px rgba(95, 137, 122, 0.247))"
+    )
+  })
+
+  it("round-trips the authored order too", () => {
+    const authored = "7.2px 7.2px 0.8px 0px rgba(95, 137, 122, 0.247)"
+    expect(boxShadowToDropFilterCss(authored)).toBe(
+      boxShadowToDropFilterCss(
+        "rgba(95, 137, 122, 0.247) 7.2px 7.2px 0.8px 0px"
+      )
+    )
+  })
+
+  it("returns nothing for an absent shadow", () => {
+    expect(boxShadowToDropFilterCss("none")).toBeUndefined()
+    expect(boxShadowToDropFilterCss("")).toBeUndefined()
   })
 })

--- a/tests/lib/editor/shadow-css.test.ts
+++ b/tests/lib/editor/shadow-css.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest"
+
+import { shadowCss, shadowDropFilterCss } from "@/lib/editor/css-utils"
+import { shadowBetween } from "@/lib/editor/animation-playback"
+import { shadowExtentPx } from "@/lib/editor/animation-export/video-media/frame-canvas-utils"
+import type { Shadow, ShadowType } from "@/lib/editor/state-types"
+
+const splitLayers = (css: string): string[] =>
+  css.split("), ").map((l) => (l.endsWith(")") ? l : `${l})`))
+
+const alphaOf = (layer: string): number =>
+  parseFloat(layer.match(/([\d.]+)\)$/)![1])
+
+const shadow = (patch: Partial<Shadow> = {}): Shadow => ({
+  type: "contact",
+  intensity: 60,
+  lightSource: "0-4",
+  color: "#000000",
+  ...patch,
+})
+
+describe("shadowCss for contact and stack", () => {
+  it("casts contact away from the light source in two layers", () => {
+    const css = shadowCss(shadow())!
+    expect(css.split("), ").length).toBe(2)
+    // Light at the top-right corner throws the cast down and to the left.
+    expect(css.startsWith("-")).toBe(true)
+    expect(css).toContain("rgba(0, 0, 0,")
+  })
+
+  it("steps stack through three offsets of fading opacity", () => {
+    const layers = splitLayers(shadowCss(shadow({ type: "stack" }))!)
+    expect(layers).toHaveLength(3)
+    const alphas = layers.map(alphaOf)
+    expect(alphas[0]).toBeGreaterThan(alphas[1])
+    expect(alphas[1]).toBeGreaterThan(alphas[2])
+  })
+
+  it("collapses contact and stack to nothing as intensity approaches zero", () => {
+    for (const type of ["contact", "stack"] as ShadowType[]) {
+      for (const layer of splitLayers(
+        shadowCss(shadow({ type, intensity: 1 }))!
+      )) {
+        expect(alphaOf(layer)).toBeLessThan(0.01)
+        for (const length of layer.match(/-?[\d.]+px/g)!) {
+          expect(Math.abs(parseFloat(length))).toBeLessThan(1)
+        }
+      }
+    }
+  })
+
+  it("renders nothing at zero intensity", () => {
+    for (const type of ["contact", "stack"] as ShadowType[]) {
+      expect(shadowCss(shadow({ type, intensity: 0 }))).toBeUndefined()
+    }
+  })
+
+  it("converts to drop-shadow filters for framed screenshots", () => {
+    for (const type of ["contact", "stack"] as ShadowType[]) {
+      const filter = shadowDropFilterCss(shadow({ type }))!
+      expect(filter).toMatch(/^drop-shadow\(/)
+      expect(filter).not.toContain("NaN")
+    }
+  })
+})
+
+describe("animating contact and stack", () => {
+  it("renders the fractional light source shadowBetween produces", () => {
+    for (const type of ["contact", "stack"] as ShadowType[]) {
+      const from = shadow({ type, intensity: 0, lightSource: "0-4" })
+      const to = shadow({ type, intensity: 80, lightSource: "4-0" })
+      const mid = shadowBetween(from, to, 0.5)
+      expect(mid.lightSource).toBe("2-2")
+      const css = shadowCss(mid)!
+      expect(css).not.toContain("NaN")
+      // Mid-travel the light is dead centre, so the cast has no offset.
+      expect(css.startsWith("0.0px 0.0px")).toBe(true)
+    }
+  })
+
+  it("grows from nothing as a first shadow keyframe reveals", () => {
+    for (const type of ["contact", "stack"] as ShadowType[]) {
+      const rest = shadow({ type: "none", intensity: 40 })
+      const to = shadow({ type, intensity: 100 })
+      expect(shadowCss(shadowBetween(rest, to, 0))).toBeUndefined()
+      expect(shadowCss(shadowBetween(rest, to, 1))).toBe(shadowCss(to))
+    }
+  })
+})
+
+describe("webkit export paths", () => {
+  it("chains one drop-shadow per box-shadow layer, as the framed path needs", () => {
+    for (const type of ["contact", "stack"] as ShadowType[]) {
+      const s = shadow({ type, intensity: 100 })
+      const layers = splitLayers(shadowCss(s)!).length
+      const filter = shadowDropFilterCss(s)!
+      expect(filter.match(/drop-shadow\(/g)).toHaveLength(layers)
+      // Negative spread has no drop-shadow equivalent and must not leak through
+      // as a fourth length, which WebKit would drop the whole filter over.
+      for (const fn of filter.match(/drop-shadow\([^)]*\)[^)]*\)/g) ?? []) {
+        expect(fn.match(/px/g)).toHaveLength(3)
+      }
+    }
+  })
+
+  it("reserves texture margin for every layer of the new shadows", () => {
+    for (const type of ["contact", "stack"] as ShadowType[]) {
+      const el = document.createElement("div")
+      el.style.boxShadow = shadowCss(shadow({ type, intensity: 100 }))!
+      const extent = shadowExtentPx(el)
+      expect(extent).toBeGreaterThan(0)
+      expect(Number.isFinite(extent)).toBe(true)
+    }
+  })
+})

--- a/wiki/core/styling-canvas.md
+++ b/wiki/core/styling-canvas.md
@@ -132,7 +132,7 @@ Edit-time progressive load: [canvas.md](./canvas.md).
 
 | Effect | Types / modes | CSS |
 |---|---|---|
-| Shadow | none, drop, soft, hard, glow, float, linear | `shadowCss` |
+| Shadow | none, drop, soft, hard, glow, float, linear, contact, stack | `shadowCss` |
 | Portrait DoF | off, soft, studio, spot, frame, iris, blur, stage | canvas + export polyfill |
 | Enhance | off, auto, vivid, soft, dramatic, sharp | `enhanceFilterCss` |
 | Overlay | texture id + opacity + overlay/underlay | CSS background-image |


### PR DESCRIPTION
## Shadow presets

Two new types in `ShadowType`, bringing the picker to eight:

- **Contact** — a tight grounded cast, two layers with negative spread so it reads as the object touching the surface
- **Stack** — three stepped offsets of fading opacity, a paper-stack look

Both size **every** dimension off intensity — offset, blur and alpha reach 0 together — so an animated reveal grows out of nothing and the release mirrors it. The first cut floored these (`step = 2 + …`, `opacity = 0.3 + …`), which made a clip pop in already three-layers-deep and vanish mid-stack on the way out.

Stack carries 2px of blur at full intensity. A zero-blur edge snaps to whole pixels, so a stack sliding one fractional step per frame visibly stutters; 2px is invisible at rest and enough to keep the travel continuous.

Also extracted the light-source offset block that was copy-pasted into four `shadowCss` branches into `shadowLightOffset`.

## Animate + WebKit

No wiring needed — clips carry the whole `Shadow` object and `shadowBetween` interpolates intensity plus a *fractional* `"r-c"` light source, which both new branches parse. The WebKit export path handles shadows generically and both types satisfy it:

- **Shell-texture cache** (`webkit-layered-frame.ts:133`) keys on the inline `cssText` of the shadow preview scope, which is where `apply-animation-frame.ts:764` writes the sampled shadow — so a per-frame change invalidates the texture instead of freezing it.
- **Texture margin** (`shadowExtentPx`) parses all three Stack layers; worst case is 110px against Linear's existing 338px.
- **Framed screenshots** convert to chained `drop-shadow()`. Contact's negative spread is folded into blur — a leaked fourth length makes WebKit drop the whole filter, so there's a test asserting exactly three `px` values per function.

Not yet run in Safari; the framed-screenshot-plus-video path is the one worth eyeballing.

## Border colours

Blueberry `#7c9cf0` and honey `#f3c969`; grid goes 6 → 8 tiles. The dynamic fill now skips colours already sampled from the image, so the grid no longer renders fewer tiles than its slots when a sampled colour happened to match a preset.

## Tests

New `tests/lib/editor/shadow-css.test.ts` covers the fractional light source, grow-from-nothing reveal, zero-collapse, the drop-shadow conversion, and the texture margin. 1566 passing, typecheck and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Contact and Stack shadow types with light and dark previews.
  * Added Blueberry and Honey border color presets.
  * Increased available border color preset slots from six to eight.

* **Bug Fixes**
  * Improved shadow color transitions during animations for smoother recoloring and reveal effects.

* **Documentation**
  * Updated feature descriptions and styling documentation to reflect the eight available shadow types.

* **Tests**
  * Added coverage for new shadow rendering, animation, export, and intensity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Contact and Stack shadow presets, expands the border palette to eight colors, and updates animation and WebKit export handling for layered shadows.
- Seeds Stack with a diagonal light direction when selected from a centered state.
- Preserves negative-spread shadow appearance during drop-shadow conversion.
- Measures each chained drop-shadow independently when allocating export margins.
- Smoothly interpolates same-type shadow colors and protects empty shadow filter chains.
- Adds WebKit export handling and retry protection for frameless shadows and ASCII layers.
- Extends focused tests and user-facing documentation for the new presets.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; both previous findings are manually resolved and the current code addresses their reported behavior without introducing an actionable regression.

The Stack selector now seeds a diagonal direction only when the current light source has no direction, and Contact export now folds negative spread into blur while measuring every filter layer independently. Both previous threads were manually resolved without explanation, and no new blocking or non-blocking issue remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/editor/css-utils.ts | Adds Contact and Stack CSS generation and improves box-shadow-to-drop-shadow conversion, including negative spread and computed color ordering. |
| components/editor/inspector/shadow-section.tsx | Adds the two shadow picker entries and seeds Stack with a usable direction when the current light source is centered. |
| lib/editor/animation-playback.ts | Interpolates colors for same-type visible shadows while preserving reveal and retraction colors. |
| lib/editor/animation-export/video-media/frame-canvas-utils.ts | Measures chained drop-shadow layers independently to avoid under-reserving texture margins. |
| lib/editor/export-shadow-filter.ts | Redirects frameless WebKit export shadows from box-shadow into the existing filter chain. |
| lib/editor/export-animation-capture.ts | Retries blank WebKit ASCII rasters and retains the original glyph DOM if flattening never succeeds. |
| components/editor/inspector/border-section.tsx | Expands the preset grid to eight unique colors while avoiding duplicates with sampled image colors. |

</details>

<sub>Reviews (2): Last reviewed commit: ["render a frameless screenshot&#39;s shadow a..."](https://github.com/shivabhattacharjee/tokokino/commit/0997dd0aea0945441e5abffdaef9b00f2313e887) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60786643)</sub>

<!-- /greptile_comment -->