### PR TITLE
Personal access tokens for API authentication

### DIFF
--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -5,7 +5,7 @@ import {
   requestAccountDeletion,
   retryPendingAccountCleanups,
 } from "@/lib/account-management"
-import { requireSession } from "@/lib/api-auth"
+import { requireBrowserSession } from "@/lib/api-auth"
 import { getAuth } from "@/lib/auth"
 import { getD1Database } from "@/lib/d1"
 import { enforceRateLimit } from "@/lib/rate-limit"
@@ -55,7 +55,7 @@ function deviceName(userAgent: string | null | undefined) {
 }
 
 export async function GET(request: Request) {
-  const auth = await requireSession(request)
+  const auth = await requireBrowserSession(request)
   if (!auth.ok) return auth.response
   const current = auth.session
 
@@ -108,7 +108,7 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
-  const auth = await requireSession(request)
+  const auth = await requireBrowserSession(request)
   if (!auth.ok) return auth.response
   const current = auth.session
 
@@ -152,7 +152,7 @@ export async function POST(request: Request) {
 }
 
 export async function DELETE(request: Request) {
-  const auth = await requireSession(request)
+  const auth = await requireBrowserSession(request)
   if (!auth.ok) return auth.response
   const current = auth.session
 

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 import { z } from "zod/v4"
 
-import { getAuth } from "@/lib/auth"
+import { resolveApiSession } from "@/lib/api-auth"
 import { env } from "@/lib/env"
 import { enforceRateLimit, getClientIp } from "@/lib/rate-limit"
 
@@ -57,7 +57,7 @@ export async function POST(request: Request) {
   // Attach the signed-in user's identity when available (best effort).
   let user: { name?: string | null; email?: string | null } | null = null
   try {
-    const session = await getAuth().api.getSession({ headers: request.headers })
+    const session = await resolveApiSession(request)
     if (session) user = { name: session.user.name, email: session.user.email }
   } catch {
     // Auth not configured or no session — feedback stays anonymous.

--- a/app/api/share/[id]/route.ts
+++ b/app/api/share/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-import { getAuth } from "@/lib/auth"
+import { resolveApiSession } from "@/lib/api-auth"
 import { deleteShareRecord } from "@/lib/share-db"
 import { isValidShareId } from "@/lib/share"
 import { deleteShareImage } from "@/lib/share-storage"
@@ -11,8 +11,7 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const auth = getAuth()
-  const session = await auth.api.getSession({ headers: request.headers })
+  const session = await resolveApiSession(request)
   if (!session) {
     return NextResponse.json({ error: "Sign in required" }, { status: 401 })
   }

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import { NextResponse } from "next/server"
 
 import { captureServerEvent } from "@/lib/posthog-server"
-import { getAuth } from "@/lib/auth"
+import { resolveApiSession } from "@/lib/api-auth"
 import {
   createShareRecord,
   deleteAllUserShares,
@@ -32,8 +32,7 @@ import {
 export const runtime = "nodejs"
 
 export async function GET(request: Request) {
-  const auth = getAuth()
-  const session = await auth.api.getSession({ headers: request.headers })
+  const session = await resolveApiSession(request)
   if (!session) {
     return NextResponse.json({ error: "Sign in required" }, { status: 401 })
   }
@@ -62,8 +61,7 @@ export async function GET(request: Request) {
 }
 
 export async function DELETE(request: Request) {
-  const auth = getAuth()
-  const session = await auth.api.getSession({ headers: request.headers })
+  const session = await resolveApiSession(request)
   if (!session) {
     return NextResponse.json({ error: "Sign in required" }, { status: 401 })
   }
@@ -90,10 +88,7 @@ export async function DELETE(request: Request) {
 }
 
 export async function POST(request: Request) {
-  const auth = getAuth()
-  const session = await auth.api.getSession({
-    headers: request.headers,
-  })
+  const session = await resolveApiSession(request)
 
   if (!session) {
     return NextResponse.json({ error: "Sign in required" }, { status: 401 })

--- a/app/api/tokens/[id]/route.ts
+++ b/app/api/tokens/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server"
+
+import { requireSession } from "@/lib/api-auth"
+import { deletePersonalAccessToken } from "@/lib/personal-access-tokens"
+import { enforceRateLimit } from "@/lib/rate-limit"
+
+export const runtime = "nodejs"
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await requireSession(request)
+  if (!auth.ok) return auth.response
+
+  const limited = await enforceRateLimit({
+    limiter: "WRITE_RATE_LIMITER",
+    scope: "pat-revoke",
+    id: auth.session.user.id,
+  })
+  if (limited) return limited
+
+  const { id } = await params
+  if (!id || typeof id !== "string") {
+    return NextResponse.json({ error: "Invalid token id" }, { status: 400 })
+  }
+
+  const deleted = await deletePersonalAccessToken(id, auth.session.user.id)
+  if (!deleted) {
+    // 404 either way so token ids can't be probed across accounts.
+    return NextResponse.json({ error: "Token not found" }, { status: 404 })
+  }
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/tokens/route.ts
+++ b/app/api/tokens/route.ts
@@ -94,9 +94,15 @@ export async function POST(request: Request) {
   // only the overflowed requests fail.
   const active = await countActivePersonalAccessTokens(auth.session.user.id)
   if (active > MAX_TOKENS_PER_USER) {
-    await deletePersonalAccessToken(record.id, auth.session.user.id).catch(
-      () => {}
-    )
+    try {
+      await deletePersonalAccessToken(record.id, auth.session.user.id)
+    } catch (rollbackError) {
+      console.error("Could not roll back overflow token", rollbackError)
+      return NextResponse.json(
+        { error: "Could not create token. Please try again." },
+        { status: 500 }
+      )
+    }
     return NextResponse.json(
       {
         error: `Token limit reached (${MAX_TOKENS_PER_USER}). Revoke an unused token first.`,

--- a/app/api/tokens/route.ts
+++ b/app/api/tokens/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server"
+import { z } from "zod/v4"
+
+import { requireSession } from "@/lib/api-auth"
+import {
+  countPersonalAccessTokens,
+  createPersonalAccessTokenRecord,
+  generatePersonalAccessToken,
+  hashPersonalAccessToken,
+  listPersonalAccessTokens,
+  MAX_TOKENS_PER_USER,
+  patNameSchema,
+  tokenPrefixDisplay,
+} from "@/lib/personal-access-tokens"
+import { enforceRateLimit } from "@/lib/rate-limit"
+
+export const runtime = "nodejs"
+
+const createTokenSchema = z.object({
+  name: patNameSchema,
+  /** Optional expiry as an ISO-8601 timestamp. Must be in the future. */
+  expiresAt: z.iso.datetime().nullable().optional(),
+})
+
+export async function GET(request: Request) {
+  const auth = await requireSession(request)
+  if (!auth.ok) return auth.response
+
+  const tokens = await listPersonalAccessTokens(auth.session.user.id)
+  return NextResponse.json({ tokens })
+}
+
+export async function POST(request: Request) {
+  const auth = await requireSession(request)
+  if (!auth.ok) return auth.response
+
+  const limited = await enforceRateLimit({
+    limiter: "WRITE_RATE_LIMITER",
+    scope: "pat-create",
+    id: auth.session.user.id,
+  })
+  if (limited) return limited
+
+  const parsed = createTokenSchema.safeParse(
+    await request.json().catch(() => null)
+  )
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Invalid token request",
+        detail: parsed.error.issues[0]?.message ?? "Invalid body",
+      },
+      { status: 400 }
+    )
+  }
+
+  const existing = await countPersonalAccessTokens(auth.session.user.id)
+  if (existing >= MAX_TOKENS_PER_USER) {
+    return NextResponse.json(
+      {
+        error: `Token limit reached (${MAX_TOKENS_PER_USER}). Revoke an unused token first.`,
+      },
+      { status: 409 }
+    )
+  }
+
+  let expiresAt: string | null = null
+  if (parsed.data.expiresAt) {
+    const time = new Date(parsed.data.expiresAt).getTime()
+    if (!Number.isFinite(time) || time <= Date.now()) {
+      return NextResponse.json(
+        { error: "Expiry must be a future date" },
+        { status: 400 }
+      )
+    }
+    expiresAt = new Date(time).toISOString()
+  }
+
+  const token = generatePersonalAccessToken()
+  const record = await createPersonalAccessTokenRecord({
+    id: crypto.randomUUID(),
+    userId: auth.session.user.id,
+    name: parsed.data.name,
+    tokenHash: hashPersonalAccessToken(token),
+    prefix: tokenPrefixDisplay(token),
+    expiresAt,
+  })
+
+  // The plaintext token is returned exactly once — it is stored only as a
+  // SHA-256 hash and can never be read back.
+  return NextResponse.json({ token, ...record })
+}

--- a/app/api/tokens/route.ts
+++ b/app/api/tokens/route.ts
@@ -3,8 +3,9 @@ import { z } from "zod/v4"
 
 import { requireSession } from "@/lib/api-auth"
 import {
-  countPersonalAccessTokens,
+  countActivePersonalAccessTokens,
   createPersonalAccessTokenRecord,
+  deletePersonalAccessToken,
   generatePersonalAccessToken,
   hashPersonalAccessToken,
   listPersonalAccessTokens,
@@ -54,7 +55,7 @@ export async function POST(request: Request) {
     )
   }
 
-  const existing = await countPersonalAccessTokens(auth.session.user.id)
+  const existing = await countActivePersonalAccessTokens(auth.session.user.id)
   if (existing >= MAX_TOKENS_PER_USER) {
     return NextResponse.json(
       {
@@ -85,6 +86,24 @@ export async function POST(request: Request) {
     prefix: tokenPrefixDisplay(token),
     expiresAt,
   })
+
+  // The pre-insert count can race with concurrent creations (D1 offers no
+  // serializable transaction here), so verify the cap after inserting and
+  // roll our own row back when we overflowed. Every concurrent creator does
+  // the same check, so the account converges back at or under the cap while
+  // only the overflowed requests fail.
+  const active = await countActivePersonalAccessTokens(auth.session.user.id)
+  if (active > MAX_TOKENS_PER_USER) {
+    await deletePersonalAccessToken(record.id, auth.session.user.id).catch(
+      () => {}
+    )
+    return NextResponse.json(
+      {
+        error: `Token limit reached (${MAX_TOKENS_PER_USER}). Revoke an unused token first.`,
+      },
+      { status: 409 }
+    )
+  }
 
   // The plaintext token is returned exactly once — it is stored only as a
   // SHA-256 hash and can never be read back.

--- a/app/auth.md/route.ts
+++ b/app/auth.md/route.ts
@@ -2,16 +2,41 @@ const SITE_URL = "https://tokokino.com"
 
 const CONTENT = `# auth.md
 
-Tokokino is a browser-based screenshot beautifier. Protected APIs require an authenticated session obtained via email/password or Google OAuth through [better-auth](https://www.better-auth.com/).
+Tokokino is a browser-based screenshot beautifier. Protected APIs accept a personal access token or an authenticated session obtained via email/password or Google OAuth through [better-auth](https://www.better-auth.com/).
 
 ## Discovery
 
 - OAuth Authorization Server: ${SITE_URL}/.well-known/oauth-authorization-server
 - OAuth Protected Resource: ${SITE_URL}/.well-known/oauth-protected-resource
 
-## Registration
+## Personal access tokens (recommended for scripts, CI, and agents)
 
-Agents authenticate by signing in through the email/password endpoint:
+Generate a token in the editor under Settings → Developer. The plaintext token is shown exactly once — store it somewhere safe, because it is kept only as a SHA-256 hash afterwards. Tokens act as your account, optionally expire, and can be revoked at any time.
+
+Send the token as a bearer token in the \`Authorization\` header:
+
+\`\`\`
+Authorization: Bearer tk_<your-personal-access-token>
+\`\`\`
+
+Example:
+
+\`\`\`
+curl -X POST ${SITE_URL}/api/share \\
+  -H "Content-Type: image/png" \\
+  -H "Authorization: Bearer tk_<your-personal-access-token>" \\
+  --data-binary @screenshot.png
+\`\`\`
+
+Manage tokens programmatically (these endpoints accept a token or a session):
+
+- \`GET /api/tokens\` — list tokens (plaintext is never returned again)
+- \`POST /api/tokens\` — generate a token: \`{ "name": "CI upload script", "expiresAt": "2026-12-31T00:00:00.000Z" }\` (\`expiresAt\` is optional)
+- \`DELETE /api/tokens/{id}\` — revoke a token immediately
+
+## Session cookies (browser callers)
+
+Agents driving a real browser session can sign in through the email/password endpoint instead:
 
 \`\`\`
 POST ${SITE_URL}/api/auth/sign-in/email
@@ -20,11 +45,7 @@ Content-Type: application/json
 { "email": "...", "password": "..." }
 \`\`\`
 
-The response sets a session cookie used for all subsequent API calls.
-
-## Credential Usage
-
-Include the session cookie returned from sign-in in all requests to protected endpoints, or pass it as a bearer token in the \`Authorization\` header:
+The response sets a session cookie used for all subsequent API calls. A better-auth session token also works as a bearer token in the \`Authorization\` header:
 
 \`\`\`
 Authorization: Bearer <session-token>
@@ -34,6 +55,7 @@ Protected endpoints:
 - \`/api/share\` — create and manage share links
 - \`/api/drafts\` — save and retrieve editor drafts
 - \`/api/presets\` — manage custom presets
+- \`/api/tokens\` — manage personal access tokens
 
 ## Session Lifecycle
 

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -61,6 +61,10 @@ const releases: Release[] = [
         title: "Timeline polish",
         text: "Lighter selection outlines, no boxed-in track border, and clips no longer clip at the edges of the timeline.",
       },
+      {
+        title: "Personal access tokens for the API",
+        text: "Generate a token in Settings under Developer and send it as an Authorization Bearer header to call the API from scripts, CI, or agents, with no session cookie to paste. Tokens act as your account, can carry an expiry, and can be revoked at any time. Every documented endpoint accepts them.",
+      },
     ],
   },
   {

--- a/app/developers/page.tsx
+++ b/app/developers/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
   title:
     "Tokokino Developer Portal — API docs, OpenAPI spec, and agent resources",
   description:
-    "Developer documentation for the Tokokino API: OpenAPI specification, session authentication, share and draft endpoints, JSON error codes, and the Tokokino agent resources.",
+    "Developer documentation for the Tokokino API: OpenAPI specification, personal access token and session authentication, share and draft endpoints, JSON error codes, and the Tokokino agent resources.",
   alternates: { canonical: "/developers" },
 }
 
@@ -58,6 +58,14 @@ const ENDPOINTS = [
     ],
   },
   {
+    group: "Tokens",
+    rows: [
+      ["GET", "/api/tokens", "List your personal access tokens"],
+      ["POST", "/api/tokens", "Generate a new personal access token"],
+      ["DELETE", "/api/tokens/{id}", "Revoke a personal access token"],
+    ],
+  },
+  {
     group: "Media",
     rows: [
       ["POST", "/api/screenshot", "Capture a screenshot of a public URL"],
@@ -69,7 +77,7 @@ const ENDPOINTS = [
 ]
 
 const ERROR_CODES = [
-  ["unauthorized", "401", "No valid session cookie was sent."],
+  ["unauthorized", "401", "No valid token or session cookie was sent."],
   ["forbidden", "403", "The account may not perform this action."],
   ["not_found", "404", "No such path, or the resource is not yours."],
   ["invalid_request", "400", "Body or query parameters failed validation."],
@@ -88,7 +96,7 @@ const RESOURCES = [
   {
     href: "/auth.md",
     label: "Authentication guide",
-    note: "How to obtain and send a Tokokino session cookie.",
+    note: "How to generate a personal access token and send it with requests.",
   },
   {
     href: "/llms.txt",
@@ -119,14 +127,14 @@ const RESOURCES = [
 
 const CURL = `curl -X POST https://tokokino.com/api/share \\
   -H "Content-Type: image/png" \\
-  -H "Cookie: better-auth.session_token=<your-session-token>" \\
+  -H "Authorization: Bearer tk_<your-personal-access-token>" \\
   --data-binary @screenshot.png`
 
 const ERROR_SAMPLE = `{
   "error": "Sign in required",
   "code": "unauthorized",
   "message": "Sign in required",
-  "hint": "Sign in at https://tokokino.com/login and send the session cookie with the request. See https://tokokino.com/auth.md.",
+  "hint": "Generate a personal access token in Settings → Developer and send it as an Authorization: Bearer header, or sign in at https://tokokino.com/login and send the session cookie. See https://tokokino.com/auth.md.",
   "docs": "https://tokokino.com/developers#errors"
 }`
 
@@ -167,7 +175,7 @@ export default function DevelopersPage() {
     <DocPage
       eyebrow="Developers"
       title="Tokokino developer portal"
-      summary="Build against the Tokokino API. Everything below is served at a stable URL: an OpenAPI 3.1 specification, session authentication, structured JSON errors, and the agent-facing manifests that describe this site to automated clients."
+      summary="Build against the Tokokino API. Everything below is served at a stable URL: an OpenAPI 3.1 specification, personal access token authentication, structured JSON errors, and the agent-facing manifests that describe this site to automated clients."
       index={<DocIndex items={INDEX} />}
     >
       <article className="flex max-w-3xl flex-col gap-8">
@@ -179,7 +187,8 @@ export default function DevelopersPage() {
             preferences, and a few media proxies.
           </p>
           <p className="mt-4">
-            Create a share by POSTing raw image bytes with a session cookie:
+            Create a share by POSTing raw image bytes with a personal access
+            token:
           </p>
           <Code>{CURL}</Code>
           <p className="mt-4">
@@ -195,10 +204,19 @@ export default function DevelopersPage() {
 
         <Section id="authentication" title="Authentication">
           <p>
-            Tokokino uses{" "}
+            Generate a personal access token in the editor under Settings →
+            Developer, then send it as an{" "}
+            <span className="font-mono text-[12px]">
+              Authorization: Bearer tk_…
+            </span>{" "}
+            header with each request. Tokens act as your account, can be given
+            an optional expiry, and can be revoked at any time — treat them like
+            passwords.
+          </p>
+          <p className="mt-4">
+            Browser-based callers can also use a{" "}
             <span className="font-mono text-[12px]">better-auth</span> session
-            cookies — email and password, or Google OAuth. There are no API
-            keys. Sign in at{" "}
+            cookie — email and password, or Google OAuth. Sign in at{" "}
             <Link href="/login" className={linkClass}>
               /login
             </Link>{" "}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -40,11 +40,11 @@ Last updated: ${UPDATED_AT}
 
 - [Tokokino developer portal](${SITE_URL}/developers): API quickstart, authentication, endpoint reference, error codes, limits, and agent resources.
 - [Tokokino OpenAPI specification](${SITE_URL}/openapi.json): OpenAPI 3.1 contract for every documented endpoint, also served at ${SITE_URL}/api/openapi.json.
-- [Tokokino authentication guide](${SITE_URL}/auth.md): How to obtain and send a better-auth session cookie.
+- [Tokokino authentication guide](${SITE_URL}/auth.md): How to generate a personal access token and send it with API requests.
 - [Tokokino agent skills](${SITE_URL}/.well-known/agent-skills/index.json): Skill documents for the share, drafts, and presets workflows.
 - [Tokokino MCP server card](${SITE_URL}/.well-known/mcp/server-card.json): Model Context Protocol descriptor. The MCP server is not live yet — ${SITE_URL}/mcp answers 503 with a coming-soon payload until it ships.
 
-Tokokino has no API keys. Authentication is a better-auth session cookie obtained at ${SITE_URL}/login. Every API error is JSON carrying a machine-readable code, a message, and a resolution hint; unmatched /api/* paths return a JSON 404 rather than an HTML page.
+Authenticate API calls with a personal access token generated in Settings → Developer, sent as an Authorization: Bearer header (a better-auth session cookie from ${SITE_URL}/login also works). Every API error is JSON carrying a machine-readable code, a message, and a resolution hint; unmatched /api/* paths return a JSON 404 rather than an HTML page.
 
 ## Trust and project information
 

--- a/components/editor/effects-sidebar.tsx
+++ b/components/editor/effects-sidebar.tsx
@@ -354,14 +354,14 @@ export function AccountTile() {
           <Link
             href="/app/shares"
             onClick={() => setExpanded(false)}
-            className="flex h-7 w-full touch-manipulation items-center gap-2.5 rounded-md px-2 text-xs font-medium text-foreground transition-colors outline-none [-webkit-tap-highlight-color:transparent] hover:bg-secondary/60 focus:ring-0 focus-visible:ring-0 sm:focus-visible:ring-2 sm:focus-visible:ring-primary/30"
+            className="flex h-7 w-full touch-manipulation items-center gap-2.5 rounded-md px-2 text-xs font-medium text-foreground transition-colors outline-none [-webkit-tap-highlight-color:transparent] hover:bg-accent focus:ring-0 focus-visible:ring-0 sm:focus-visible:ring-2 sm:focus-visible:ring-primary/30"
           >
             <RiGalleryLine className="size-4 shrink-0 text-muted-foreground" />
             My Shares
           </Link>
           <button
             type="button"
-            className="flex h-7 w-full touch-manipulation items-center gap-2.5 rounded-md px-2 text-xs font-medium text-foreground transition-colors outline-none [-webkit-tap-highlight-color:transparent] hover:bg-secondary/60 focus:ring-0 focus-visible:ring-0 sm:focus-visible:ring-2 sm:focus-visible:ring-primary/30"
+            className="flex h-7 w-full touch-manipulation items-center gap-2.5 rounded-md px-2 text-xs font-medium text-foreground transition-colors outline-none [-webkit-tap-highlight-color:transparent] hover:bg-accent focus:ring-0 focus-visible:ring-0 sm:focus-visible:ring-2 sm:focus-visible:ring-primary/30"
             onClick={() => {
               setExpanded(false)
               setStorageOpen(true)
@@ -372,7 +372,7 @@ export function AccountTile() {
           </button>
           <button
             type="button"
-            className="flex h-7 w-full touch-manipulation items-center gap-2.5 rounded-md px-2 text-xs font-medium text-foreground transition-colors outline-none [-webkit-tap-highlight-color:transparent] hover:bg-secondary/60 focus:ring-0 focus-visible:ring-0 sm:focus-visible:ring-2 sm:focus-visible:ring-primary/30"
+            className="flex h-7 w-full touch-manipulation items-center gap-2.5 rounded-md px-2 text-xs font-medium text-foreground transition-colors outline-none [-webkit-tap-highlight-color:transparent] hover:bg-accent focus:ring-0 focus-visible:ring-0 sm:focus-visible:ring-2 sm:focus-visible:ring-primary/30"
             onClick={() => {
               setExpanded(false)
               setSettingsOpen(true)

--- a/components/editor/settings/settings-dialog.tsx
+++ b/components/editor/settings/settings-dialog.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import {
   RiCheckLine,
   RiCloseLine,
+  RiCodeLine,
   RiComputerLine,
   RiDeleteBinLine,
   RiEyeLine,
@@ -20,6 +21,7 @@ import {
   RiFunctionLine,
   RiImageLine,
   RiKeyboardLine,
+  RiKeyLine,
   RiUserLine,
   RiUserSettingsLine,
 } from "@remixicon/react"
@@ -28,6 +30,16 @@ import { toast } from "sonner"
 
 import { AccountAvatar } from "@/components/editor/account-avatar"
 import { Button } from "@/components/ui/button"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import {
   Dialog,
   DialogClose,
@@ -59,7 +71,12 @@ import {
   SHORTCUT_GROUPS,
 } from "@/lib/editor/shortcuts"
 
-type SettingsSection = "profile" | "account" | "export" | "shortcuts"
+type SettingsSection =
+  | "profile"
+  | "account"
+  | "developer"
+  | "export"
+  | "shortcuts"
 
 const NAV_ITEMS: {
   id: SettingsSection
@@ -68,6 +85,7 @@ const NAV_ITEMS: {
 }[] = [
   { id: "profile", label: "Profile", icon: RiUserLine },
   { id: "account", label: "Account", icon: RiUserSettingsLine },
+  { id: "developer", label: "Developer", icon: RiCodeLine },
   { id: "export", label: "Export", icon: RiImageLine },
   { id: "shortcuts", label: "Shortcuts", icon: RiKeyboardLine },
 ]
@@ -89,7 +107,8 @@ export function SettingsDialog({
       >
         <DialogTitle className="sr-only">Settings</DialogTitle>
         <DialogDescription className="sr-only">
-          Manage your profile, export format, and view keyboard shortcuts.
+          Manage your profile, API tokens, export format, and view keyboard
+          shortcuts.
         </DialogDescription>
 
         <DialogClose asChild>
@@ -153,6 +172,7 @@ export function SettingsDialog({
           <div className="min-w-0 flex-1 [scrollbar-width:none] overflow-y-auto bg-background px-4 py-5 sm:px-8 sm:py-7 [&::-webkit-scrollbar]:hidden">
             {section === "profile" && <ProfileSection />}
             {section === "account" && <AccountSection />}
+            {section === "developer" && <DeveloperSection />}
             {section === "export" && <ExportSection />}
             {section === "shortcuts" && <ShortcutsSection />}
           </div>
@@ -801,6 +821,425 @@ function AccountSection() {
           </div>
         </DialogContent>
       </Dialog>
+    </div>
+  )
+}
+
+type ApiTokenSummary = {
+  id: string
+  name: string
+  prefix: string
+  createdAt: string
+  lastUsedAt: string | null
+  expiresAt: string | null
+}
+
+const TOKEN_EXPIRY_OPTIONS = [
+  { value: "never", label: "No expiry" },
+  { value: "30d", label: "30 days" },
+  { value: "90d", label: "90 days" },
+  { value: "365d", label: "1 year" },
+] as const
+
+function DeveloperSection() {
+  const { data: session, isPending } = useSession()
+  const user = session?.user
+  const [tokens, setTokens] = React.useState<ApiTokenSummary[] | null>(null)
+  const [name, setName] = React.useState("")
+  const [expiry, setExpiry] = React.useState<string>("never")
+  const [isCreating, setIsCreating] = React.useState(false)
+  const [revokeTarget, setRevokeTarget] =
+    React.useState<ApiTokenSummary | null>(null)
+  const [revokingId, setRevokingId] = React.useState<string | null>(null)
+  const [newToken, setNewToken] = React.useState<string | null>(null)
+  const [copiedToken, setCopiedToken] = React.useState(false)
+  const copyResetRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  React.useEffect(
+    () => () => {
+      if (copyResetRef.current) clearTimeout(copyResetRef.current)
+    },
+    []
+  )
+
+  React.useEffect(() => {
+    if (!user) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const response = await fetch("/api/tokens", { credentials: "include" })
+        if (!response.ok) throw new Error("Could not load tokens")
+        const body: { tokens: ApiTokenSummary[] } = await response.json()
+        if (!cancelled) setTokens(body.tokens)
+      } catch {
+        if (cancelled) return
+        toast.error("Couldn't load API tokens")
+        setTokens([])
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [user])
+
+  const handleCreate = React.useCallback(async () => {
+    const trimmed = name.trim()
+    if (!trimmed) {
+      toast.error("Give the token a name first")
+      return
+    }
+    setIsCreating(true)
+    try {
+      const days =
+        expiry === "30d"
+          ? 30
+          : expiry === "90d"
+            ? 90
+            : expiry === "365d"
+              ? 365
+              : null
+      const response = await fetch("/api/tokens", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: trimmed,
+          expiresAt: days
+            ? new Date(Date.now() + days * 86400_000).toISOString()
+            : null,
+        }),
+      })
+      const body = (await response.json().catch(() => null)) as {
+        error?: string
+        token?: string
+        id?: string
+        name?: string
+        prefix?: string
+        createdAt?: string
+        lastUsedAt?: string | null
+        expiresAt?: string | null
+      } | null
+      if (!response.ok) throw new Error(body?.error ?? "Could not create token")
+      if (
+        !body?.token ||
+        !body.id ||
+        !body.name ||
+        !body.prefix ||
+        !body.createdAt
+      ) {
+        throw new Error("Could not create token")
+      }
+      setNewToken(body.token)
+      setCopiedToken(false)
+      setName("")
+      setExpiry("never")
+      // The create response already carries the stored metadata, so add the
+      // row directly instead of refetching the list (no skeleton flash).
+      const record: ApiTokenSummary = {
+        id: body.id,
+        name: body.name,
+        prefix: body.prefix,
+        createdAt: body.createdAt,
+        lastUsedAt: body.lastUsedAt ?? null,
+        expiresAt: body.expiresAt ?? null,
+      }
+      setTokens((current) => [record, ...(current ?? [])])
+      toast.success("API token created")
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Couldn't create API token"
+      )
+    } finally {
+      setIsCreating(false)
+    }
+  }, [name, expiry])
+
+  const handleRevoke = React.useCallback(async (token: ApiTokenSummary) => {
+    setRevokingId(token.id)
+    try {
+      const response = await fetch(`/api/tokens/${token.id}`, {
+        method: "DELETE",
+        credentials: "include",
+      })
+      if (!response.ok) throw new Error("Could not revoke token")
+      setTokens(
+        (current) => current?.filter((item) => item.id !== token.id) ?? []
+      )
+      setRevokeTarget(null)
+      toast.success("API token revoked")
+    } catch {
+      toast.error("Couldn't revoke that token")
+    } finally {
+      setRevokingId(null)
+    }
+  }, [])
+
+  const copyToken = React.useCallback(async (value: string) => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopiedToken(true)
+      if (copyResetRef.current) clearTimeout(copyResetRef.current)
+      copyResetRef.current = setTimeout(() => setCopiedToken(false), 1500)
+    } catch {
+      toast.error("Couldn't copy token")
+    }
+  }, [])
+
+  if (!user && !isPending) {
+    return (
+      <div className="space-y-6">
+        <SectionHeader
+          title="Developer"
+          description="Create personal access tokens for the Tokokino API."
+        />
+        <div className="rounded-lg border border-border/60 bg-secondary/30 px-4 py-3 text-[13px] text-muted-foreground">
+          Sign in to generate personal access tokens.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-7">
+      <SectionHeader
+        title="Developer"
+        description="Personal access tokens authenticate API requests without a browser session. Send one as an Authorization: Bearer header."
+      />
+
+      <Dialog
+        open={newToken !== null}
+        onOpenChange={(open) => {
+          if (!open) setNewToken(null)
+        }}
+      >
+        <DialogContent showCloseButton={false} className="max-w-md p-5">
+          <DialogTitle className="text-base font-semibold">
+            Copy your new token
+          </DialogTitle>
+          <DialogDescription className="mt-2">
+            It won&apos;t be shown again. Store it somewhere safe — it acts as
+            your account on every API call.
+          </DialogDescription>
+          <div className="mt-4 flex min-w-0 items-center gap-2 rounded-md border border-border/60 bg-secondary/30 px-3 py-2.5">
+            <code className="min-w-0 flex-1 truncate font-mono text-[12px] text-foreground">
+              {newToken}
+            </code>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={copiedToken ? "Token copied" : "Copy token"}
+              onClick={() => newToken && void copyToken(newToken)}
+              className="shrink-0 hover:bg-accent hover:text-accent-foreground"
+            >
+              {copiedToken ? (
+                <RiCheckLine className="size-4 animate-in text-emerald-500 duration-200 zoom-in-50" />
+              ) : (
+                <RiFileCopyLine className="size-4" />
+              )}
+            </Button>
+          </div>
+          <div className="mt-5">
+            <Button
+              type="button"
+              onClick={() => setNewToken(null)}
+              className="w-full"
+            >
+              Okay
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <section className="space-y-3 border-b border-border/50 pb-6">
+        <p className="text-base font-medium text-foreground">
+          Generate a new token
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="e.g. CI upload script"
+            maxLength={60}
+            autoComplete="off"
+            className="h-10 min-w-0 flex-1 rounded-md border border-border/60 bg-secondary/30 px-3 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/60 focus:border-foreground/30"
+          />
+          <Select value={expiry} onValueChange={setExpiry}>
+            <SelectTrigger
+              size="default"
+              aria-label="Token expiry"
+              className="w-full text-[13px] data-[size=default]:h-10 sm:w-36"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TOKEN_EXPIRY_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            type="button"
+            onClick={() => void handleCreate()}
+            disabled={isCreating || !name.trim()}
+            className="h-10 shrink-0 px-4"
+          >
+            {isCreating ? (
+              <RiLoader4Line className="size-4 animate-spin" />
+            ) : (
+              <RiKeyLine className="size-4" />
+            )}
+            Generate
+          </Button>
+        </div>
+        <p className="text-[12px] text-muted-foreground">
+          Use it with{" "}
+          <code className="rounded bg-secondary/70 px-1.5 py-0.5 font-mono text-[11px]">
+            Authorization: Bearer tk_…
+          </code>{" "}
+          on any documented API endpoint. Tokens act as you. Keep them secret.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <p className="text-base font-semibold text-foreground">
+            Active tokens
+          </p>
+          <p className="text-[12px] text-muted-foreground">
+            Revoking a token immediately stops every integration using it.
+          </p>
+        </div>
+        <div className="overflow-x-auto rounded-md border border-border/50">
+          <div className="min-w-[44rem] divide-y divide-border/50">
+            <div className="grid grid-cols-[minmax(10rem,1.6fr)_minmax(7rem,.9fr)_minmax(7rem,.9fr)_minmax(8rem,1fr)_7.5rem] gap-4 bg-secondary/30 px-4 py-2.5 text-[11px] font-medium text-muted-foreground">
+              <span>Token</span>
+              <span>Created</span>
+              <span>Expires</span>
+              <span>Last used</span>
+              <span className="text-right">Action</span>
+            </div>
+            {tokens?.map((token) => (
+              <div
+                key={token.id}
+                className="grid grid-cols-[minmax(10rem,1.6fr)_minmax(7rem,.9fr)_minmax(7rem,.9fr)_minmax(8rem,1fr)_7.5rem] items-center gap-4 px-4 py-3 text-[12px]"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <RiKeyLine className="size-4 shrink-0 text-muted-foreground" />
+                  <p className="truncate text-foreground">{token.name}</p>
+                </div>
+                <span
+                  className="text-muted-foreground"
+                  title={new Date(token.createdAt).toLocaleString()}
+                >
+                  {new Date(token.createdAt).toLocaleDateString()}
+                </span>
+                <span
+                  className="text-muted-foreground"
+                  title={
+                    token.expiresAt
+                      ? new Date(token.expiresAt).toLocaleString()
+                      : undefined
+                  }
+                >
+                  {token.expiresAt
+                    ? new Date(token.expiresAt).toLocaleDateString()
+                    : "No expiry"}
+                </span>
+                <span
+                  className="text-muted-foreground"
+                  title={
+                    token.lastUsedAt
+                      ? new Date(token.lastUsedAt).toLocaleString()
+                      : undefined
+                  }
+                >
+                  {token.lastUsedAt
+                    ? relativeTime(token.lastUsedAt)
+                    : "Never used"}
+                </span>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="default"
+                  onClick={() => setRevokeTarget(token)}
+                  disabled={revokingId === token.id}
+                  className="min-w-[7rem] justify-self-end border-destructive/50 bg-transparent hover:bg-destructive/10 dark:bg-transparent dark:hover:bg-destructive/10"
+                >
+                  <RiDeleteBinLine className="size-3.5" />
+                  Revoke
+                </Button>
+              </div>
+            ))}
+            {tokens === null
+              ? Array.from({ length: 3 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="grid animate-pulse grid-cols-[minmax(10rem,1.6fr)_minmax(7rem,.9fr)_minmax(7rem,.9fr)_minmax(8rem,1fr)_7.5rem] items-center gap-4 px-4 py-3"
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="size-4 shrink-0 rounded bg-foreground/10" />
+                      <div className="min-w-0 flex-1 space-y-1.5">
+                        <span className="block h-3.5 w-32 rounded bg-foreground/10" />
+                        <span className="block h-3 w-24 rounded bg-foreground/10" />
+                      </div>
+                    </div>
+                    <span className="h-3.5 w-20 rounded bg-foreground/10" />
+                    <span className="h-3.5 w-20 rounded bg-foreground/10" />
+                    <span className="h-3.5 w-24 rounded bg-foreground/10" />
+                    <span className="h-7 w-[7rem] justify-self-end rounded-md bg-foreground/10" />
+                  </div>
+                ))
+              : null}
+            {tokens?.length === 0 ? (
+              <div className="px-4 py-5 text-[12px] text-muted-foreground">
+                No tokens yet. Generate one above to call the API from scripts,
+                CI, or agents.
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <AlertDialog
+        open={revokeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setRevokeTarget(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke token?</AlertDialogTitle>
+            <AlertDialogDescription>
+              &ldquo;{revokeTarget?.name}&rdquo; will stop working immediately.
+              Every script, CI job, or agent using it will start getting
+              unauthorized errors. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => revokeTarget && void handleRevoke(revokeTarget)}
+              disabled={revokingId !== null}
+              className="text-destructive-foreground bg-destructive hover:bg-destructive/90"
+            >
+              {revokingId !== null ? (
+                <>
+                  <RiLoader4Line className="size-3.5 animate-spin" />
+                  Revoking
+                </>
+              ) : (
+                <>
+                  <RiDeleteBinLine className="size-3.5" />
+                  Revoke
+                </>
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/components/editor/settings/settings-dialog.tsx
+++ b/components/editor/settings/settings-dialog.tsx
@@ -1168,7 +1168,7 @@ function DeveloperSection() {
                   disabled={revokingId === token.id}
                   className="min-w-[7rem] justify-self-end border-destructive/50 bg-transparent hover:bg-destructive/10 dark:bg-transparent dark:hover:bg-destructive/10"
                 >
-                  <RiDeleteBinLine className="size-3.5" />
+                  <RiDeleteBinLine className="size-4" />
                   Revoke
                 </Button>
               </div>
@@ -1227,12 +1227,12 @@ function DeveloperSection() {
             >
               {revokingId !== null ? (
                 <>
-                  <RiLoader4Line className="size-3.5 animate-spin" />
+                  <RiLoader4Line className="size-4 animate-spin" />
                   Revoking
                 </>
               ) : (
                 <>
-                  <RiDeleteBinLine className="size-3.5" />
+                  <RiDeleteBinLine className="size-4" />
                   Revoke
                 </>
               )}

--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -79,6 +79,33 @@ export async function requireSession(
 }
 
 /**
+ * Like `requireSession`, but rejects personal access tokens. Use it for
+ * actions that operate on the caller's browser sessions (listing or revoking
+ * them): those go through better-auth with the request headers, so a PAT
+ * would silently match nothing while reporting success.
+ */
+export async function requireBrowserSession(
+  request: Request
+): Promise<
+  | { ok: true; session: AuthorizedSession }
+  | { ok: false; response: NextResponse }
+> {
+  const auth = await requireSession(request)
+  if (!auth.ok) return auth
+  if (auth.session.authMethod !== "session") {
+    return {
+      ok: false,
+      response: apiError({
+        status: 403,
+        code: "forbidden",
+        message: "This action requires a browser session sign-in",
+      }),
+    }
+  }
+  return auth
+}
+
+/**
  * Session must belong to a maintainer email listed in
  * TEMPLATE_MAINTAINER_EMAILS. Fail closed when the allowlist is empty.
  */

--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -5,6 +5,11 @@ import type { NextResponse } from "next/server"
 import { apiError } from "@/lib/api-error"
 import { getAuth } from "@/lib/auth"
 import { env } from "@/lib/env"
+import {
+  extractBearerToken,
+  isPersonalAccessTokenFormat,
+  verifyPersonalAccessToken,
+} from "@/lib/personal-access-tokens"
 
 export type AuthorizedSession = {
   session: {
@@ -15,6 +20,42 @@ export type AuthorizedSession = {
     name?: string | null
     email?: string | null
   }
+  /** How the caller authenticated: browser session cookie vs PAT. */
+  authMethod: "session" | "pat"
+}
+
+/**
+ * Resolve the caller to a user via a personal access token
+ * (`Authorization: Bearer tk_…`) or a better-auth session (cookie, or a
+ * session token in the Authorization header). Returns null when neither
+ * credential is present or valid.
+ */
+export async function resolveApiSession(
+  request: Request
+): Promise<AuthorizedSession | null> {
+  const bearer = extractBearerToken(request.headers)
+  if (bearer && isPersonalAccessTokenFormat(bearer)) {
+    try {
+      const owner = await verifyPersonalAccessToken(bearer)
+      if (owner) {
+        return {
+          session: { id: `pat:${owner.tokenId}` },
+          user: owner.user,
+          authMethod: "pat",
+        }
+      }
+      // A well-formed but unknown/revoked PAT is a hard failure — don't fall
+      // through to the session cookie and mask a broken integration.
+      return null
+    } catch {
+      return null
+    }
+  }
+
+  const auth = getAuth()
+  const session = await auth.api.getSession({ headers: request.headers })
+  if (!session) return null
+  return { ...session, authMethod: "session" as const }
 }
 
 export async function requireSession(
@@ -23,8 +64,7 @@ export async function requireSession(
   | { ok: true; session: AuthorizedSession }
   | { ok: false; response: NextResponse }
 > {
-  const auth = getAuth()
-  const session = await auth.api.getSession({ headers: request.headers })
+  const session = await resolveApiSession(request)
   if (!session) {
     return {
       ok: false,

--- a/lib/api-error.ts
+++ b/lib/api-error.ts
@@ -17,7 +17,7 @@ export type ApiErrorCode =
   | "internal_error"
 
 const DEFAULT_HINTS: Record<ApiErrorCode, string> = {
-  unauthorized: `Sign in at ${SITE_URL}/login and send the session cookie with the request. See ${SITE_URL}/auth.md.`,
+  unauthorized: `Generate a personal access token in Settings → Developer and send it as an Authorization: Bearer header, or sign in at ${SITE_URL}/login and send the session cookie. See ${SITE_URL}/auth.md.`,
   forbidden: "This account is not permitted to perform that action.",
   not_found: "Check the path and any resource id, then retry.",
   invalid_request:

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -167,6 +167,24 @@ export const shareViews = sqliteTable(
   ]
 )
 
+/** Personal access token for API use without a browser session cookie. */
+export const personalAccessTokens = sqliteTable(
+  "personal_access_tokens",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id").notNull(),
+    name: text("name").notNull(),
+    /** SHA-256 hex of the token. The plaintext is shown once at creation. */
+    tokenHash: text("token_hash").notNull().unique(),
+    /** Non-secret prefix shown in the UI to identify the token. */
+    prefix: text("prefix").notNull(),
+    createdAt: text("created_at").notNull(),
+    lastUsedAt: text("last_used_at"),
+    expiresAt: text("expires_at"),
+  },
+  (table) => [index("idx_pat_user_created").on(table.userId, table.createdAt)]
+)
+
 /** Durable R2 multipart session for an unpublished animated/video share. */
 export const shareUploads = sqliteTable(
   "share_uploads",

--- a/lib/openapi/spec.ts
+++ b/lib/openapi/spec.ts
@@ -9,7 +9,7 @@ const errorResponse = (description: string) => ({
   },
 })
 
-const sessionSecurity = [{ sessionCookie: [] }]
+const sessionSecurity = [{ sessionCookie: [] }, { patBearer: [] }]
 
 export const openApiSpec = {
   openapi: "3.1.0",
@@ -18,7 +18,7 @@ export const openApiSpec = {
     version: "1.0.0",
     summary: "HTTP API for Tokokino screenshot shares, drafts, and presets.",
     description:
-      "Tokokino is a browser-based screenshot and product-demo editor. Editing and export run entirely on the client; this API covers the server-backed features — public share links, cloud drafts, custom style presets, editor preferences, and a few media proxies used by the editor.\n\nAuthentication uses a better-auth session cookie. Sign in at /login, then send the session cookie with each request. See /auth.md for the full authentication guide.",
+      "Tokokino is a browser-based screenshot and product-demo editor. Editing and export run entirely on the client; this API covers the server-backed features — public share links, cloud drafts, custom style presets, editor preferences, and a few media proxies used by the editor.\n\nAuthentication uses a personal access token (generate one in Settings → Developer and send it as an `Authorization: Bearer tk_…` header) or a better-auth session cookie. Sign in at /login, then send the session cookie with each request. See /auth.md for the full authentication guide.",
     contact: { name: "Tokokino", url: `${SITE_URL}/contact` },
     license: {
       name: "AGPL-3.0",
@@ -37,6 +37,10 @@ export const openApiSpec = {
     },
     { name: "Drafts", description: "Cloud-saved editor state." },
     { name: "Presets", description: "Reusable custom style presets." },
+    {
+      name: "Tokens",
+      description: "Personal access tokens for script and agent use.",
+    },
     { name: "Preferences", description: "Per-user editor preferences." },
     {
       name: "Media",
@@ -871,6 +875,104 @@ export const openApiSpec = {
         },
       },
     },
+    "/api/tokens": {
+      get: {
+        tags: ["Tokens"],
+        operationId: "listTokens",
+        summary: "List personal access tokens",
+        description:
+          "Only metadata is returned — plaintext tokens are shown once at creation and never again.",
+        security: sessionSecurity,
+        responses: {
+          200: {
+            description: "The user's tokens.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["tokens"],
+                  properties: {
+                    tokens: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/TokenSummary" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          401: errorResponse("Not signed in."),
+        },
+      },
+      post: {
+        tags: ["Tokens"],
+        operationId: "createToken",
+        summary: "Generate a personal access token",
+        description:
+          "The plaintext `token` is returned exactly once. It is stored only as a SHA-256 hash.",
+        security: sessionSecurity,
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["name"],
+                properties: {
+                  name: { type: "string", maxLength: 60 },
+                  expiresAt: {
+                    type: ["string", "null"],
+                    format: "date-time",
+                    description: "Optional future expiry timestamp.",
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "The created token, including its one-time plaintext.",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/CreatedToken" },
+              },
+            },
+          },
+          400: errorResponse("Invalid body."),
+          401: errorResponse("Not signed in."),
+          409: errorResponse("Token limit reached."),
+          429: errorResponse("Rate limited."),
+        },
+      },
+    },
+    "/api/tokens/{id}": {
+      parameters: [{ $ref: "#/components/parameters/TokenId" }],
+      delete: {
+        tags: ["Tokens"],
+        operationId: "revokeToken",
+        summary: "Revoke a personal access token",
+        description:
+          "Revocation takes effect immediately on every request using the token.",
+        security: sessionSecurity,
+        responses: {
+          200: {
+            description: "Token revoked.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["ok"],
+                  properties: { ok: { type: "boolean" } },
+                },
+              },
+            },
+          },
+          401: errorResponse("Not signed in."),
+          404: errorResponse("Token not found."),
+        },
+      },
+    },
     "/api/screenshot": {
       post: {
         tags: ["Media"],
@@ -1088,6 +1190,11 @@ export const openApiSpec = {
   },
   components: {
     securitySchemes: {
+      patBearer: {
+        type: "http",
+        scheme: "bearer",
+        description: `Personal access token generated in Settings → Developer. Send as \`Authorization: Bearer tk_…\`. Full guide at ${SITE_URL}/auth.md.`,
+      },
       sessionCookie: {
         type: "apiKey",
         in: "cookie",
@@ -1122,6 +1229,13 @@ export const openApiSpec = {
         in: "path",
         required: true,
         description: "Preset UUID.",
+        schema: { type: "string", format: "uuid" },
+      },
+      TokenId: {
+        name: "id",
+        in: "path",
+        required: true,
+        description: "Personal access token UUID.",
         schema: { type: "string", format: "uuid" },
       },
     },
@@ -1268,6 +1382,36 @@ export const openApiSpec = {
         type: "object",
         properties: {
           exportFilenameFormat: { type: "string" },
+        },
+      },
+      TokenSummary: {
+        type: "object",
+        required: ["id", "name", "prefix", "createdAt"],
+        properties: {
+          id: { type: "string", format: "uuid" },
+          name: { type: "string", maxLength: 60 },
+          prefix: {
+            type: "string",
+            description: "Non-secret identifier shown in Settings.",
+          },
+          createdAt: { type: "string" },
+          lastUsedAt: { type: ["string", "null"] },
+          expiresAt: { type: ["string", "null"] },
+        },
+      },
+      CreatedToken: {
+        type: "object",
+        required: ["token", "id", "name", "prefix", "createdAt"],
+        description:
+          "The plaintext `token` is returned exactly once and can never be read back.",
+        properties: {
+          token: { type: "string", description: "One-time plaintext token." },
+          id: { type: "string", format: "uuid" },
+          name: { type: "string", maxLength: 60 },
+          prefix: { type: "string" },
+          createdAt: { type: "string" },
+          lastUsedAt: { type: ["string", "null"] },
+          expiresAt: { type: ["string", "null"] },
         },
       },
       UnsplashPhoto: {

--- a/lib/personal-access-tokens.ts
+++ b/lib/personal-access-tokens.ts
@@ -1,0 +1,195 @@
+import "server-only"
+
+import { createHash } from "node:crypto"
+
+import { and, desc, eq } from "drizzle-orm"
+import { z } from "zod/v4"
+
+import { getD1Database, getDb, toD1Date } from "@/lib/d1"
+import { personalAccessTokens } from "@/lib/db/schema"
+
+/** Prefix distinguishing personal access tokens from session tokens. */
+export const PAT_PREFIX = "tk_"
+
+/** Cap on active tokens per user, to bound the verification scan. */
+export const MAX_TOKENS_PER_USER = 20
+
+export const patNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Name is required")
+  .max(60, "Name must be 60 characters or fewer")
+
+export type PersonalAccessTokenSummary = {
+  id: string
+  name: string
+  prefix: string
+  createdAt: string
+  lastUsedAt: string | null
+  expiresAt: string | null
+}
+
+function rowToSummary(row: typeof personalAccessTokens.$inferSelect) {
+  return {
+    id: row.id,
+    name: row.name,
+    prefix: row.prefix,
+    createdAt: row.createdAt,
+    lastUsedAt: row.lastUsedAt,
+    expiresAt: row.expiresAt,
+  }
+}
+
+/**
+ * Generate a new token. Uses the Web Crypto API so this also runs on the
+ * Workers runtime, where `node:crypto` random helpers may be unavailable.
+ */
+export function generatePersonalAccessToken(): string {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  let binary = ""
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return `${PAT_PREFIX}${btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")}`
+}
+
+export function hashPersonalAccessToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex")
+}
+
+export function isPersonalAccessTokenFormat(value: string): boolean {
+  return (
+    value.startsWith(PAT_PREFIX) &&
+    value.length >= PAT_PREFIX.length + 20 &&
+    /^[A-Za-z0-9_-]+$/.test(value.slice(PAT_PREFIX.length))
+  )
+}
+
+/** Non-secret identifier shown in the UI, e.g. `tk_ab12…wxyz`. */
+export function tokenPrefixDisplay(token: string): string {
+  const secret = token.slice(PAT_PREFIX.length)
+  return `${PAT_PREFIX}${secret.slice(0, 4)}…${secret.slice(-4)}`
+}
+
+export function extractBearerToken(headers: Headers): string | null {
+  const header = headers.get("authorization")
+  if (!header) return null
+  const match = /^Bearer\s+(\S+)\s*$/i.exec(header.trim())
+  return match?.[1] ? match[1].trim() : null
+}
+
+export function isTokenExpired(expiresAt: string | null | undefined): boolean {
+  if (!expiresAt) return false
+  return new Date(expiresAt).getTime() <= Date.now()
+}
+
+export async function listPersonalAccessTokens(
+  userId: string
+): Promise<PersonalAccessTokenSummary[]> {
+  const rows = await getDb()
+    .select()
+    .from(personalAccessTokens)
+    .where(eq(personalAccessTokens.userId, userId))
+    .orderBy(desc(personalAccessTokens.createdAt))
+  return rows.map(rowToSummary)
+}
+
+export async function countPersonalAccessTokens(
+  userId: string
+): Promise<number> {
+  const rows = await getDb()
+    .select({ id: personalAccessTokens.id })
+    .from(personalAccessTokens)
+    .where(eq(personalAccessTokens.userId, userId))
+  return rows.length
+}
+
+export async function createPersonalAccessTokenRecord({
+  id,
+  userId,
+  name,
+  tokenHash,
+  prefix,
+  expiresAt,
+}: {
+  id: string
+  userId: string
+  name: string
+  tokenHash: string
+  prefix: string
+  expiresAt: string | null
+}) {
+  const createdAt = toD1Date(new Date())
+  await getDb().insert(personalAccessTokens).values({
+    id,
+    userId,
+    name,
+    tokenHash,
+    prefix,
+    createdAt,
+    lastUsedAt: null,
+    expiresAt,
+  })
+  return { id, name, prefix, createdAt, lastUsedAt: null, expiresAt }
+}
+
+export async function deletePersonalAccessToken(
+  id: string,
+  userId: string
+): Promise<boolean> {
+  const existing = await getDb()
+    .select({ id: personalAccessTokens.id })
+    .from(personalAccessTokens)
+    .where(
+      and(
+        eq(personalAccessTokens.id, id),
+        eq(personalAccessTokens.userId, userId)
+      )
+    )
+    .limit(1)
+  if (existing.length === 0) return false
+  await getDb()
+    .delete(personalAccessTokens)
+    .where(eq(personalAccessTokens.id, id))
+  return true
+}
+
+export type PatOwner = {
+  tokenId: string
+  user: { id: string; name: string | null; email: string | null }
+}
+
+/**
+ * Resolve a plaintext token to its owner. Returns null for unknown, expired,
+ * or orphaned tokens. Refreshes `last_used_at` as a side effect.
+ */
+export async function verifyPersonalAccessToken(
+  token: string
+): Promise<PatOwner | null> {
+  if (!isPersonalAccessTokenFormat(token)) return null
+  const tokenHash = hashPersonalAccessToken(token)
+  const rows = await getDb()
+    .select()
+    .from(personalAccessTokens)
+    .where(eq(personalAccessTokens.tokenHash, tokenHash))
+    .limit(1)
+  const row = rows[0]
+  if (!row) return null
+  if (isTokenExpired(row.expiresAt)) return null
+
+  const userRow = await getD1Database()
+    .prepare('SELECT id, name, email FROM "user" WHERE id = ?')
+    .bind(row.userId)
+    .first<{ id: string; name: string | null; email: string | null }>()
+  if (!userRow) return null
+
+  await getDb()
+    .update(personalAccessTokens)
+    .set({ lastUsedAt: toD1Date(new Date()) })
+    .where(eq(personalAccessTokens.id, row.id))
+    .catch(() => {})
+
+  return {
+    tokenId: row.id,
+    user: { id: userRow.id, name: userRow.name, email: userRow.email },
+  }
+}

--- a/lib/personal-access-tokens.ts
+++ b/lib/personal-access-tokens.ts
@@ -2,7 +2,7 @@ import "server-only"
 
 import { createHash } from "node:crypto"
 
-import { and, desc, eq } from "drizzle-orm"
+import { and, desc, eq, gt, isNull, or } from "drizzle-orm"
 import { z } from "zod/v4"
 
 import { getD1Database, getDb, toD1Date } from "@/lib/d1"
@@ -103,6 +103,47 @@ export async function countPersonalAccessTokens(
   return rows.length
 }
 
+/**
+ * Tokens counting toward `MAX_TOKENS_PER_USER`. Expired tokens can never
+ * authenticate, so they must not block the creation of usable ones.
+ */
+export async function countActivePersonalAccessTokens(
+  userId: string
+): Promise<number> {
+  const now = toD1Date(new Date())
+  const rows = await getDb()
+    .select({ id: personalAccessTokens.id })
+    .from(personalAccessTokens)
+    .where(
+      and(
+        eq(personalAccessTokens.userId, userId),
+        or(
+          isNull(personalAccessTokens.expiresAt),
+          gt(personalAccessTokens.expiresAt, now)
+        )
+      )
+    )
+  return rows.length
+}
+
+/** Minimum age of `last_used_at` before a PAT request refreshes it. */
+export const PAT_LAST_USED_UPDATE_INTERVAL_MS = 60 * 60 * 1000
+
+/**
+ * Whether a successful authentication should rewrite `last_used_at`.
+ * Throttled so bursty scripts and CI cost one metadata write per token per
+ * hour instead of one per request.
+ */
+export function shouldRefreshLastUsedAt(
+  lastUsedAt: string | null | undefined,
+  now = Date.now()
+): boolean {
+  if (!lastUsedAt) return true
+  const seen = new Date(lastUsedAt).getTime()
+  if (!Number.isFinite(seen)) return true
+  return now - seen >= PAT_LAST_USED_UPDATE_INTERVAL_MS
+}
+
 export async function createPersonalAccessTokenRecord({
   id,
   userId,
@@ -182,11 +223,13 @@ export async function verifyPersonalAccessToken(
     .first<{ id: string; name: string | null; email: string | null }>()
   if (!userRow) return null
 
-  await getDb()
-    .update(personalAccessTokens)
-    .set({ lastUsedAt: toD1Date(new Date()) })
-    .where(eq(personalAccessTokens.id, row.id))
-    .catch(() => {})
+  if (shouldRefreshLastUsedAt(row.lastUsedAt)) {
+    await getDb()
+      .update(personalAccessTokens)
+      .set({ lastUsedAt: toD1Date(new Date()) })
+      .where(eq(personalAccessTokens.id, row.id))
+      .catch(() => {})
+  }
 
   return {
     tokenId: row.id,

--- a/lib/share-upload-server.ts
+++ b/lib/share-upload-server.ts
@@ -2,7 +2,7 @@ import "server-only"
 
 import { NextResponse } from "next/server"
 
-import { getAuth } from "@/lib/auth"
+import { resolveApiSession } from "@/lib/api-auth"
 import { getShareById } from "@/lib/share-db"
 import {
   getExpiredShareUploads,
@@ -30,7 +30,7 @@ export function isShareUploadContentType(
 }
 
 export async function requireShareUploadUser(request: Request) {
-  const session = await getAuth().api.getSession({ headers: request.headers })
+  const session = await resolveApiSession(request)
   if (!session) {
     return {
       session: null,

--- a/migrations/0014_personal_access_tokens.sql
+++ b/migrations/0014_personal_access_tokens.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS "personal_access_tokens" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "user_id" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "token_hash" TEXT NOT NULL UNIQUE,
+  "prefix" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL,
+  "last_used_at" TEXT,
+  "expires_at" TEXT,
+  FOREIGN KEY ("user_id") REFERENCES "user" ("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "personal_access_tokens_user_created_idx"
+  ON "personal_access_tokens" ("user_id", "created_at" DESC);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "build:thumbs": "node scripts/build-overlay-thumbs.mjs",
     "build:backgrounds": "node --env-file-if-exists=.env.local scripts/build-background-thumbs.mjs",
     "build:shapes": "node --env-file-if-exists=.env.local scripts/build-shapes.mjs",
-    "build:glass-preview": "node --env-file-if-exists=.env.local scripts/upload-glass-frame-preview.mjs"
+    "build:glass-preview": "node --env-file-if-exists=.env.local scripts/upload-glass-frame-preview.mjs",
+    "db:migrate:local": "wrangler d1 migrations apply tokokino-db --local",
+    "db:migrate:remote": "wrangler d1 migrations apply tokokino-db --remote"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/public/.well-known/agent-skills/drafts.md
+++ b/public/.well-known/agent-skills/drafts.md
@@ -13,4 +13,4 @@ Save and restore editor state as named drafts.
 
 ## Authentication
 
-Session cookie required. See [auth.md](https://tokokino.com/auth.md).
+Personal access token (`Authorization: Bearer tk_…`) or session cookie. See [auth.md](https://tokokino.com/auth.md).

--- a/public/.well-known/agent-skills/presets.md
+++ b/public/.well-known/agent-skills/presets.md
@@ -11,4 +11,4 @@ Manage custom style presets for the screenshot editor.
 
 ## Authentication
 
-Session cookie required. See [auth.md](https://tokokino.com/auth.md).
+Personal access token (`Authorization: Bearer tk_…`) or session cookie. See [auth.md](https://tokokino.com/auth.md).

--- a/public/.well-known/agent-skills/share.md
+++ b/public/.well-known/agent-skills/share.md
@@ -10,14 +10,14 @@ Create and retrieve public share links for beautified screenshots.
 
 ## Authentication
 
-Session cookie required. See [auth.md](https://tokokino.com/auth.md).
+Personal access token (`Authorization: Bearer tk_…`) or session cookie. See [auth.md](https://tokokino.com/auth.md).
 
 ## Request
 
 ```
 POST /api/share
 Content-Type: image/png
-Authorization: session cookie
+Authorization: Bearer tk_<your-personal-access-token>
 Body: raw PNG or JPEG blob (max 20 MB)
 ```
 

--- a/tests/app/api/account-route.test.ts
+++ b/tests/app/api/account-route.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import type * as PatModule from "@/lib/personal-access-tokens"
 
 const mocks = vi.hoisted(() => ({
   requestAccountDeletion: vi.fn(),
@@ -13,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   retryPendingAccountCleanups: vi.fn(),
   run: vi.fn(),
   getCloudflareContext: vi.fn(),
+  verifyPersonalAccessToken: vi.fn(),
 }))
 
 const statement = {
@@ -42,6 +44,14 @@ vi.mock("@/lib/d1", () => ({
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: mocks.getCloudflareContext,
 }))
+
+vi.mock("@/lib/personal-access-tokens", async (importOriginal) => {
+  const actual = await importOriginal<typeof PatModule>()
+  return {
+    ...actual,
+    verifyPersonalAccessToken: mocks.verifyPersonalAccessToken,
+  }
+})
 
 const SESSION = {
   user: { id: "user_1" },
@@ -84,6 +94,7 @@ describe("/api/account", () => {
     mocks.getCloudflareContext.mockReturnValue({
       cf: { city: "Dispur", region: "Assam", country: "IN" },
     })
+    mocks.verifyPersonalAccessToken.mockResolvedValue(null)
   })
 
   it("requires a session before listing active devices", async () => {
@@ -98,6 +109,72 @@ describe("/api/account", () => {
       code: "unauthorized",
     })
     expect(mocks.listSessions).not.toHaveBeenCalled()
+  })
+
+  it("rejects personal access tokens for session listing", async () => {
+    mocks.verifyPersonalAccessToken.mockResolvedValue({
+      tokenId: "token_1",
+      user: { id: "user_1", name: "Shiva", email: "shiva@example.com" },
+    })
+    const { GET } = await loadRoute()
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/account", {
+        headers: {
+          Authorization: "Bearer tk_test-token-value-0123456789abcdef",
+        },
+      })
+    )
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toMatchObject({
+      code: "forbidden",
+    })
+    expect(mocks.listSessions).not.toHaveBeenCalled()
+  })
+
+  it("rejects personal access tokens for session revocation", async () => {
+    mocks.verifyPersonalAccessToken.mockResolvedValue({
+      tokenId: "token_1",
+      user: { id: "user_1", name: "Shiva", email: "shiva@example.com" },
+    })
+    const { POST } = await loadRoute()
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/account", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          Authorization: "Bearer tk_test-token-value-0123456789abcdef",
+        },
+        body: JSON.stringify({ action: "revoke-all" }),
+      })
+    )
+
+    expect(response.status).toBe(403)
+    expect(mocks.revokeSessions).not.toHaveBeenCalled()
+  })
+
+  it("rejects personal access tokens for account deletion", async () => {
+    mocks.verifyPersonalAccessToken.mockResolvedValue({
+      tokenId: "token_1",
+      user: { id: "user_1", name: "Shiva", email: "shiva@example.com" },
+    })
+    const { DELETE } = await loadRoute()
+
+    const response = await DELETE(
+      new Request("http://localhost:3000/api/account", {
+        method: "DELETE",
+        headers: {
+          "content-type": "application/json",
+          Authorization: "Bearer tk_test-token-value-0123456789abcdef",
+        },
+        body: JSON.stringify({ confirmation: "DELETE" }),
+      })
+    )
+
+    expect(response.status).toBe(403)
+    expect(mocks.requestAccountDeletion).not.toHaveBeenCalled()
   })
 
   it("lists safe session details without returning session tokens", async () => {

--- a/tests/app/api/share-pat-auth.test.ts
+++ b/tests/app/api/share-pat-auth.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+// Proves protected share endpoints authenticate callers carrying a personal
+// access token: the route resolves the user through resolveApiSession (which
+// accepts PAT bearers) rather than reading the session cookie directly.
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  resolveApiSession: vi.fn(),
+  enforceRateLimit: vi.fn(),
+  getUserShares: vi.fn(),
+  getUserStorageUsage: vi.fn(),
+  createShareRecord: vi.fn(),
+  uploadShareImage: vi.fn(),
+}))
+
+vi.mock("@/lib/api-auth", () => ({
+  resolveApiSession: mocks.resolveApiSession,
+}))
+
+vi.mock("@/lib/rate-limit", () => ({
+  enforceRateLimit: mocks.enforceRateLimit,
+}))
+
+vi.mock("@/lib/share-db", () => ({
+  MAX_USER_SHARE_STORAGE_BYTES: 1024,
+  createShareRecord: mocks.createShareRecord,
+  deleteAllUserShares: vi.fn(),
+  getUserShares: mocks.getUserShares,
+  getUserStorageUsage: mocks.getUserStorageUsage,
+}))
+
+vi.mock("@/lib/share-storage", () => ({
+  MAX_SHARE_IMAGE_BYTES: 4096,
+  deleteShareImage: vi.fn(),
+  deleteShareImages: vi.fn(),
+  uploadShareImage: mocks.uploadShareImage,
+  uploadSharePoster: vi.fn(),
+}))
+
+const VALID_SHARE_ID = "123e4567-e89b-42d3-a456-426614174000"
+const PAT_SESSION = {
+  session: { id: "pat:token_1" },
+  user: { id: "user_1", name: "Shiva", email: "shiva@example.com" },
+  authMethod: "pat",
+}
+const PNG_BYTES = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00,
+])
+
+function imageRequest(extraHeaders: Record<string, string> = {}) {
+  const body = new ArrayBuffer(PNG_BYTES.byteLength)
+  new Uint8Array(body).set(PNG_BYTES)
+  return new Request("http://localhost:3000/api/share", {
+    method: "POST",
+    headers: {
+      "content-type": "image/png",
+      "content-length": String(PNG_BYTES.byteLength),
+      Authorization: "Bearer tk_test-token-value-0123456789abcdef",
+      ...extraHeaders,
+    },
+    body,
+  })
+}
+
+describe("POST /api/share with a personal access token", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.resolveApiSession.mockResolvedValue(PAT_SESSION)
+    mocks.enforceRateLimit.mockResolvedValue(null)
+    mocks.getUserStorageUsage.mockResolvedValue(0)
+    mocks.uploadShareImage.mockResolvedValue(undefined)
+    mocks.createShareRecord.mockResolvedValue(undefined)
+    vi.stubGlobal("crypto", {
+      randomUUID: vi.fn(() => VALID_SHARE_ID),
+    })
+  })
+
+  it("creates a share for the PAT owner without any session cookie", async () => {
+    const { POST } = await import("@/app/api/share/route")
+
+    const response = await POST(imageRequest())
+
+    expect(response.status).toBe(200)
+    expect(mocks.resolveApiSession).toHaveBeenCalled()
+    expect(mocks.createShareRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ user: PAT_SESSION.user })
+    )
+    expect(mocks.enforceRateLimit).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "user_1" })
+    )
+  })
+
+  it("still rejects requests with no credential at all", async () => {
+    mocks.resolveApiSession.mockResolvedValue(null)
+    const { POST } = await import("@/app/api/share/route")
+
+    const response = await POST(imageRequest())
+
+    expect(response.status).toBe(401)
+    expect(mocks.createShareRecord).not.toHaveBeenCalled()
+  })
+})

--- a/tests/app/api/tokens-route.test.ts
+++ b/tests/app/api/tokens-route.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type * as PatModule from "@/lib/personal-access-tokens"
+
+const mocks = vi.hoisted(() => ({
+  requireSession: vi.fn(),
+  enforceRateLimit: vi.fn(),
+  listPersonalAccessTokens: vi.fn(),
+  countPersonalAccessTokens: vi.fn(),
+  createPersonalAccessTokenRecord: vi.fn(),
+  deletePersonalAccessToken: vi.fn(),
+}))
+
+vi.mock("@/lib/api-auth", () => ({
+  requireSession: mocks.requireSession,
+}))
+
+vi.mock("@/lib/rate-limit", () => ({
+  enforceRateLimit: mocks.enforceRateLimit,
+}))
+
+vi.mock("@/lib/personal-access-tokens", async (importOriginal) => {
+  const actual = await importOriginal<typeof PatModule>()
+  return {
+    ...actual,
+    listPersonalAccessTokens: mocks.listPersonalAccessTokens,
+    countPersonalAccessTokens: mocks.countPersonalAccessTokens,
+    createPersonalAccessTokenRecord: mocks.createPersonalAccessTokenRecord,
+    deletePersonalAccessToken: mocks.deletePersonalAccessToken,
+    generatePersonalAccessToken: () =>
+      "tk_test-plaintext-token-value-0123456789",
+    hashPersonalAccessToken: () => "test-hash",
+    tokenPrefixDisplay: () => "tk_test…6789",
+  }
+})
+
+const SESSION = {
+  session: { id: "session_1" },
+  user: { id: "user_1", name: "Shiva", email: "shiva@example.com" },
+  authMethod: "session",
+}
+
+function jsonRequest(url: string, body: unknown) {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
+describe("GET /api/tokens", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.requireSession.mockResolvedValue({ ok: true, session: SESSION })
+    mocks.listPersonalAccessTokens.mockResolvedValue([])
+  })
+
+  it("requires authentication", async () => {
+    mocks.requireSession.mockResolvedValue({
+      ok: false,
+      response: new Response("unauthorized", { status: 401 }),
+    })
+    const { GET } = await import("@/app/api/tokens/route")
+
+    const response = await GET(new Request("http://localhost:3000/api/tokens"))
+
+    expect(response.status).toBe(401)
+    expect(mocks.listPersonalAccessTokens).not.toHaveBeenCalled()
+  })
+
+  it("lists the caller's tokens", async () => {
+    const tokens = [
+      {
+        id: "token_1",
+        name: "CI",
+        prefix: "tk_abcd…wxyz",
+        createdAt: new Date().toISOString(),
+        lastUsedAt: null,
+        expiresAt: null,
+      },
+    ]
+    mocks.listPersonalAccessTokens.mockResolvedValue(tokens)
+    const { GET } = await import("@/app/api/tokens/route")
+
+    const response = await GET(new Request("http://localhost:3000/api/tokens"))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ tokens })
+    expect(mocks.listPersonalAccessTokens).toHaveBeenCalledWith("user_1")
+  })
+})
+
+describe("POST /api/tokens", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.requireSession.mockResolvedValue({ ok: true, session: SESSION })
+    mocks.enforceRateLimit.mockResolvedValue(null)
+    mocks.countPersonalAccessTokens.mockResolvedValue(0)
+    mocks.createPersonalAccessTokenRecord.mockResolvedValue({
+      id: "token_1",
+      name: "CI",
+      prefix: "tk_test…6789",
+      createdAt: "2026-09-07T00:00:00.000Z",
+      lastUsedAt: null,
+      expiresAt: null,
+    })
+    vi.stubGlobal("crypto", { randomUUID: vi.fn(() => "token_1") })
+  })
+
+  it("requires authentication", async () => {
+    mocks.requireSession.mockResolvedValue({
+      ok: false,
+      response: new Response("unauthorized", { status: 401 }),
+    })
+    const { POST } = await import("@/app/api/tokens/route")
+
+    const response = await POST(
+      jsonRequest("http://localhost:3000/api/tokens", { name: "CI" })
+    )
+
+    expect(response.status).toBe(401)
+    expect(mocks.createPersonalAccessTokenRecord).not.toHaveBeenCalled()
+  })
+
+  it("rejects an empty name", async () => {
+    const { POST } = await import("@/app/api/tokens/route")
+
+    const response = await POST(
+      jsonRequest("http://localhost:3000/api/tokens", { name: "   " })
+    )
+
+    expect(response.status).toBe(400)
+    expect(mocks.createPersonalAccessTokenRecord).not.toHaveBeenCalled()
+  })
+
+  it("rejects a past expiry", async () => {
+    const { POST } = await import("@/app/api/tokens/route")
+
+    const response = await POST(
+      jsonRequest("http://localhost:3000/api/tokens", {
+        name: "CI",
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(mocks.createPersonalAccessTokenRecord).not.toHaveBeenCalled()
+  })
+
+  it("enforces the per-user token limit", async () => {
+    mocks.countPersonalAccessTokens.mockResolvedValue(20)
+    const { POST } = await import("@/app/api/tokens/route")
+
+    const response = await POST(
+      jsonRequest("http://localhost:3000/api/tokens", { name: "CI" })
+    )
+
+    expect(response.status).toBe(409)
+    expect(mocks.createPersonalAccessTokenRecord).not.toHaveBeenCalled()
+  })
+
+  it("returns the plaintext token exactly once with its metadata", async () => {
+    const { POST } = await import("@/app/api/tokens/route")
+
+    const response = await POST(
+      jsonRequest("http://localhost:3000/api/tokens", { name: "CI" })
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      token: "tk_test-plaintext-token-value-0123456789",
+      id: "token_1",
+      name: "CI",
+      prefix: "tk_test…6789",
+      createdAt: "2026-09-07T00:00:00.000Z",
+      lastUsedAt: null,
+      expiresAt: null,
+    })
+    expect(mocks.createPersonalAccessTokenRecord).toHaveBeenCalledWith({
+      id: "token_1",
+      userId: "user_1",
+      name: "CI",
+      tokenHash: "test-hash",
+      prefix: "tk_test…6789",
+      expiresAt: null,
+    })
+  })
+
+  it("accepts a future expiry", async () => {
+    const expiresAt = new Date(Date.now() + 86_400_000).toISOString()
+    const { POST } = await import("@/app/api/tokens/route")
+
+    const response = await POST(
+      jsonRequest("http://localhost:3000/api/tokens", {
+        name: "CI",
+        expiresAt,
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(mocks.createPersonalAccessTokenRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresAt: new Date(expiresAt).toISOString() })
+    )
+  })
+})
+
+describe("DELETE /api/tokens/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.requireSession.mockResolvedValue({ ok: true, session: SESSION })
+    mocks.enforceRateLimit.mockResolvedValue(null)
+    mocks.deletePersonalAccessToken.mockResolvedValue(true)
+  })
+
+  async function callDelete(id: string) {
+    const { DELETE } = await import("@/app/api/tokens/[id]/route")
+    return DELETE(
+      new Request(`http://localhost:3000/api/tokens/${id}`, {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ id }) }
+    )
+  }
+
+  it("requires authentication", async () => {
+    mocks.requireSession.mockResolvedValue({
+      ok: false,
+      response: new Response("unauthorized", { status: 401 }),
+    })
+
+    const response = await callDelete("token_1")
+
+    expect(response.status).toBe(401)
+    expect(mocks.deletePersonalAccessToken).not.toHaveBeenCalled()
+  })
+
+  it("revokes an owned token", async () => {
+    const response = await callDelete("token_1")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(mocks.deletePersonalAccessToken).toHaveBeenCalledWith(
+      "token_1",
+      "user_1"
+    )
+  })
+
+  it("returns 404 for a token that is not yours", async () => {
+    mocks.deletePersonalAccessToken.mockResolvedValue(false)
+
+    const response = await callDelete("someone-elses-token")
+
+    expect(response.status).toBe(404)
+  })
+})

--- a/tests/app/api/tokens-route.test.ts
+++ b/tests/app/api/tokens-route.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   requireSession: vi.fn(),
   enforceRateLimit: vi.fn(),
   listPersonalAccessTokens: vi.fn(),
-  countPersonalAccessTokens: vi.fn(),
+  countActivePersonalAccessTokens: vi.fn(),
   createPersonalAccessTokenRecord: vi.fn(),
   deletePersonalAccessToken: vi.fn(),
 }))
@@ -24,7 +24,7 @@ vi.mock("@/lib/personal-access-tokens", async (importOriginal) => {
   return {
     ...actual,
     listPersonalAccessTokens: mocks.listPersonalAccessTokens,
-    countPersonalAccessTokens: mocks.countPersonalAccessTokens,
+    countActivePersonalAccessTokens: mocks.countActivePersonalAccessTokens,
     createPersonalAccessTokenRecord: mocks.createPersonalAccessTokenRecord,
     deletePersonalAccessToken: mocks.deletePersonalAccessToken,
     generatePersonalAccessToken: () =>
@@ -95,7 +95,7 @@ describe("POST /api/tokens", () => {
     vi.clearAllMocks()
     mocks.requireSession.mockResolvedValue({ ok: true, session: SESSION })
     mocks.enforceRateLimit.mockResolvedValue(null)
-    mocks.countPersonalAccessTokens.mockResolvedValue(0)
+    mocks.countActivePersonalAccessTokens.mockResolvedValue(0)
     mocks.createPersonalAccessTokenRecord.mockResolvedValue({
       id: "token_1",
       name: "CI",
@@ -148,7 +148,7 @@ describe("POST /api/tokens", () => {
   })
 
   it("enforces the per-user token limit", async () => {
-    mocks.countPersonalAccessTokens.mockResolvedValue(20)
+    mocks.countActivePersonalAccessTokens.mockResolvedValue(20)
     const { POST } = await import("@/app/api/tokens/route")
 
     const response = await POST(
@@ -157,6 +157,26 @@ describe("POST /api/tokens", () => {
 
     expect(response.status).toBe(409)
     expect(mocks.createPersonalAccessTokenRecord).not.toHaveBeenCalled()
+  })
+
+  it("rolls back its own insert when a concurrent creation overflows the cap", async () => {
+    // Pre-insert count passes, post-insert count observes the overflow.
+    mocks.countActivePersonalAccessTokens
+      .mockResolvedValueOnce(19)
+      .mockResolvedValue(21)
+    mocks.deletePersonalAccessToken.mockResolvedValue(true)
+    const { POST } = await import("@/app/api/tokens/route")
+
+    const response = await POST(
+      jsonRequest("http://localhost:3000/api/tokens", { name: "CI" })
+    )
+
+    expect(response.status).toBe(409)
+    expect(mocks.deletePersonalAccessToken).toHaveBeenCalledWith(
+      "token_1",
+      "user_1"
+    )
+    await expect(response.json()).resolves.not.toHaveProperty("token")
   })
 
   it("returns the plaintext token exactly once with its metadata", async () => {

--- a/tests/lib/api-auth-pat.test.ts
+++ b/tests/lib/api-auth-pat.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type * as PatModule from "@/lib/personal-access-tokens"
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  verifyPersonalAccessToken: vi.fn(),
+}))
+
+vi.mock("@/lib/auth", () => ({
+  getAuth: () => ({
+    api: { getSession: mocks.getSession },
+  }),
+}))
+
+vi.mock("@/lib/personal-access-tokens", async (importOriginal) => {
+  const actual = await importOriginal<typeof PatModule>()
+  return {
+    ...actual,
+    verifyPersonalAccessToken: mocks.verifyPersonalAccessToken,
+  }
+})
+
+const COOKIE_SESSION = {
+  session: { id: "session_1" },
+  user: { id: "user_1", name: "Shiva", email: "shiva@example.com" },
+}
+
+describe("resolveApiSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getSession.mockResolvedValue(COOKIE_SESSION)
+    mocks.verifyPersonalAccessToken.mockResolvedValue(null)
+  })
+
+  it("resolves a valid PAT without touching the session store", async () => {
+    mocks.verifyPersonalAccessToken.mockResolvedValue({
+      tokenId: "token_1",
+      user: { id: "user_1", name: "Shiva", email: "shiva@example.com" },
+    })
+    const { resolveApiSession } = await import("@/lib/api-auth")
+
+    const session = await resolveApiSession(
+      new Request("http://localhost:3000/api/share", {
+        headers: { Authorization: "Bearer tk_valid-token-value-0123456789ab" },
+      })
+    )
+
+    expect(session).toEqual({
+      session: { id: "pat:token_1" },
+      user: { id: "user_1", name: "Shiva", email: "shiva@example.com" },
+      authMethod: "pat",
+    })
+    expect(mocks.getSession).not.toHaveBeenCalled()
+  })
+
+  it("rejects an unknown PAT even when a session cookie exists", async () => {
+    mocks.verifyPersonalAccessToken.mockResolvedValue(null)
+    const { resolveApiSession } = await import("@/lib/api-auth")
+
+    const session = await resolveApiSession(
+      new Request("http://localhost:3000/api/share", {
+        headers: {
+          Authorization: "Bearer tk_revoked-token-value-0123456789ab",
+          Cookie: "better-auth.session_token=valid",
+        },
+      })
+    )
+
+    expect(session).toBeNull()
+    expect(mocks.getSession).not.toHaveBeenCalled()
+  })
+
+  it("falls through to the session for requests without a PAT", async () => {
+    const { resolveApiSession } = await import("@/lib/api-auth")
+
+    const session = await resolveApiSession(
+      new Request("http://localhost:3000/api/share")
+    )
+
+    expect(session).toEqual({ ...COOKIE_SESSION, authMethod: "session" })
+    expect(mocks.verifyPersonalAccessToken).not.toHaveBeenCalled()
+  })
+
+  it("falls through to the session for a non-PAT bearer token", async () => {
+    const { resolveApiSession } = await import("@/lib/api-auth")
+
+    const session = await resolveApiSession(
+      new Request("http://localhost:3000/api/share", {
+        headers: { Authorization: "Bearer some-session-token" },
+      })
+    )
+
+    expect(session).toEqual({ ...COOKIE_SESSION, authMethod: "session" })
+    expect(mocks.verifyPersonalAccessToken).not.toHaveBeenCalled()
+    expect(mocks.getSession).toHaveBeenCalled()
+  })
+
+  it("returns null when neither credential is valid", async () => {
+    mocks.getSession.mockResolvedValue(null)
+    const { resolveApiSession, requireSession } = await import("@/lib/api-auth")
+
+    expect(
+      await resolveApiSession(new Request("http://localhost:3000/api/share"))
+    ).toBeNull()
+
+    const result = await requireSession(
+      new Request("http://localhost:3000/api/share")
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.response.status).toBe(401)
+      await expect(result.response.json()).resolves.toMatchObject({
+        code: "unauthorized",
+      })
+    }
+  })
+})

--- a/tests/lib/personal-access-tokens.test.ts
+++ b/tests/lib/personal-access-tokens.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest"
+
+import {
+  extractBearerToken,
+  generatePersonalAccessToken,
+  hashPersonalAccessToken,
+  isPersonalAccessTokenFormat,
+  isTokenExpired,
+  patNameSchema,
+  tokenPrefixDisplay,
+} from "@/lib/personal-access-tokens"
+
+describe("personal access token primitives", () => {
+  it("generates unique tokens in the tk_ format", () => {
+    const first = generatePersonalAccessToken()
+    const second = generatePersonalAccessToken()
+
+    expect(first).toMatch(/^tk_[A-Za-z0-9_-]{20,}$/)
+    expect(second).toMatch(/^tk_[A-Za-z0-9_-]{20,}$/)
+    expect(first).not.toBe(second)
+    expect(isPersonalAccessTokenFormat(first)).toBe(true)
+  })
+
+  it("rejects non-PAT strings as token format", () => {
+    expect(isPersonalAccessTokenFormat("")).toBe(false)
+    expect(isPersonalAccessTokenFormat("tk_short")).toBe(false)
+    expect(isPersonalAccessTokenFormat("Bearer tk_abc")).toBe(false)
+    expect(isPersonalAccessTokenFormat("session-token-value")).toBe(false)
+    expect(isPersonalAccessTokenFormat("tk_not valid!")).toBe(false)
+  })
+
+  it("hashes deterministically and never embeds the plaintext", () => {
+    const token = generatePersonalAccessToken()
+    const first = hashPersonalAccessToken(token)
+    const second = hashPersonalAccessToken(token)
+
+    expect(first).toBe(second)
+    expect(first).toMatch(/^[0-9a-f]{64}$/)
+    expect(first).not.toContain(token.slice(3, 10))
+    expect(hashPersonalAccessToken(generatePersonalAccessToken())).not.toBe(
+      first
+    )
+  })
+
+  it("derives a non-secret display prefix from the token", () => {
+    const token = generatePersonalAccessToken()
+    const prefix = tokenPrefixDisplay(token)
+
+    expect(prefix.startsWith("tk_")).toBe(true)
+    expect(prefix).toContain("…")
+    expect(prefix.length).toBeLessThan(token.length)
+  })
+
+  it("extracts bearer tokens case-insensitively", () => {
+    const token = generatePersonalAccessToken()
+    const headers = new Headers({ Authorization: `Bearer ${token}` })
+    expect(extractBearerToken(headers)).toBe(token)
+
+    const lower = new Headers({ authorization: `bearer ${token}` })
+    expect(extractBearerToken(lower)).toBe(token)
+
+    expect(extractBearerToken(new Headers())).toBeNull()
+    expect(
+      extractBearerToken(new Headers({ Authorization: "Basic abc" }))
+    ).toBeNull()
+  })
+
+  it("detects expired tokens by timestamp", () => {
+    expect(isTokenExpired(null)).toBe(false)
+    expect(isTokenExpired(undefined)).toBe(false)
+    expect(isTokenExpired(new Date(Date.now() + 60_000).toISOString())).toBe(
+      false
+    )
+    expect(isTokenExpired(new Date(Date.now() - 60_000).toISOString())).toBe(
+      true
+    )
+  })
+
+  it("validates token names", () => {
+    expect(patNameSchema.safeParse("CI upload script").success).toBe(true)
+    expect(patNameSchema.safeParse("  padded  ").data).toBe("padded")
+    expect(patNameSchema.safeParse("").success).toBe(false)
+    expect(patNameSchema.safeParse("   ").success).toBe(false)
+    expect(patNameSchema.safeParse("x".repeat(61)).success).toBe(false)
+  })
+})

--- a/tests/lib/personal-access-tokens.test.ts
+++ b/tests/lib/personal-access-tokens.test.ts
@@ -8,6 +8,8 @@ import {
   isPersonalAccessTokenFormat,
   isTokenExpired,
   patNameSchema,
+  PAT_LAST_USED_UPDATE_INTERVAL_MS,
+  shouldRefreshLastUsedAt,
   tokenPrefixDisplay,
 } from "@/lib/personal-access-tokens"
 
@@ -83,5 +85,25 @@ describe("personal access token primitives", () => {
     expect(patNameSchema.safeParse("").success).toBe(false)
     expect(patNameSchema.safeParse("   ").success).toBe(false)
     expect(patNameSchema.safeParse("x".repeat(61)).success).toBe(false)
+  })
+
+  it("throttles last-used refreshes to one write per interval", () => {
+    const now = 1_000_000_000_000
+    expect(PAT_LAST_USED_UPDATE_INTERVAL_MS).toBe(3_600_000)
+    expect(shouldRefreshLastUsedAt(null, now)).toBe(true)
+    expect(shouldRefreshLastUsedAt(undefined, now)).toBe(true)
+    expect(shouldRefreshLastUsedAt("not-a-date", now)).toBe(true)
+    expect(
+      shouldRefreshLastUsedAt(new Date(now - 30 * 60_000).toISOString(), now)
+    ).toBe(false)
+    expect(
+      shouldRefreshLastUsedAt(
+        new Date(now - PAT_LAST_USED_UPDATE_INTERVAL_MS).toISOString(),
+        now
+      )
+    ).toBe(true)
+    expect(
+      shouldRefreshLastUsedAt(new Date(now - 2 * 3_600_000).toISOString(), now)
+    ).toBe(true)
   })
 })


### PR DESCRIPTION
Replaces session-cookie pasting with scoped personal access tokens for scripts, CI, and agents.

## What changed
- New `personal_access_tokens` D1 table (migration `0014`) storing only SHA-256 hashes. Plaintext is shown once at creation.
- `lib/personal-access-tokens.ts`: `tk_`-prefixed generation (Web Crypto, Workers-safe), hashing, verification with expiry checks and `last_used_at` tracking, CRUD helpers.
- `resolveApiSession()` in `lib/api-auth.ts` accepts `Authorization: Bearer tk_…` on every protected endpoint (shares, multipart uploads, drafts, presets, preferences, tokens). Unknown or revoked PATs fail closed without falling through to cookies.
- Token management API: `GET/POST /api/tokens`, `DELETE /api/tokens/{id}` (zod validation, rate limited, 20-token cap, 404-not-403 on foreign ids).
- Settings → Developer section: generate with optional expiry, one-time reveal modal with full-width strawberry Okay, session-style token table, revoke behind the existing AlertDialog confirm.
- Docs: developer portal (PAT-first auth, Tokens endpoint group), `auth.md`, OpenAPI spec (`patBearer` scheme OR'd with the session cookie, token paths and schemas), `llms.txt`, agent skills, changelog entry under v2.3.0.

## Verification
- `pnpm typecheck` clean, ESLint clean.
- 4 new test files, 26 tests (token primitives, auth branching, token routes, PAT share wiring). Full suite: 199 files / 1612 tests pass.

## Deploy note
Run `pnpm db:migrate:remote` after merge so prod D1 gets the new table. Until then PAT requests fail closed with 401.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added personal access tokens for API authentication.
  - Generate, view, copy, set expiry dates for, and revoke tokens in Settings → Developer.
  - Use tokens with `Authorization: Bearer` headers across supported API endpoints.
  - Tokens are shown in full only once and support account-specific limits and expiration.
  - Account and session-management actions remain limited to browser sessions.

- **Documentation**
  - Updated developer guides, API references, changelog, and endpoint examples with token authentication instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds scoped personal access tokens as an alternative to browser sessions for protected API access.
- Introduces hashed token storage, creation, verification, expiry, usage tracking, listing, and revocation.
- Adds token-management APIs and a Developer settings interface with one-time token disclosure.
- Extends API authentication, documentation, OpenAPI definitions, agent resources, and tests for PAT use.
- Changes since the previous review report rollback failures rather than silently suppressing them and update revoke icons to the required size.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no outstanding findings after the resolved previous threads and the latest targeted fixes.

The browser-session guard addresses PAT misuse on account session operations, active counting addresses expired-token capacity, the token-cap behavior and usage tracking threads were manually resolved, rollback failures are now surfaced, and all affected icons use the required size.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/tokens/route.ts | Creates PATs with expiry and active-token-cap checks; the latest change makes rollback failures visible through logging and a server error. |
| components/editor/settings/settings-dialog.tsx | Adds token creation, one-time disclosure, listing, and revocation UI; the latest changes align revoke-related icons with repository conventions. |
| lib/api-auth.ts | Resolves PAT or session credentials while retaining a browser-session-only guard for account session management. |
| lib/personal-access-tokens.ts | Implements token generation, hashing, verification, expiry enforcement, metadata updates, and persistence helpers. |
| migrations/0014_personal_access_tokens.sql | Adds persistent storage and indexes for hashed personal access tokens. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: surface token rollback failures and..."](https://github.com/shivabhattacharjee/tokokino/commit/87ddae942cd00392e8a3fb2d8d47467e0c165112) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61391179)</sub>

<!-- /greptile_comment -->